### PR TITLE
feat: Create elements manager ab test. Place test ad in right slot.

### DIFF
--- a/bundle/src/projects/commercial/modules/dfp/prepare-googletag.ts
+++ b/bundle/src/projects/commercial/modules/dfp/prepare-googletag.ts
@@ -6,6 +6,8 @@ import {
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import { loadScript } from '@guardian/libs';
 import { init as initMeasureAdLoad } from 'commercial/modules/messenger/measure-ad-load';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { elementsManager } from 'common/modules/experiments/tests/elements-manager';
 import raven from '../../../../lib/raven';
 import { reportError } from '../../../../lib/report-error';
 import { removeSlots } from '../../../commercial/modules/remove-slots';
@@ -82,6 +84,11 @@ const setPublisherProvidedId = (): void =>
 	);
 
 export const init = (): Promise<void> => {
+	// Don't create Google ads (for now) if loading Elements Manager
+	if (isInVariantSynchronous(elementsManager, 'variant')) {
+		return Promise.resolve();
+	}
+
 	const setupAdvertising = (): Promise<void> => {
 		return onConsent().then((consentState: ConsentState) => {
 			let canRun = true;

--- a/bundle/src/projects/commercial/modules/elementsManager.ts
+++ b/bundle/src/projects/commercial/modules/elementsManager.ts
@@ -1,0 +1,25 @@
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { elementsManager } from 'common/modules/experiments/tests/elements-manager';
+import { renderAdvertLabel } from './dfp/render-advert-label';
+
+const initElementsManager = (): Promise<void> => {
+	if (!isInVariantSynchronous(elementsManager, 'variant')) {
+		return Promise.resolve();
+	}
+
+	const rightAdSlot = document.querySelector('#dfp-ad--right');
+	if (!rightAdSlot) return Promise.resolve();
+
+	const iframeNode = document.createElement('iframe');
+	iframeNode.src = 'http://localhost:3002/assets/mpu.gif';
+	iframeNode.title = 'Guardian jobs advertisement';
+	iframeNode.width = '300';
+	iframeNode.height = '250';
+
+	rightAdSlot.appendChild(iframeNode);
+	void renderAdvertLabel(rightAdSlot as HTMLElement);
+
+	return Promise.resolve();
+};
+
+export { initElementsManager };

--- a/bundle/src/projects/commercial/modules/manage-ad-free-cookie-on-consent-change.spec.ts
+++ b/bundle/src/projects/commercial/modules/manage-ad-free-cookie-on-consent-change.spec.ts
@@ -14,6 +14,10 @@ const {
 const { AdFreeCookieReasons, setAdFreeCookie, maybeUnsetAdFreeCookie } =
 	ActualManageAdFreeCookie;
 
+jest.mock('common/modules/experiments/ab', () => ({
+	isInVariantSynchronous: jest.fn(() => false),
+}));
+
 jest.mock('@guardian/consent-management-platform', () => ({
 	onConsentChange: jest.fn(),
 }));

--- a/bundle/src/projects/commercial/modules/remove-slots.ts
+++ b/bundle/src/projects/commercial/modules/remove-slots.ts
@@ -1,4 +1,6 @@
 import { once } from 'lodash-es';
+import { isInVariantSynchronous } from 'common/modules/experiments/ab';
+import { elementsManager } from 'common/modules/experiments/tests/elements-manager';
 import fastdom from '../../../lib/fastdom-promise';
 import { dfpEnv } from './dfp/dfp-env';
 
@@ -23,7 +25,14 @@ const filterDisabledNodes = (nodes: Element[]) => nodes.filter(isDisabled);
 const removeNodes = (nodes: Element[]): Promise<void> =>
 	fastdom.mutate(() => nodes.forEach((node) => node.remove()));
 
-const removeSlots = (): Promise<void> => removeNodes(selectNodes());
+const removeSlots = (): Promise<void> => {
+	// Don't collapse slots when in the Elements Manager AB test variant.
+	if (isInVariantSynchronous(elementsManager, 'variant')) {
+		return Promise.resolve();
+	}
+
+	return removeNodes(selectNodes());
+};
 
 /**
  * Remove ad slot elements that have style display: none

--- a/bundle/src/projects/common/modules/experiments/ab-tests.ts
+++ b/bundle/src/projects/common/modules/experiments/ab-tests.ts
@@ -2,6 +2,7 @@ import type { ABTest } from '@guardian/ab-core';
 import { billboardsInMerch } from './tests/billboards-in-merch';
 import { consentlessAds } from './tests/consentlessAds';
 import { deeplyReadArticleFooterTest } from './tests/deeply-read-article-footer';
+import { elementsManager } from './tests/elements-manager';
 import { integrateIma } from './tests/integrate-ima';
 import { noCarrotAdsNearNewsletterSignupBlocks } from './tests/no-carrot-ads-near-newsletter-signup-blocks';
 import { remoteRRHeaderLinksTest } from './tests/remote-header-test';
@@ -21,4 +22,5 @@ export const concurrentTests: readonly ABTest[] = [
 	integrateIma,
 	billboardsInMerch,
 	noCarrotAdsNearNewsletterSignupBlocks,
+	elementsManager,
 ];

--- a/bundle/src/projects/common/modules/experiments/tests/elements-manager.ts
+++ b/bundle/src/projects/common/modules/experiments/tests/elements-manager.ts
@@ -1,0 +1,19 @@
+import type { ABTest } from '@guardian/ab-core';
+import { noop } from '../../../../../lib/noop';
+
+export const elementsManager: ABTest = {
+	id: 'ElementsManager',
+	author: '@commercial-dev',
+	start: '2023-02-23',
+	expiry: '2023-06-30',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'Opt in only',
+	successMeasure: 'Able to serve GEM assets in ad slots on page',
+	description: 'Test serving GEM assets in ad slots on page',
+	variants: [
+		{ id: 'control', test: noop },
+		{ id: 'variant', test: noop },
+	],
+	canRun: () => true,
+};


### PR DESCRIPTION
## What does this change?

- Create an Elements Manager 0% AB test. This is [mirrored in frontend](https://github.com/guardian/frontend/pull/25940).
- When in the test:
    - Don't load opt-out or googletag
    - Load an example ad in an iframe in the right slot.

To test, note that you will need to run elements manager on port 3002 to see the ad.

## Why?

This is a step towards using elements manager to place elements on the page.