### PR TITLE
fix: update file location for cross icon

### DIFF
--- a/bundle/src/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/bundle/src/projects/commercial/modules/dfp/render-advert-label.ts
@@ -4,7 +4,7 @@
 -- "Promise returned in function argument where a void return was expected"
 */
 import { getCookie } from '@guardian/libs';
-import crossIcon from 'svgs/icon/cross.svg';
+import crossIcon from '../../../../../static/svg/icon/cross.svg';
 import fastdom from '../../../../lib/fastdom-promise';
 
 const shouldRenderLabel = (adSlotNode: HTMLElement): boolean => {


### PR DESCRIPTION
## What does this change?
Updates the file location for the cross icon used in the mobile sticky close button

## Why?
Currently the import does not point to the correct file location, leading to 'undefined' showing where the cross icon should appear
