### PR TITLE
feat: Refine data naming convention

### DIFF
--- a/.changeset/late-ants-relate.md
+++ b/.changeset/late-ants-relate.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Refactor internal naming conventions around quantitative and qualitative data.

--- a/src/core/event-timer.ts
+++ b/src/core/event-timer.ts
@@ -251,3 +251,4 @@ class EventTimer {
 }
 
 export { EventTimer };
+export type { EventTimerProperties };

--- a/src/core/send-commercial-metrics.spec.ts
+++ b/src/core/send-commercial-metrics.spec.ts
@@ -7,13 +7,7 @@ import {
 	initCommercialMetrics,
 } from './send-commercial-metrics';
 
-const {
-	Endpoints,
-	mapEventTimerPropertiesToString,
-	reset,
-	roundTimeStamp,
-	transformToObjectEntries,
-} = _;
+const { Endpoints, reset, roundTimeStamp, transformPropertiesObjectToData } = _;
 
 jest.mock('@guardian/consent-management-platform');
 
@@ -365,9 +359,10 @@ describe('send commercial metrics', () => {
 					Endpoints.PROD,
 					JSON.stringify({
 						...defaultMetrics,
+						metrics: [{ name: 'downlink', value: 1 }],
 						properties: [
-							{ name: 'downlink', value: '1' },
 							{ name: 'effectiveType', value: '4g' },
+							{ name: 'downlink', value: '1' },
 							{ name: 'adBlockerInUse', value: 'false' },
 						],
 					}),
@@ -401,9 +396,10 @@ describe('send commercial metrics', () => {
 					Endpoints.CODE,
 					JSON.stringify({
 						...defaultMetrics,
+						metrics: [{ name: 'downlink', value: 1 }],
 						properties: [
-							{ name: 'downlink', value: '1' },
 							{ name: 'effectiveType', value: '4g' },
+							{ name: 'downlink', value: '1' },
 							{ name: 'isDev', value: 'testurl.theguardian.com' },
 							{ name: 'adBlockerInUse', value: 'false' },
 						],
@@ -464,9 +460,10 @@ describe('send commercial metrics', () => {
 					Endpoints.CODE,
 					JSON.stringify({
 						...defaultMetrics,
+						metrics: [{ name: 'downlink', value: 1 }],
 						properties: [
-							{ name: 'downlink', value: '1' },
 							{ name: 'effectiveType', value: '4g' },
+							{ name: 'downlink', value: '1' },
 							{ name: 'isDev', value: 'testurl.theguardian.com' },
 						],
 					}),
@@ -495,6 +492,10 @@ describe('send commercial metrics', () => {
 					Endpoints.CODE,
 					JSON.stringify({
 						...defaultMetrics,
+						metrics: [
+							{ name: 'adSlotsInline', value: 5 },
+							{ name: 'adSlotsTotal', value: 10 },
+						],
 						properties: [
 							{ name: 'adSlotsInline', value: '5' },
 							{ name: 'adSlotsTotal', value: '10' },
@@ -593,33 +594,14 @@ describe('send commercial metrics', () => {
 describe('send commercial metrics helpers', () => {
 	it('can transform event timer properties into object entries', () => {
 		expect(
-			transformToObjectEntries({
+			transformPropertiesObjectToData({
 				type: undefined,
 				downlink: 1,
 				effectiveType: '4g',
 			}),
 		).toEqual([
-			['type', undefined],
-			['downlink', 1],
-			['effectiveType', '4g'],
-		]);
-	});
-
-	it('can map event timer properties to the required format', () => {
-		expect(
-			mapEventTimerPropertiesToString([
-				['downlink', 1],
-				['effectiveType', '4g'],
-			]),
-		).toEqual([
-			{
-				name: 'downlink',
-				value: '1',
-			},
-			{
-				name: 'effectiveType',
-				value: '4g',
-			},
+			[{ name: 'effectiveType', value: '4g' }],
+			[{ name: 'downlink', value: 1 }],
 		]);
 	});
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Use a consistent naming convention for the type of data that we send: **Qualitative** & **Quantitative**

Automatically sort EventTimer properties in qualitative or quantitative:
- properties: qualitative, string or categorical
- metrics: quantitative, number or numerical

Keep legacy data around to prevent a breaking change

### Quantitative

For numerical data of type `number`.
Anything that can be measured discretely or continuously:
- size of element
- number of elements
- duration of event
- occurrences of event

See [Quantitative Data](https://en.wikibooks.org/wiki/Statistics/Different_Types_of_Data/Quantitative_and_Qualitative_Data#Quantitative_data) on wiki.

```ts
const data: Quantitative[] = [
	{ name: "time on page", value: 10_320 },
	{ name: "height of banner", value: 360 },
	{ name: "cumulative layout shift", value: 0.0625 },
];
```

### Qualitative
For categorical data of type `string`.

Anything that can be identified with distinct labels:
- edition
- host name
- name of element
- type of connection

See [Qualitative Data](https://en.wikibooks.org/wiki/Statistics/Different_Types_of_Data/Quantitative_and_Qualitative_Data#Qualitative_data) on wiki.

```ts
const data: Qualitative[] = [
	{ name: "edition", value: "UK" },
	{ name: "content ID", value: "/2023/feb/23/…" },
	{ name: "connection type", value: "4g" },
]
```

## Why?

The distinction between “properties” and “metrics” is confusing:
- the file is called “metrics”, but deals with both types
- event “properties” can be `number` (numerical) or `string` (categorical) but currently are only recorded as strings
- data transformation is required in our warehouse to convert some types because of the current confusion
  - Following, #773 we struggled to find the data because it was not where we expected it
- When musing about a unified approach to data collection, [defining these two distinct types of data was key](https://github.com/guardian/libs/pull/323/files#diff-20c0b52052623c9d08e4046e8930c31563414fb8ed4b2fb6596071d78cd0b02aR85-R87)