### PR TITLE
fix: Update `frontendAssetsFullURL`

### DIFF
--- a/bundle/src/bootstraps/standalone.commercial.ts
+++ b/bundle/src/bootstraps/standalone.commercial.ts
@@ -54,13 +54,14 @@ import { init as initTrackScrollDepth } from '../projects/commercial/modules/tra
 import { commercialFeatures } from '../projects/common/modules/commercial/commercial-features';
 import type { Modules } from './types';
 
-const { isDotcomRendering, page } = window.guardian.config;
+const { isDotcomRendering, frontendAssetsFullURL, page } =
+	window.guardian.config;
 
 const decideAssetsPath = () => {
 	if (process.env.OVERRIDE_BUNDLE_PATH) {
 		return process.env.OVERRIDE_BUNDLE_PATH;
 	} else {
-		const assetsPath = page.frontendAssetsFullURL ?? page.assetsPath;
+		const assetsPath = frontendAssetsFullURL ?? page.assetsPath;
 		return `${assetsPath}javascripts/commercial/`;
 	}
 };

--- a/bundle/src/types/global.d.ts
+++ b/bundle/src/types/global.d.ts
@@ -106,6 +106,7 @@ interface Config {
 		[key: `${string}Variant`]: 'variant';
 	};
 	isDotcomRendering: boolean;
+	frontendAssetsFullURL?: string;
 	googleAnalytics?: {
 		trackers?: {
 			editorial?: string;


### PR DESCRIPTION
## What does this change?

We were previously relying on `window.guardian.config.page` providing the `frontendAssetsFullURL` property. However, the actual data model reliably provides that value in `window.guardian.config` - so we'll use that instead.

Where it's populated on DCR:
- [For articles](https://github.com/guardian/dotcom-rendering/blob/5217cb56aa23a896c14840123fd1f5378a8faa30/dotcom-rendering/src/web/server/articleToHtml.tsx#L125).
- [For fronts](https://github.com/guardian/dotcom-rendering/blob/5217cb56aa23a896c14840123fd1f5378a8faa30/dotcom-rendering/src/web/server/frontToHtml.tsx#L76).

## Why?

Fix an issue with dynamic imports not loading. on new DCR fronts - this is because `window.guardian.config.page.frontendAssetsFullURL` was not defined.
