### PR TITLE
chore: Bump @guardian/source-foundations@^9.0.0

### DIFF
--- a/bundle/package.json
+++ b/bundle/package.json
@@ -97,7 +97,7 @@
 		"@guardian/eslint-config-typescript": "^3.0.0",
 		"@guardian/libs": "^10.0.0",
 		"@guardian/prettier": "^2.1.1",
-		"@guardian/source-foundations": "^7.0.1",
+		"@guardian/source-foundations": "^9.0.0",
 		"@guardian/support-dotcom-components": "^1.0.7",
 		"@octokit/core": "^4.0.5",
 		"csstype": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1366,10 +1366,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-2.1.5.tgz#715fff5b110006408f92a3fe2a803ad0e4c79e06"
   integrity sha512-4fehERf5HHS9Nkaw+4u5EZ1OrFEHL4lYhLUWkpwEx4VmHI+RgcMezfDfosb3TD8cPFCKakrpdQEJUwNP283SJw==
 
-"@guardian/source-foundations@^7.0.1":
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-7.0.3.tgz#2d30d8a76ac1a5382774bbaaaa39a84551d4709d"
-  integrity sha512-XDShUQ1MvQlTaa1Va+QbLSjHA2hg/lBhfoP31wQAFd0mqpGeCjGnwI6snSX31EdpkniLqJH4Y7gGcOsZ1SqtQg==
+"@guardian/source-foundations@^9.0.0":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-9.0.1.tgz#133704bdf14e870fc2168c5adc0a071f74ef6864"
+  integrity sha512-LK4ymc3U72dNzlfQ04ZKn5cY1omSVzvKhbInvTBbWi7hoTQK8U9mikbkYG1uTMLgS8YlO1JckjYT/JpmG3TwqQ==
   dependencies:
     mini-svg-data-uri "1.4.4"
 
@@ -10798,10 +10798,25 @@ typescript-tuple@^2.2.1:
   dependencies:
     typescript-compare "^0.0.2"
 
-typescript@4.2.2, typescript@^3.9.10, typescript@^3.9.5, typescript@^3.9.7, typescript@^4.5.2, typescript@^4.6.4, typescript@~4.5.4, typescript@~4.9.0:
+typescript@4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
+  integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
+
+typescript@^3.9.10, typescript@^3.9.5, typescript@^3.9.7:
+  version "3.9.10"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
+  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+
+typescript@^4.5.2, typescript@^4.6.4:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+typescript@~4.5.4:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 uglify-js@^3.1.4:
   version "3.17.4"


### PR DESCRIPTION
## What does this change?

Bump @guardian/source-foundations@^9.0.0 to align deps with upcoming bumps in Frontend:

https://github.com/guardian/frontend/pull/25949


