### PR TITLE
feat: Migration update

### DIFF
--- a/.github/workflows/visual-e2e.yml
+++ b/.github/workflows/visual-e2e.yml
@@ -1,0 +1,92 @@
+name: Commercial E2E Visual Tests
+on: workflow_dispatch
+    # pull_request:
+    #     paths:
+    #         - static/src/javascripts/projects/common/modules/commercial/**
+    #         - static/src/javascripts/projects/commercial/**
+    #         - static/src/javascripts/projects/common/modules/spacefinder-*
+    #         - commercial/**
+    #         - cypress/**
+    #         - cypress.config.ts
+    #         - .github/workflows/commercial-e2e-visual.yml
+
+concurrency:
+    group: 'commercial-e2e-visual-${{ github.head_ref }}'
+    cancel-in-progress: true
+
+jobs:
+    test:
+        name: Test
+        runs-on: ubuntu-latest
+        steps:
+            # Frontend
+            - name: Checkout frontend
+              uses: actions/checkout@v3
+              with:
+                  path: ./frontend
+
+            - name: Setup frontend node
+              uses: actions/setup-node@v3
+              with:
+                  node-version-file: './frontend/.nvmrc'
+
+            - name: Install Frontend dependencies
+              uses: bahmutov/npm-install@v1
+              with:
+                  working-directory: ./frontend
+
+            # DCR
+            - name: Checkout DCR
+              uses: actions/checkout@v3
+              with:
+                  repository: guardian/dotcom-rendering
+                  path: ./dcr
+
+            - name: Setup DCR node
+              uses: actions/setup-node@v3
+              with:
+                  node-version-file: './dcr/.nvmrc'
+
+            - name: Install DCR dependencies
+              uses: bahmutov/npm-install@v1
+              with:
+                  working-directory: ./dcr
+
+            - name: Build DCR
+              run: make build
+              working-directory: ./dcr/dotcom-rendering
+
+            - name: Start Commercial server
+              run: make commercial-dev & npx wait-on -v -i 1000 http://localhost:3031/graun.standalone.commercial.js
+              working-directory: ./frontend
+
+            - name: Start DCR server
+              run: make start-ci & npx wait-on -v -i 1000 http://localhost:3030
+              working-directory: ./dcr/dotcom-rendering
+              env:
+                  PORT: 3030
+                  COMMERCIAL_BUNDLE_URL: http://localhost:3031/graun.standalone.commercial.js
+
+            - name: Run Percy Visual Regression Tests
+              run: yarn cypress:run:snapshot
+              working-directory: ./frontend
+              env:
+                  PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+
+            - name: Wait for Percy Snapshots
+              run: yarn percy build:wait --verbose --fail-on-changes --project ced09b1a/commercial --commit ${{ github.event.pull_request.head.sha }} --timeout 900000 --interval 5000
+              working-directory: ./frontend
+              env:
+                  PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+
+            - uses: actions/upload-artifact@v2
+              if: always()
+              with:
+                  name: cypress-videos
+                  path: frontend/cypress/videos
+
+            - uses: actions/upload-artifact@v2
+              if: failure()
+              with:
+                  name: cypress-screenshots
+                  path: frontend/cypress/screenshots

--- a/bundle/package.json
+++ b/bundle/package.json
@@ -38,6 +38,8 @@
 		"@babel/runtime": "^7.11.2",
 		"@commitlint/cli": "^17.0.3",
 		"@commitlint/config-conventional": "^17.0.0",
+		"@percy/cli": "^1.20.1",
+		"@percy/cypress": "^3.1.2",
 		"@semantic-release/github": "^8.0.2",
 		"@types/google.analytics": "^0.0.42",
 		"@types/googletag": "~1.1.3",

--- a/bundle/src/projects/commercial/modules/dfp/create-advert.ts
+++ b/bundle/src/projects/commercial/modules/dfp/create-advert.ts
@@ -18,14 +18,17 @@ const createAdvert = (
 		}`;
 
 		log('commercial', errMsg);
-		reportError(
-			new Error(errMsg),
-			{
-				feature: 'commercial',
-			},
-			false,
-			1 / 100,
-		);
+
+		if (!navigator.userAgent.includes('DuckDuckGo')) {
+			reportError(
+				new Error(errMsg),
+				{
+					feature: 'commercial',
+				},
+				false,
+				1 / 100,
+			);
+		}
 
 		return null;
 	}

--- a/bundle/src/projects/common/modules/article/space-filler.ts
+++ b/bundle/src/projects/common/modules/article/space-filler.ts
@@ -6,6 +6,15 @@ import type {
 import { findSpace, SpaceError } from 'common/modules/spacefinder';
 import raven from 'lib/raven';
 
+const fireSpacefillerCompleteEvent = (
+	options: SpacefinderOptions | undefined,
+): void => {
+	if (options?.debug) {
+		const event = new CustomEvent('spacefiller-complete');
+		document.dispatchEvent(event);
+	}
+};
+
 class SpaceFiller {
 	queue = Promise.resolve(true);
 
@@ -24,16 +33,14 @@ class SpaceFiller {
 			findSpace(rules, options)
 				.then((paragraphs: HTMLElement[]) => writer(paragraphs))
 				.then(() => {
-					if (options?.debug) {
-						const event = new CustomEvent('adverts-created');
-						document.dispatchEvent(event);
-					}
+					fireSpacefillerCompleteEvent(options);
 				})
 				.then(() => {
 					return true;
 				})
 				.catch((ex) => {
 					if (ex instanceof SpaceError) {
+						fireSpacefillerCompleteEvent(options);
 						return false;
 					}
 					throw ex;

--- a/bundle/src/projects/common/modules/spacefinder-debug-tools.ts
+++ b/bundle/src/projects/common/modules/spacefinder-debug-tools.ts
@@ -208,7 +208,7 @@ const runDebugTool = (
 	rules: SpacefinderRules,
 ): void => {
 	document.addEventListener(
-		'adverts-created',
+		'spacefiller-complete',
 		() => {
 			if (rules.minAbove && rules.body instanceof HTMLElement) {
 				debugMinAbove(rules.body, rules.minAbove);
@@ -222,7 +222,7 @@ const runDebugTool = (
 
 const createAdvertBorder = (advert: HTMLElement): void => {
 	document.addEventListener(
-		'adverts-created',
+		'spacefiller-complete',
 		() => {
 			advert.style.cssText += `outline: 4px solid ${colours.darkRed};`;
 		},

--- a/e2e/cypress/fixtures/api/long-read.ts
+++ b/e2e/cypress/fixtures/api/long-read.ts
@@ -1,0 +1,282 @@
+// the response for https://api.nextgen.guardianapps.co.uk/series/news/series/the-long-read.json?dcr&shortUrl=/p/y8ykh
+// this is used for 'the long read' onwards section
+export const longRead = {
+	id: 'news/series/the-long-read',
+	displayname: 'The long read',
+	description: 'In-depth reporting, essays and profiles',
+	url: 'https://www.theguardian.com/news/series/the-long-read',
+	trails: [
+		{
+			url: 'https://www.theguardian.com/news/audio/2023/jan/06/they-want-toys-to-get-their-children-into-harvard-have-we-been-getting-playthings-all-wrong-podcast',
+			linkText:
+				'‘They want toys to get their children into Harvard’: have we been getting playthings all wrong? – podcast',
+			showByline: false,
+			byline: 'Written by Alex Blasdel, read by James Sobol Kelly and produced by Jessica Beck. The executive producer was Ellie Bury',
+			masterImage:
+				'https://media.guim.co.uk/03368e1a83d597deb0cadd6823968f2d1beb5b4c/0_0_4999_3000/master/4999.jpg',
+			image: 'https://i.guim.co.uk/img/media/03368e1a83d597deb0cadd6823968f2d1beb5b4c/0_0_4999_3000/master/4999.jpg?width=300&quality=85&auto=format&fit=max&s=e54283592e72f57b3f8ee316db65418f',
+			carouselImages: {
+				'300': 'https://i.guim.co.uk/img/media/03368e1a83d597deb0cadd6823968f2d1beb5b4c/0_0_4999_3000/master/4999.jpg?width=300&quality=85&auto=format&fit=max&s=e54283592e72f57b3f8ee316db65418f',
+				'460': 'https://i.guim.co.uk/img/media/03368e1a83d597deb0cadd6823968f2d1beb5b4c/0_0_4999_3000/master/4999.jpg?width=460&quality=85&auto=format&fit=max&s=13fb1cb468daeb0305b88ff907769cdc',
+			},
+			isLiveBlog: false,
+			pillar: 'news',
+			designType: 'Media',
+			format: {
+				design: 'AudioDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2023-01-06T05:00:42.000Z',
+			headline:
+				'‘They want toys to get their children into Harvard’: have we been getting playthings all wrong? – podcast',
+			mediaType: 'Audio',
+			shortUrl: 'https://www.theguardian.com/p/nv3ta',
+			kickerText: 'The Audio Long Read',
+		},
+		{
+			url: 'https://www.theguardian.com/society/2023/jan/05/nhs-hospital-ward-understaffed-12-hour-shifts-we-cant-even-get-basic-care-done',
+			linkText:
+				'‘We can’t even get basic care done’: what it’s like doing 12-hour shifts on an understaffed NHS ward',
+			showByline: false,
+			byline: 'William Fear',
+			masterImage:
+				'https://media.guim.co.uk/8a0e97e9fea2b18322a6a9c8a39b22518e89bc25/54_161_2856_1713/master/2856.jpg',
+			image: 'https://i.guim.co.uk/img/media/8a0e97e9fea2b18322a6a9c8a39b22518e89bc25/54_161_2856_1713/master/2856.jpg?width=300&quality=85&auto=format&fit=max&s=9911c81474410acaafa3c07007e9f147',
+			carouselImages: {
+				'300': 'https://i.guim.co.uk/img/media/8a0e97e9fea2b18322a6a9c8a39b22518e89bc25/54_161_2856_1713/master/2856.jpg?width=300&quality=85&auto=format&fit=max&s=9911c81474410acaafa3c07007e9f147',
+				'460': 'https://i.guim.co.uk/img/media/8a0e97e9fea2b18322a6a9c8a39b22518e89bc25/54_161_2856_1713/master/2856.jpg?width=460&quality=85&auto=format&fit=max&s=f6c5e6ce8c4072b2b14a0f9aa597ce1d',
+			},
+			isLiveBlog: false,
+			pillar: 'news',
+			designType: 'Immersive',
+			format: {
+				design: 'FeatureDesign',
+				theme: 'NewsPillar',
+				display: 'ImmersiveDisplay',
+			},
+			webPublicationDate: '2023-01-05T06:00:14.000Z',
+			headline:
+				'‘We can’t even get basic care done’: what it’s like doing 12-hour shifts on an understaffed NHS ward',
+			shortUrl: 'https://www.theguardian.com/p/n3dte',
+		},
+		{
+			url: 'https://www.theguardian.com/news/audio/2023/jan/04/from-the-archive-how-the-rugby-trial-divided-ireland-podcast',
+			linkText:
+				'From the archive: How the ‘rugby rape trial’ divided Ireland – podcast',
+			showByline: false,
+			byline: 'Written by Susan McKay and read by Melanie MacHugh. Originally produced by Simon Barnard, with additions and scoring by Jessica Beck. The executive producer was Danielle Stephens',
+			masterImage:
+				'https://media.guim.co.uk/52aa005a2dc0001cca08ee5afc08e07f83df7424/0_307_2048_1229/master/2048.jpg',
+			image: 'https://i.guim.co.uk/img/media/52aa005a2dc0001cca08ee5afc08e07f83df7424/0_307_2048_1229/master/2048.jpg?width=300&quality=85&auto=format&fit=max&s=5187a1733ff05687873e23fffbe389e5',
+			carouselImages: {
+				'300': 'https://i.guim.co.uk/img/media/52aa005a2dc0001cca08ee5afc08e07f83df7424/0_307_2048_1229/master/2048.jpg?width=300&quality=85&auto=format&fit=max&s=5187a1733ff05687873e23fffbe389e5',
+				'460': 'https://i.guim.co.uk/img/media/52aa005a2dc0001cca08ee5afc08e07f83df7424/0_307_2048_1229/master/2048.jpg?width=460&quality=85&auto=format&fit=max&s=9af5e8c48307c85d879dfb995f7acc0c',
+			},
+			isLiveBlog: false,
+			pillar: 'news',
+			designType: 'Media',
+			format: {
+				design: 'AudioDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2023-01-04T05:00:08.000Z',
+			headline:
+				'From the archive: How the ‘rugby rape trial’ divided Ireland – podcast',
+			mediaType: 'Audio',
+			shortUrl: 'https://www.theguardian.com/p/nv3h3',
+			kickerText: 'The Audio Long Read',
+		},
+		{
+			url: 'https://www.theguardian.com/news/audio/2023/jan/02/iran-moment-of-truth-what-will-it-take-for-the-people-to-topple-the-regime-podcast',
+			linkText:
+				'Iran’s moment of truth: what will it take for the people to topple the regime? – podcast',
+			showByline: false,
+			byline: 'Written by Christopher de Bellaigue, read by Serena Manteghi and produced by Jessica Beck. The executive producer was Maz Ebtehaj',
+			masterImage:
+				'https://media.guim.co.uk/1519c5c7c2f7f84344e353d5dcd961651b3db78c/0_231_1770_1062/master/1770.jpg',
+			image: 'https://i.guim.co.uk/img/media/1519c5c7c2f7f84344e353d5dcd961651b3db78c/0_231_1770_1062/master/1770.jpg?width=300&quality=85&auto=format&fit=max&s=a8c9f7781c4f39832e78fc71d573077d',
+			carouselImages: {
+				'300': 'https://i.guim.co.uk/img/media/1519c5c7c2f7f84344e353d5dcd961651b3db78c/0_231_1770_1062/master/1770.jpg?width=300&quality=85&auto=format&fit=max&s=a8c9f7781c4f39832e78fc71d573077d',
+				'460': 'https://i.guim.co.uk/img/media/1519c5c7c2f7f84344e353d5dcd961651b3db78c/0_231_1770_1062/master/1770.jpg?width=460&quality=85&auto=format&fit=max&s=f1939e5cdb037264f48e514d09914a8c',
+			},
+			isLiveBlog: false,
+			pillar: 'news',
+			designType: 'Media',
+			format: {
+				design: 'AudioDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2023-01-02T05:00:06.000Z',
+			headline:
+				'Iran’s moment of truth: what will it take for the people to topple the regime? – podcast',
+			mediaType: 'Audio',
+			shortUrl: 'https://www.theguardian.com/p/mqkqq',
+			kickerText: 'The Audio Long Read',
+		},
+		{
+			url: 'https://www.theguardian.com/news/audio/2022/dec/30/best-of-2022-is-this-justice-why-sudan-is-facing-a-multibillion-dollar-bill-for-911-podcast',
+			linkText:
+				'Best of 2022: ‘Is this justice?’: why Sudan is facing a multibillion-dollar bill for 9/11 – podcast',
+			showByline: false,
+			byline: 'Written and read by Nesrine Malik, produced by Jessica Beck and Cheyenne Bryan. The executive producer was Danielle Stephens',
+			masterImage:
+				'https://media.guim.co.uk/d4044010408f562e4c48ac53d3f652775490708d/0_154_5288_3173/master/5288.jpg',
+			image: 'https://i.guim.co.uk/img/media/d4044010408f562e4c48ac53d3f652775490708d/0_154_5288_3173/master/5288.jpg?width=300&quality=85&auto=format&fit=max&s=3b5e51b0eb431f551df3cb878a6e5c00',
+			carouselImages: {
+				'300': 'https://i.guim.co.uk/img/media/d4044010408f562e4c48ac53d3f652775490708d/0_154_5288_3173/master/5288.jpg?width=300&quality=85&auto=format&fit=max&s=3b5e51b0eb431f551df3cb878a6e5c00',
+				'460': 'https://i.guim.co.uk/img/media/d4044010408f562e4c48ac53d3f652775490708d/0_154_5288_3173/master/5288.jpg?width=460&quality=85&auto=format&fit=max&s=fe73fe8bfbef37c8a17aea0121b2e487',
+			},
+			isLiveBlog: false,
+			pillar: 'news',
+			designType: 'Media',
+			format: {
+				design: 'AudioDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2022-12-30T05:00:39.000Z',
+			headline:
+				'Best of 2022: ‘Is this justice?’: why Sudan is facing a multibillion-dollar bill for 9/11 – podcast',
+			mediaType: 'Audio',
+			shortUrl: 'https://www.theguardian.com/p/mq9h3',
+			kickerText: 'The Audio Long Read',
+		},
+		{
+			url: 'https://www.theguardian.com/news/2022/dec/27/the-best-of-the-long-read-in-2022',
+			linkText: 'The best of the long read in 2022',
+			showByline: false,
+			byline: '',
+			masterImage:
+				'https://media.guim.co.uk/173b206a04e7379f933fb92bdf78848c93004818/19_19_1628_977/master/1628.jpg',
+			image: 'https://i.guim.co.uk/img/media/173b206a04e7379f933fb92bdf78848c93004818/19_19_1628_977/master/1628.jpg?width=300&quality=85&auto=format&fit=max&s=adc6c443a561ff7278981b98e612bc20',
+			carouselImages: {
+				'300': 'https://i.guim.co.uk/img/media/173b206a04e7379f933fb92bdf78848c93004818/19_19_1628_977/master/1628.jpg?width=300&quality=85&auto=format&fit=max&s=adc6c443a561ff7278981b98e612bc20',
+				'460': 'https://i.guim.co.uk/img/media/173b206a04e7379f933fb92bdf78848c93004818/19_19_1628_977/master/1628.jpg?width=460&quality=85&auto=format&fit=max&s=2861e5b11a67596b70ffc3926db1b5c9',
+			},
+			isLiveBlog: false,
+			pillar: 'news',
+			designType: 'Feature',
+			format: {
+				design: 'FeatureDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2022-12-27T12:00:21.000Z',
+			headline: 'The best of the long read in 2022',
+			shortUrl: 'https://www.theguardian.com/p/nvzx3',
+		},
+		{
+			url: 'https://www.theguardian.com/news/audio/2022/dec/26/best-of-2022-the-amazing-trueish-story-of-the-honduran-maradona-podcast',
+			linkText:
+				'Best of 2022: The amazing true(ish) story of the ‘Honduran Maradona’ – podcast',
+			showByline: false,
+			byline: 'Written and read by Kieran Morris and produced by Jessica Beck. The executive producer was Danielle Stephens',
+			masterImage:
+				'https://media.guim.co.uk/214f72b81b35a319da75844bc0674a43e5bcebf0/365_562_3141_1885/master/3141.jpg',
+			image: 'https://i.guim.co.uk/img/media/214f72b81b35a319da75844bc0674a43e5bcebf0/365_562_3141_1885/master/3141.jpg?width=300&quality=85&auto=format&fit=max&s=3d68ed48901ced368411ea4c46fc19de',
+			carouselImages: {
+				'300': 'https://i.guim.co.uk/img/media/214f72b81b35a319da75844bc0674a43e5bcebf0/365_562_3141_1885/master/3141.jpg?width=300&quality=85&auto=format&fit=max&s=3d68ed48901ced368411ea4c46fc19de',
+				'460': 'https://i.guim.co.uk/img/media/214f72b81b35a319da75844bc0674a43e5bcebf0/365_562_3141_1885/master/3141.jpg?width=460&quality=85&auto=format&fit=max&s=9e8b78bb9e2c5856a9f1719171819352',
+			},
+			isLiveBlog: false,
+			pillar: 'news',
+			designType: 'Media',
+			format: {
+				design: 'AudioDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2022-12-26T05:00:21.000Z',
+			headline:
+				'Best of 2022: The amazing true(ish) story of the ‘Honduran Maradona’ – podcast',
+			mediaType: 'Audio',
+			shortUrl: 'https://www.theguardian.com/p/mq9g4',
+			kickerText: 'The Audio Long Read',
+		},
+		{
+			url: 'https://www.theguardian.com/news/audio/2022/dec/23/best-of-2022-parents-are-frightened-for-themselves-and-for-their-children-an-inspirational-school-in-impossible-times-podcast',
+			linkText:
+				'Best of 2022: ‘Parents are frightened for themselves and for their children’: an inspirational school in impossible times – podcast',
+			showByline: false,
+			byline: 'Written by Aida Edemariam, read by Lucy Scott and produced by Jessica Beck. The executive producers were Danielle Stephens and Ellie Bury',
+			masterImage:
+				'https://media.guim.co.uk/6f78b84c2d819f5d0b63efbba80dcb5dd48d028f/0_1000_6532_3918/master/6532.jpg',
+			image: 'https://i.guim.co.uk/img/media/6f78b84c2d819f5d0b63efbba80dcb5dd48d028f/0_1000_6532_3918/master/6532.jpg?width=300&quality=85&auto=format&fit=max&s=564c75c798fa4c461afe4b8c46ed6b47',
+			carouselImages: {
+				'300': 'https://i.guim.co.uk/img/media/6f78b84c2d819f5d0b63efbba80dcb5dd48d028f/0_1000_6532_3918/master/6532.jpg?width=300&quality=85&auto=format&fit=max&s=564c75c798fa4c461afe4b8c46ed6b47',
+				'460': 'https://i.guim.co.uk/img/media/6f78b84c2d819f5d0b63efbba80dcb5dd48d028f/0_1000_6532_3918/master/6532.jpg?width=460&quality=85&auto=format&fit=max&s=bbe6ea0dd97408dfbd17fdfd61b41535',
+			},
+			isLiveBlog: false,
+			pillar: 'news',
+			designType: 'Media',
+			format: {
+				design: 'AudioDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2022-12-23T05:00:18.000Z',
+			headline:
+				'Best of 2022: ‘Parents are frightened for themselves and for their children’: an inspirational school in impossible times – podcast',
+			mediaType: 'Audio',
+			shortUrl: 'https://www.theguardian.com/p/mq9f8',
+			kickerText: 'The Audio Long Read',
+		},
+		{
+			url: 'https://www.theguardian.com/environment/2022/dec/20/india-adani-coal-mine-kete-hasdeo-arand-forest-displaced-villages',
+			linkText:
+				'‘It was a set-up, we were fooled’: the coal mine that ate an Indian village',
+			showByline: false,
+			byline: 'Ankur Paliwal',
+			masterImage:
+				'https://media.guim.co.uk/6bd88377027603dbb5681ac9bf030b999fe1bc0b/0_0_5568_3342/master/5568.jpg',
+			image: 'https://i.guim.co.uk/img/media/6bd88377027603dbb5681ac9bf030b999fe1bc0b/0_0_5568_3342/master/5568.jpg?width=300&quality=85&auto=format&fit=max&s=393acf643e9bc140e709b55f3f8a80f7',
+			carouselImages: {
+				'300': 'https://i.guim.co.uk/img/media/6bd88377027603dbb5681ac9bf030b999fe1bc0b/0_0_5568_3342/master/5568.jpg?width=300&quality=85&auto=format&fit=max&s=393acf643e9bc140e709b55f3f8a80f7',
+				'460': 'https://i.guim.co.uk/img/media/6bd88377027603dbb5681ac9bf030b999fe1bc0b/0_0_5568_3342/master/5568.jpg?width=460&quality=85&auto=format&fit=max&s=a1ab7a660dd6867a1f5a78636ac4c7d8',
+			},
+			isLiveBlog: false,
+			pillar: 'news',
+			designType: 'Immersive',
+			format: {
+				design: 'FeatureDesign',
+				theme: 'NewsPillar',
+				display: 'ImmersiveDisplay',
+			},
+			webPublicationDate: '2022-12-20T06:00:41.000Z',
+			headline:
+				'‘It was a set-up, we were fooled’: the coal mine that ate an Indian village',
+			shortUrl: 'https://www.theguardian.com/p/nv3fp',
+		},
+		{
+			url: 'https://www.theguardian.com/news/audio/2022/dec/19/best-of-2022-the-sludge-king-how-one-man-turned-an-industrial-wasteland-into-his-own-el-dorado-podcast',
+			linkText:
+				'Best of 2022: The sludge king: how one man turned an industrial wasteland into his own El Dorado – podcast',
+			showByline: false,
+			byline: 'Written by Alexander Clapp, read by Simon Darwen and produced by Jessica Beck. The executive producer were Danielle Stephens and Ellie Bury',
+			masterImage:
+				'https://media.guim.co.uk/94572df0cfd4b77b457e19b3df3c496d23a1fd8b/1_520_4309_2585/master/4309.jpg',
+			image: 'https://i.guim.co.uk/img/media/94572df0cfd4b77b457e19b3df3c496d23a1fd8b/1_520_4309_2585/master/4309.jpg?width=300&quality=85&auto=format&fit=max&s=50ee7ba8b15eef6470196afb7cad1493',
+			carouselImages: {
+				'300': 'https://i.guim.co.uk/img/media/94572df0cfd4b77b457e19b3df3c496d23a1fd8b/1_520_4309_2585/master/4309.jpg?width=300&quality=85&auto=format&fit=max&s=50ee7ba8b15eef6470196afb7cad1493',
+				'460': 'https://i.guim.co.uk/img/media/94572df0cfd4b77b457e19b3df3c496d23a1fd8b/1_520_4309_2585/master/4309.jpg?width=460&quality=85&auto=format&fit=max&s=3f3c25e52b806c6e7047544c0e1b4d67',
+			},
+			isLiveBlog: false,
+			pillar: 'news',
+			designType: 'Media',
+			format: {
+				design: 'AudioDesign',
+				theme: 'NewsPillar',
+				display: 'StandardDisplay',
+			},
+			webPublicationDate: '2022-12-19T05:00:09.000Z',
+			headline:
+				'Best of 2022: The sludge king: how one man turned an industrial wasteland into his own El Dorado – podcast',
+			mediaType: 'Audio',
+			shortUrl: 'https://www.theguardian.com/p/mq9dv',
+			kickerText: 'The Audio Long Read',
+		},
+	],
+};

--- a/e2e/cypress/lib/rewriteGamRequest.ts
+++ b/e2e/cypress/lib/rewriteGamRequest.ts
@@ -1,0 +1,50 @@
+const overrideGamRequest = (
+	matchRequestParam: string,
+	rewriteUrl: (reqUrl: string) => string,
+) =>
+	cy.intercept(
+		'https://securepubads.g.doubleclick.net/gampad/ads**',
+		(req) => {
+			if (req.url.includes(matchRequestParam)) {
+				req.url = rewriteUrl(req.url);
+			}
+		},
+	);
+
+/**
+ * GAM intermitently renders a 320x250 MPU ad in the top-above-nav slot when in a Cypress test
+ * For now we hardcode size targeting
+ */
+const rewriteGamRequestForTopAboveNav = (reqUrl: string) => {
+	console.log('URL before rewrite:', reqUrl);
+	const iframeDimensionParams = new RegExp(/&isw=([0-9]+)&ish=([0-9]+)/).exec(
+		reqUrl,
+	);
+	const browserDimensionParams = new RegExp(
+		/&biw=([0-9]+)&bih=([0-9]+)/,
+	).exec(reqUrl);
+	const psz = new RegExp(/&psz=([0-9]+x[0-9]+)/).exec(reqUrl);
+	const prevIuSzs = new RegExp(/&prev_iu_szs=(.*?)&/).exec(reqUrl);
+
+	let newReqUrl = reqUrl;
+	if (iframeDimensionParams && browserDimensionParams && psz && prevIuSzs) {
+		console.log('iframeDimensionParams:', iframeDimensionParams);
+		console.log('browserDimensionParams:', browserDimensionParams);
+		console.log('psz:', psz);
+		console.log('preVszs:', prevIuSzs);
+		newReqUrl = newReqUrl.replace(iframeDimensionParams[0], '');
+		newReqUrl = newReqUrl.replace(
+			browserDimensionParams[0],
+			'&biw=1000&bih=660',
+		);
+		newReqUrl = newReqUrl.replace(psz[0], '&psz=1000x293');
+		newReqUrl = newReqUrl.replace(
+			prevIuSzs[1],
+			encodeURIComponent('728x90|940x230|900x250|970x250'),
+		);
+	}
+	console.log('URL after rewrite:', newReqUrl);
+	return newReqUrl;
+};
+
+export { overrideGamRequest, rewriteGamRequestForTopAboveNav };

--- a/e2e/cypress/lib/stubApiRequests.ts
+++ b/e2e/cypress/lib/stubApiRequests.ts
@@ -1,0 +1,59 @@
+import { mostReadGeo } from '../fixtures/api/most-read-geo';
+import { mostRead } from '../fixtures/api/most-read';
+import { regularStories } from '../fixtures/api/regular-stories';
+import { longRead } from '../fixtures/api/long-read';
+
+const stubApiRequest = (matchUrl: string, response: object) =>
+	cy.intercept(matchUrl, (req) => {
+		console.log('matching', req.url, matchUrl);
+		req.reply({ body: response });
+	});
+
+/**
+ * Cypress matches URLs using a glob pattern via minimatch.
+ * You can test if the pattern will match the intended URLs here:
+ * https://lironzluf.github.io/minimatch-playground/
+ *
+ * Be careful when changing these patterns. An incorrect glob
+ * could mean Cypress will not intercept and stub the request.
+ * Snapshot tests will pass locally but visual regression tests
+ * in Percy will fail.
+ */
+const stubApiRequests = () => {
+	// most viewed right
+	stubApiRequest(
+		// variations:
+		// https://api.nextgen.guardianapps.co.uk/most-read-geo.json?dcr=true
+		// https://code.api.nextgen.guardianapps.co.uk/most-read-geo.json?dcr=true
+		'https://*api.nextgen.guardianapps.co.uk/most-read-geo.json?dcr=true',
+		mostReadGeo,
+	);
+	// headlines
+	stubApiRequest(
+		// variations:
+		// https://api.nextgen.guardianapps.co.uk/container/data/uk-alpha/news/regular-stories.json
+		// https://code.api.nextgen.guardianapps.co.uk/container/data/uk-alpha/news/regular-stories.json
+		'https://*api.nextgen.guardianapps.co.uk/container/data/uk-alpha/news/regular-stories.json',
+		regularStories,
+	);
+	// most viewed bottom
+	stubApiRequest(
+		// variations:
+		// https://api.nextgen.guardianapps.co.uk/most-read/politics.json?dcr=true
+		// https://code.api.nextgen.guardianapps.co.uk/most-read/politics.json?dcr=true
+		// https://api.nextgen.guardianapps.co.uk/most-read/business.json?dcr=true
+		// https://api.nextgen.guardianapps.co.uk/most-read/football.json?dcr=true
+		'https://*api.nextgen.guardianapps.co.uk/most-read/*',
+		mostRead,
+	);
+	// long read
+	stubApiRequest(
+		// variations:
+		// https://api.nextgen.guardianapps.co.uk/series/news/series/the-long-read.json?dcr&shortUrl=/p/y8ykh
+		// https://code.api.nextgen.guardianapps.co.uk/series/news/series/the-long-read.json?dcr&shortUrl=/p/y8ykh
+		'https://*api.nextgen.guardianapps.co.uk/series/news/series/the-long-read**/**',
+		longRead,
+	);
+};
+
+export { stubApiRequests };

--- a/e2e/cypress/lib/util.ts
+++ b/e2e/cypress/lib/util.ts
@@ -12,7 +12,7 @@ export const getTestUrl = (
 	stage: 'code' | 'prod' | 'dev',
 	path: string,
 	{ isDcr } = { isDcr: false },
-	adtest = 'fixed-puppies',
+	adtest = 'fixed-puppies-ci',
 ) => {
 	let url = '';
 	switch (stage) {
@@ -37,6 +37,8 @@ export const getTestUrl = (
 	if (adtest) {
 		const builder = new URL(url);
 		builder.searchParams.append('adtest', adtest);
+		// force an invalid epic so it is not shown
+		builder.searchParams.append('force-epic', '9999:CONTROL');
 		url = builder.toString();
 	}
 	return url;

--- a/e2e/cypress/snapshot/snapshot-article-long-read.cy.ts
+++ b/e2e/cypress/snapshot/snapshot-article-long-read.cy.ts
@@ -1,0 +1,32 @@
+import { storage } from '@guardian/libs';
+import { getStage, getTestUrl } from '../lib/util';
+import { stubApiRequests } from '../lib/stubApiRequests';
+import '@percy/cypress';
+
+describe('Visually snapshot long read article', () => {
+	it(`snapshots long read article`, () => {
+		const path = getTestUrl(
+			getStage(),
+			'/business/2022/apr/14/a-day-in-the-life-of-almost-every-vending-machine-in-the-world',
+			{ isDcr: true },
+		);
+		// stub all api requests
+		stubApiRequests();
+		// force geolocation to UK
+		storage.local.set('gu.geo.override', 'GB');
+		// load article
+		cy.visit(path);
+		cy.allowAllConsent();
+		// scroll to and hydrate all islands
+		cy.hydrate();
+		// scroll to and check all ads are rendered
+		cy.checkAdsRendered();
+		// workaround for onwards sections
+		// the intercept intermittently fails to stub the request
+		cy.get('[name=OnwardsUpper]').invoke('remove');
+		// snapshot
+		cy.percySnapshot('article-long-read', {
+			widths: [320, 740, 1300],
+		});
+	});
+});

--- a/e2e/cypress/snapshot/snapshot-article-standard.cy.ts
+++ b/e2e/cypress/snapshot/snapshot-article-standard.cy.ts
@@ -1,0 +1,33 @@
+import { storage } from '@guardian/libs';
+import { getStage, getTestUrl } from '../lib/util';
+import { stubApiRequests } from '../lib/stubApiRequests';
+import '@percy/cypress';
+
+describe('Visually snapshot standard article', () => {
+	it(`snapshots standard article`, () => {
+		const path = getTestUrl(
+			getStage(),
+			'/commentisfree/2023/feb/27/dont-believe-those-who-claim-science-proves-masks-dont-work',
+			{ isDcr: true },
+		);
+		// stub all api requests
+		stubApiRequests();
+		// force geolocation to UK
+		storage.local.set('gu.geo.override', 'GB');
+		// load article
+		cy.visit(path);
+		cy.allowAllConsent();
+		// scroll to and hydrate all islands
+		cy.hydrate();
+		// scroll to and check all ads are rendered
+		cy.checkAdsRendered();
+		// workaround for onwards sections
+		// the intercept intermittently fails to stub the request
+		cy.get('section:has(gu-island[name="Carousel"])').invoke('remove');
+		cy.get('[name=OnwardsUpper]').invoke('remove');
+		// snapshot
+		cy.percySnapshot('article-standard', {
+			widths: [320, 740, 1300],
+		});
+	});
+});

--- a/e2e/cypress/support/commands.ts
+++ b/e2e/cypress/support/commands.ts
@@ -30,7 +30,9 @@ Cypress.Commands.add('findAdSlotIframeBySlotId', (adSlotId: string) => {
 	cy.get(`#${adSlotId}`).find('iframe', { timeout: 30000 });
 });
 
-const allowAll = 'Yes, I’m happy';
+const allowAllButtons = ['Yes, I’m happy', 'Accept all', 'Yes, ok']
+	.map((title) => `button[title="${title}"]`)
+	.join(',');
 const manageConsent = 'Manage my cookies';
 const rejectAll = 'Reject all';
 
@@ -47,27 +49,64 @@ Cypress.Commands.add('rejectAllConsent', () => {
 
 Cypress.Commands.add('allowAllConsent', () => {
 	cy.getIframeBody('sp_message_iframe_')
-		.find(`button[title="${allowAll}"]`, { timeout: 30000 })
+		.find(allowAllButtons, { timeout: 30000 })
 		.click();
 	cy.wait(100);
 });
 
 Cypress.Commands.add('hydrate', () => {
+	// force all islands to trigger in case Cypress cannot find the scroll position
+	cy.scrollTo('bottom', { duration: 1000 });
+	cy.scrollTo('top', { duration: 1000 });
+	// individually wait for all islands to hydrate
 	return cy
 		.get('gu-island')
 		.each((el) => {
-			cy.log(`Scrolling to ${el.attr('name')}`);
-			cy.wrap(el)
-				.scrollIntoView({ duration: 1000, timeout: 30000 })
-				.should('have.attr', 'data-gu-ready', 'true', {
-					timeout: 30000,
-				});
+			const deferuntil = el.attr('deferuntil');
+			const name = el.attr('name');
+			const defer = el.attr('deferuntil');
+			const islandMeta = `island: ${name} defer: ${defer}`;
+			if (['idle', 'visible', undefined].includes(deferuntil)) {
+				cy.log(`Scrolling to ${islandMeta}`);
+				cy.wrap(el)
+					.scrollIntoView({ duration: 1000, timeout: 30000 })
+					.should('have.attr', 'data-gu-ready', 'true', {
+						timeout: 30000,
+					});
+				// Additional wait to ensure island defer=visible has triggered
+				// eslint-disable-next-line cypress/no-unnecessary-waiting
+				cy.wait(1000);
+			} else {
+				cy.log(`Skipping ${islandMeta}`);
+			}
 		})
 		.then(() => {
 			cy.scrollTo('top');
 			// Additional wait to ensure layout shift has completed post hydration
 			// eslint-disable-next-line cypress/no-unnecessary-waiting
-			cy.wait(5000);
+			cy.wait(10000);
+		});
+});
+
+Cypress.Commands.add('checkAdsRendered', () => {
+	return cy
+		.get('.ad-slot')
+		.each((el) => {
+			cy.log(`Scrolling to ad: ${el.attr('id')}`);
+			cy.wrap(el)
+				.scrollIntoView({ duration: 1000, timeout: 30000 })
+				.should('have.class', 'ad-slot--rendered', {
+					timeout: 30000,
+				});
+			// Additional wait to ensure visbility has triggered
+			// eslint-disable-next-line cypress/no-unnecessary-waiting
+			cy.wait(2000);
+		})
+		.then(() => {
+			cy.scrollTo('top');
+			// Additional wait to ensure layout shift has completed post hydration
+			// eslint-disable-next-line cypress/no-unnecessary-waiting
+			cy.wait(10000);
 		});
 });
 
@@ -83,6 +122,6 @@ Cypress.Commands.add('useConsentedSession', (name: string) => {
 			`{"value":"${new Date().toISOString()}"}`,
 		);
 		cy.allowAllConsent();
-		cy.wait('@consentAll');
+		cy.wait('@consentAll', { timeout: 30000 });
 	});
 });

--- a/e2e/cypress/support/e2e.ts
+++ b/e2e/cypress/support/e2e.ts
@@ -34,6 +34,8 @@ declare global {
 			hydrate(): Chainable<JQuery<HTMLElement>>;
 
 			useConsentedSession(name: string): void;
+
+			checkAdsRendered(): void;
 		}
 
 		/**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1970,6 +1970,142 @@
   dependencies:
     "@octokit/openapi-types" "^16.0.0"
 
+"@percy/cli-app@1.20.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-app/-/cli-app-1.20.1.tgz#55133f2d15ddc781a40ac67f6a08d924523b6cf7"
+  integrity sha512-epDxlyrk7sI7APp0DPsThrAQHNtELEYhiYrqs6tWORhIAXMZTbKOrOx4pIiHLq9C97daqeEQL/9m+O/RUtUeLA==
+  dependencies:
+    "@percy/cli-command" "1.20.1"
+    "@percy/cli-exec" "1.20.1"
+
+"@percy/cli-build@1.20.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.20.1.tgz#bf04a397956e3bbb2b7c71e25a1a58700fa647f5"
+  integrity sha512-C69gd1I/5sFauAi8ca0gIx1aNEc0W8Md1YWcQA+AKp9ZGB7zlNepbBpDQmDp1JCXOJvnQKEjRpO07PNM3rRirw==
+  dependencies:
+    "@percy/cli-command" "1.20.1"
+
+"@percy/cli-command@1.20.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.20.1.tgz#9aaab47b013bb91034afd4d2327237547ace7e5d"
+  integrity sha512-JMhqFec5W9barvCxGMbeHEzZBYpoXLiSqSb9Uli9dP2MRKQhvJhjyWlPqLDN+kFOUimi+AT8NK88rJWOgszwGw==
+  dependencies:
+    "@percy/config" "1.20.1"
+    "@percy/core" "1.20.1"
+    "@percy/logger" "1.20.1"
+
+"@percy/cli-config@1.20.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.20.1.tgz#6eaf62f3e7d783f0d430a2dfdc877aedf4c97b60"
+  integrity sha512-XIl4AbFvMcg6uDnDUTcLlJ8I2FdU9ATUr0DwRYIcl6vLXX+eIZ8+5eOPIX7tfeuA9bO2JGCY4Rz1nG0U2sOVzg==
+  dependencies:
+    "@percy/cli-command" "1.20.1"
+
+"@percy/cli-exec@1.20.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.20.1.tgz#8b0ee77e24cd13e8320e7eb4d91df5f264f376c4"
+  integrity sha512-l6P+4vgtXmenm34j1CGW0QoJh68JKSVeuHxh81dERqqT4sYdZZU8w0MV80QXa2ibHm9UCDYg35cNXESL4xzfog==
+  dependencies:
+    "@percy/cli-command" "1.20.1"
+    cross-spawn "^7.0.3"
+    which "^2.0.2"
+
+"@percy/cli-snapshot@1.20.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.20.1.tgz#fb0399d27678eb5124f0079747ea7e879ec4a66d"
+  integrity sha512-5O4El6QJotjsOoV6zBtWGBhPxdaxQndHMmRXgyr+Zuc8Fz0N74knDLB4WaX+qMGqF1WyygJt4RE8qsEG7wtFiA==
+  dependencies:
+    "@percy/cli-command" "1.20.1"
+    yaml "^2.0.0"
+
+"@percy/cli-upload@1.20.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.20.1.tgz#d12abb621800bcbe8f89acfe27a21c105ee2e404"
+  integrity sha512-t4pJRNHDPF34JbpF5bPf2Ol7k02ohZ8nXhh3IuiPtGJR5nFM8HWiynZbn4wowhZL0hg8+tNGFstRPgB4GR7Mnw==
+  dependencies:
+    "@percy/cli-command" "1.20.1"
+    fast-glob "^3.2.11"
+    image-size "^1.0.0"
+
+"@percy/cli@^1.20.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.20.1.tgz#92864ef45ea5599be5c8f404bddde0474fc5a7e6"
+  integrity sha512-X3HNbQhRHQQx9P3pa4M2RZh4dA94Tv3rUBKRLPcIBIXxHoMz2mbKOuld/Dt2Ont7VHxpV62x2fq+/ohMTu064g==
+  dependencies:
+    "@percy/cli-app" "1.20.1"
+    "@percy/cli-build" "1.20.1"
+    "@percy/cli-command" "1.20.1"
+    "@percy/cli-config" "1.20.1"
+    "@percy/cli-exec" "1.20.1"
+    "@percy/cli-snapshot" "1.20.1"
+    "@percy/cli-upload" "1.20.1"
+    "@percy/client" "1.20.1"
+    "@percy/logger" "1.20.1"
+
+"@percy/client@1.20.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.20.1.tgz#4cdd52439926bd5bfcfed6694d963e82169fdbf5"
+  integrity sha512-BUhtUbPMQIcGjE9Axwuxw7ZIyY7lP5HhySax51frY7Gub3WvqONFZOEcYZMrTlWaKqaWAWjW26xQibSdiQZwqg==
+  dependencies:
+    "@percy/env" "1.20.1"
+    "@percy/logger" "1.20.1"
+
+"@percy/config@1.20.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.20.1.tgz#df7d78fcfbcf47efecfea6bbba863b48ca1edc49"
+  integrity sha512-crrfg4hXV3F7a+YnKWLl5LzWmxT3Xb63B0/IP9lm9VQ8QGhW1tDXwDBN/nleciGQUZ62u8upCWi+TosuJidVkw==
+  dependencies:
+    "@percy/logger" "1.20.1"
+    ajv "^8.6.2"
+    cosmiconfig "^7.0.0"
+    yaml "^2.0.0"
+
+"@percy/core@1.20.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.20.1.tgz#139ca01122ec899ed71d3d366951b178a1baae67"
+  integrity sha512-FQoFt+c8HkeD+fxLyD7mZgLCHP9kELktLHGQ3ZCie2Um+BeQXS7pfQiaKI0hvF5FI5pQOVo/UP5TF1ILDUJZEQ==
+  dependencies:
+    "@percy/client" "1.20.1"
+    "@percy/config" "1.20.1"
+    "@percy/dom" "1.20.1"
+    "@percy/logger" "1.20.1"
+    content-disposition "^0.5.4"
+    cross-spawn "^7.0.3"
+    extract-zip "^2.0.1"
+    fast-glob "^3.2.11"
+    micromatch "^4.0.4"
+    mime-types "^2.1.34"
+    path-to-regexp "^6.2.0"
+    rimraf "^3.0.2"
+    ws "^8.0.0"
+
+"@percy/cypress@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@percy/cypress/-/cypress-3.1.2.tgz#a087d3c59a6b155eab5fdb4c237526b9cfacbc22"
+  integrity sha512-JXrGDZbqwkzQd2h5T5D7PvqoucNaiMh4ChPp8cLQiEtRuLHta9nf1lEuXH+jnatGL2j+3jJFIHJ0L7XrgVnvQA==
+  dependencies:
+    "@percy/sdk-utils" "^1.3.1"
+
+"@percy/dom@1.20.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.20.1.tgz#3e8456e35324676ff8139bb04d42117c07aedc7d"
+  integrity sha512-CckhaeFEHBowUGD8ksmTnt8VNP9/0wkK5ruRCfuz9ZMgJozfQK11pz/DGWwE4U6J3k5e5GM9kTzZRNaeQvAW4A==
+
+"@percy/env@1.20.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.20.1.tgz#34767ed53823d52868e1bcafd66f838eeabecfe7"
+  integrity sha512-90KCezrnghuKQ43xiN2lsJbwliuwjq7w/Ores8uxfWvYJqIsqGRuqMkXXLx4nKpDuJ3WTJRUZPgLRzKeNV3C4g==
+
+"@percy/logger@1.20.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.20.1.tgz#0130f6b38e1b0a1e57c832afe352e04befe4f63d"
+  integrity sha512-IjST297JAJ2z7Aq5KzijsRqOR/eCh+RltyXVEmI2rcLyGdcEuAgxrhRa3iezhKzSImitsgps/MRhXrN4OQ1EMw==
+
+"@percy/sdk-utils@^1.3.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.20.1.tgz#d387b632026cdb1d8fa7d85706e481091d184bd6"
+  integrity sha512-57YD6sxrnxxYc+ylSO1JxkRCnrFnTvHGwnedAcDfxSRXrEyKlr7WavLc2YxSIDAuHmFZ+fRs8+oGXlakOnjIBw==
+
 "@pkgr/utils@^2.3.1":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@pkgr/utils/-/utils-2.3.1.tgz#0a9b06ffddee364d6642b3cd562ca76f55b34a03"
@@ -2973,7 +3109,7 @@ ajv@^6.10.0, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.11.0, ajv@^8.8.0:
+ajv@^8.0.0, ajv@^8.11.0, ajv@^8.6.2, ajv@^8.8.0:
   version "8.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
   integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
@@ -3945,7 +4081,7 @@ console-control-strings@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
 
-content-disposition@0.5.4:
+content-disposition@0.5.4, content-disposition@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
   integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
@@ -5234,7 +5370,7 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
-extract-zip@2.0.1:
+extract-zip@2.0.1, extract-zip@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
   integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
@@ -6181,6 +6317,13 @@ ignore@^5.0.5, ignore@^5.2.0:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
+
+image-size@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.0.2.tgz#d778b6d0ab75b2737c1556dd631652eb963bc486"
+  integrity sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==
+  dependencies:
+    queue "6.0.2"
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -7874,7 +8017,7 @@ mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@^2.1.34, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -8809,6 +8952,11 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
 
+path-to-regexp@^6.2.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.1.tgz#d54934d6798eb9e5ef14e7af7962c945906918e5"
+  integrity sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==
+
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
@@ -9151,6 +9299,13 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+queue@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/queue/-/queue-6.0.2.tgz#b91525283e2315c7553d2efa18d83e76432fed65"
+  integrity sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==
+  dependencies:
+    inherits "~2.0.3"
 
 quick-lru@^4.0.1:
   version "4.0.1"
@@ -11160,6 +11315,11 @@ ws@^7.3.1:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
+ws@^8.0.0:
+  version "8.12.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.1.tgz#c51e583d79140b5e42e39be48c934131942d4a8f"
+  integrity sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==
+
 ws@^8.11.0, ws@^8.4.2:
   version "8.12.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.0.tgz#485074cc392689da78e1828a9ff23585e06cddd8"
@@ -11205,7 +11365,7 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yaml@^2.1.3:
+yaml@^2.0.0, yaml@^2.1.3:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.1.tgz#3014bf0482dcd15147aa8e56109ce8632cd60ce4"
   integrity sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==


### PR DESCRIPTION
## What does this change?

One last run of the migration script from Frontend brings in:

- exclude DuckDuckGo from 'could not create advert' errors https://github.com/guardian/commercial/pull/810/commits/c1e2e36b5ac5a84fc2d0135660f627d07cf10e61
- spacefiller-complete event https://github.com/guardian/commercial/pull/810/commits/543036b2608c5105cba1ba471e74f0af8c4403d0
- e2e visual tests https://github.com/guardian/commercial/pull/810/commits/67e79463385a99d04a48129c9a29498e85014334 (WIP but bringing it over to commercial)

