### PR TITLE
fix(bundle): mobile sticky cross icon

### DIFF
--- a/bundle/package.json
+++ b/bundle/package.json
@@ -70,6 +70,7 @@
 		"mockdate": "^3.0.5",
 		"npm-run-all": "^4.1.5",
 		"prettier": "^2.5.0",
+		"raw-loader": "^4.0.2",
 		"semantic-release": "^19.0.2",
 		"semantic-release-monorepo": "^7.0.5",
 		"terser-webpack-plugin": "^5.3.6",
@@ -105,8 +106,6 @@
 		"prebid.js": "guardian/prebid.js#2e3b96d",
 		"process": "^0.11.10",
 		"raven-js": "^3.27.2",
-		"raw-loader": "^4.0.2",
-		"svg-loader": "^0.0.2",
 		"tslib": "^2.4.1",
 		"web-vitals": "^2.1.2",
 		"wolfy87-eventemitter": "^5.2.9"

--- a/bundle/src/projects/commercial/modules/consentless/render-advert-label.ts
+++ b/bundle/src/projects/commercial/modules/consentless/render-advert-label.ts
@@ -10,7 +10,7 @@ import { shouldRenderLabel } from '../dfp/render-advert-label';
 export const createAdCloseDiv = (): HTMLElement => {
 	const closeDiv: HTMLElement = document.createElement('button');
 	closeDiv.className = 'ad-slot__close-button';
-	closeDiv.innerHTML = crossIcon.markup;
+	closeDiv.innerHTML = crossIcon;
 	closeDiv.onclick = () => {
 		const container: HTMLElement | null = closeDiv.closest(
 			'.mobilesticky-container',

--- a/bundle/src/projects/commercial/modules/dfp/render-advert-label.ts
+++ b/bundle/src/projects/commercial/modules/dfp/render-advert-label.ts
@@ -35,7 +35,7 @@ const shouldRenderCloseButton = (adSlotNode: HTMLElement): boolean =>
 const createAdCloseDiv = (): HTMLElement => {
 	const buttonDiv: HTMLElement = document.createElement('button');
 	buttonDiv.className = 'ad-slot__close-button';
-	buttonDiv.innerHTML = crossIcon.markup;
+	buttonDiv.innerHTML = crossIcon;
 	buttonDiv.onclick = () => {
 		const container: HTMLElement | null = buttonDiv.closest(
 			'.mobilesticky-container',

--- a/bundle/src/types/global.d.ts
+++ b/bundle/src/types/global.d.ts
@@ -29,7 +29,7 @@ declare const jsdom: {
 };
 
 declare module '*.svg' {
-	const content: { markup: string };
+	const content: string;
 	// eslint-disable-next-line import/no-default-export -- allow svg imports
 	export default content;
 }

--- a/bundle/webpack.config.js
+++ b/bundle/webpack.config.js
@@ -50,7 +50,7 @@ module.exports = {
 			{
 				test: /\.svg$/,
 				exclude: /(node_modules)/,
-				loader: 'svg-loader',
+				loader: 'raw-loader',
 			},
 		],
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -10236,11 +10236,6 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-svg-loader@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/svg-loader/-/svg-loader-0.0.2.tgz#601ab2fdaa1dadae3ca9975b550de92a07e1d92b"
-  integrity sha512-otmaUALijTGJJpvPVTHhHIzseEsrB7DyJJxygb0XkiZPeJT9t+PiK7tDT9YWSUDqHqqqutTqF0ldXth/+T72wg==
-
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"


### PR DESCRIPTION
## What does this change?
We discovered it was due to a webpack 5 issue, replaced `svg-loader` with `raw-loader`

## Why?
