### PR TITLE
fix: `dcre` should use `dcrCouldRender`

### DIFF
--- a/core/src/create-ad-slot.spec.ts
+++ b/core/src/create-ad-slot.spec.ts
@@ -23,12 +23,13 @@ const DEFAULT_CONFIG = {
 	isDotcomRendering: true,
 	ophan: { pageViewId: 'pv_id_1234567890' },
 	page: {
-		pageId: 'world/uk',
+		dcrCouldRender: true,
+		edition: 'UK' as const,
 		isPreview: false,
 		isSensitive: false,
+		pageId: 'world/uk',
 		section: 'uk-news',
 		videoDuration: 63,
-		edition: 'UK' as const,
 		webPublicationDate: 608857200,
 	},
 };

--- a/core/src/event-timer.spec.ts
+++ b/core/src/event-timer.spec.ts
@@ -45,12 +45,13 @@ const DEFAULT_CONFIG = {
 	isDotcomRendering: true,
 	ophan: { pageViewId: 'pv_id_1234567890' },
 	page: {
-		pageId: 'world/uk',
+		dcrCouldRender: true,
+		edition: 'UK' as const,
 		isPreview: false,
 		isSensitive: false,
+		pageId: 'world/uk',
 		section: 'uk-news',
 		videoDuration: 63,
-		edition: 'UK' as const,
 		webPublicationDate: 608857200,
 	},
 };

--- a/core/src/google-analytics.spec.ts
+++ b/core/src/google-analytics.spec.ts
@@ -16,12 +16,13 @@ const DEFAULT_CONFIG = {
 	isDotcomRendering: true,
 	ophan: { pageViewId: 'pv_id_1234567890' },
 	page: {
-		pageId: 'world/uk',
+		dcrCouldRender: true,
+		edition: 'UK' as const,
 		isPreview: false,
 		isSensitive: false,
+		pageId: 'world/uk',
 		section: 'uk-news',
 		videoDuration: 63,
-		edition: 'UK' as const,
 		webPublicationDate: 608857200,
 	},
 };

--- a/core/src/targeting/build-page-targeting.spec.ts
+++ b/core/src/targeting/build-page-targeting.spec.ts
@@ -860,4 +860,28 @@ describe('Build Page Targeting', () => {
 			expect(valueFromStorage).toEqual(valueGenerated);
 		});
 	});
+
+	describe('dcre dotcom-rendering-eligible', () => {
+		it('should be true if page is a dotcom-rendering-eligible page', () => {
+			window.guardian.config.page.dcrCouldRender = true;
+			expect(
+				buildPageTargeting({
+					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
+				}).dcre,
+			).toBe('t');
+		});
+
+		it('should be false if page is not a dotcom-rendering-eligible page', () => {
+			window.guardian.config.page.dcrCouldRender = false;
+			expect(
+				buildPageTargeting({
+					adFree: false,
+					clientSideParticipations: {},
+					consentState: emptyConsent,
+				}).dcre,
+			).toBe('f');
+		});
+	});
 });

--- a/core/src/targeting/build-page-targeting.ts
+++ b/core/src/targeting/build-page-targeting.ts
@@ -88,7 +88,7 @@ const buildPageTargeting = ({
 
 	const contentTargeting: ContentTargeting = getContentTargeting({
 		webPublicationDate: page.webPublicationDate,
-		eligibleForDCR: isDotcomRendering,
+		eligibleForDCR: page.dcrCouldRender,
 		path: `/${page.pageId}`,
 		renderingPlatform: isDotcomRendering
 			? 'dotcom-rendering'

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -51,6 +51,7 @@ export type GuardianWindowConfig = {
 		pageViewId: string;
 	};
 	page: {
+		dcrCouldRender: boolean;
 		edition: Edition;
 		isPreview: boolean;
 		isSensitive: boolean;


### PR DESCRIPTION
## What does this change?

The targeting property `dcre` (dcr-eligible) should derive from `config.page.dcrCouldRender` and not `config.isDotcomRendering`

