### PR TITLE
docs: Add GAM link in comment

### DIFF
--- a/core/src/targeting/content.ts
+++ b/core/src/targeting/content.ts
@@ -42,7 +42,7 @@ type ContentTargeting = {
 	/**
 	 * **R**ecently Published **C**ontent - [see on Ad Manager][gam]
 	 *
-	 * [gam]: TODO: add URL here once it's been created
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=13845194
 	 */
 	rc: string;
 


### PR DESCRIPTION
## What does this change?

Following on from [this PR](https://github.com/guardian/commercial-core/pull/782), Tom has now added the new `rc` key to GAM. Include a link in the comment.

## Why?

Because all the other keys have GAM links.