### PR TITLE
feat: Client-side targeting for elements-manager

### DIFF
--- a/bundle/src/bootstraps/standalone.commercial.ts
+++ b/bundle/src/bootstraps/standalone.commercial.ts
@@ -241,7 +241,7 @@ const chooseAdvertisingTag = async () => {
 if (isInVariantSynchronous(elementsManager, 'variant')) {
 	void import(
 		/* webpackChunkName: "elements-manager" */
-		'../projects/commercial/modules/elementsManager'
+		'../projects/commercial/modules/elements-manager/init'
 	).then(({ initElementsManager }) => initElementsManager());
 }
 

--- a/bundle/src/projects/commercial/modules/elements-manager/init.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/init.ts
@@ -7,7 +7,7 @@ import { dfpEnv } from '../dfp/dfp-env';
 import { renderAdvertLabel } from '../dfp/render-advert-label';
 import {
 	fetchSelectionPayload,
-	getPageTargeting,
+	getPageTargetingForElements,
 	initTargeting,
 } from './targeting';
 
@@ -80,13 +80,10 @@ const showPreview = (
 
 const selectAssetsForSlots = async (slots: HTMLElement[]) => {
 	const consentState = await onConsent();
-	const selectionPayload = await fetchSelectionPayload();
-	const pageTargeting = getPageTargeting(consentState);
+	const elements = await fetchSelectionPayload();
+	const pageTargeting = getPageTargetingForElements(consentState);
 
-	const { selectAssetForSlot } = initTargeting(
-		selectionPayload,
-		pageTargeting,
-	);
+	const { selectAssetForSlot } = initTargeting(elements, pageTargeting);
 
 	slots.forEach((slot) => {
 		const slotName = slot.dataset.name;

--- a/bundle/src/projects/commercial/modules/elements-manager/init.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/init.ts
@@ -93,7 +93,8 @@ const selectAssetsForSlots = async (slots: HTMLElement[]) => {
 			);
 			return;
 		}
-		const asset = selectAssetForSlot(slotName);
+		const slotTargeting = { slot: slot.dataset.name };
+		const asset = selectAssetForSlot(slotTargeting);
 		if (asset) {
 			createIframe(slot, asset.path, {
 				width: asset.width?.toString(),

--- a/bundle/src/projects/commercial/modules/elements-manager/init.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/init.ts
@@ -2,8 +2,8 @@ import { isString } from '@guardian/libs';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { elementsManager } from 'common/modules/experiments/tests/elements-manager';
 import { getUrlVars } from 'lib/url';
-import { dfpEnv } from './dfp/dfp-env';
-import { renderAdvertLabel } from './dfp/render-advert-label';
+import { dfpEnv } from '../dfp/dfp-env';
+import { renderAdvertLabel } from '../dfp/render-advert-label';
 
 type PreviewParameters = {
 	assetPath: string;

--- a/bundle/src/projects/commercial/modules/elements-manager/init.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/init.ts
@@ -1,9 +1,15 @@
+import { onConsent } from '@guardian/consent-management-platform';
 import { isString } from '@guardian/libs';
 import { isInVariantSynchronous } from 'common/modules/experiments/ab';
 import { elementsManager } from 'common/modules/experiments/tests/elements-manager';
 import { getUrlVars } from 'lib/url';
 import { dfpEnv } from '../dfp/dfp-env';
 import { renderAdvertLabel } from '../dfp/render-advert-label';
+import {
+	fetchSelectionPayload,
+	getPageTargeting,
+	initTargeting,
+} from './targeting';
 
 type PreviewParameters = {
 	assetPath: string;
@@ -61,25 +67,60 @@ const createIframe = (
 	adSlot.appendChild(iframeNode);
 };
 
-const initElementsManager = (): Promise<void> => {
+const showPreview = (
+	slots: HTMLElement[],
+	previewParams: PreviewParameters,
+) => {
+	const { assetPath, width, height } = previewParams;
+	slots.forEach((adSlot) => {
+		createIframe(adSlot, assetPath, { width, height });
+		void renderAdvertLabel(adSlot);
+	});
+};
+
+const selectAssetsForSlots = async (slots: HTMLElement[]) => {
+	const consentState = await onConsent();
+	const selectionPayload = await fetchSelectionPayload();
+	const pageTargeting = getPageTargeting(consentState);
+
+	const { selectAssetForSlot } = initTargeting(
+		selectionPayload,
+		pageTargeting,
+	);
+
+	slots.forEach((slot) => {
+		const slotName = slot.dataset.name;
+		if (!slotName) {
+			console.error(
+				`Name attribute not found for slot with id ${slot.id}`,
+			);
+			return;
+		}
+		const asset = selectAssetForSlot(slotName);
+		if (asset) {
+			createIframe(slot, asset.path, {
+				width: asset.width?.toString(),
+				height: asset.height?.toString(),
+			});
+			void renderAdvertLabel(slot);
+		}
+	});
+};
+
+const initElementsManager = async (): Promise<void> => {
 	if (!isInVariantSynchronous(elementsManager, 'variant')) {
 		return Promise.resolve();
 	}
 
+	const slots = getSlots();
 	const previewParams = parsePreviewUrl();
 
-	if (!previewParams) {
+	if (previewParams) {
+		showPreview(slots, previewParams);
 		return Promise.resolve();
 	}
 
-	const { assetPath, width, height } = previewParams;
-
-	getSlots().forEach((adSlot) => {
-		createIframe(adSlot, assetPath, { width, height });
-		void renderAdvertLabel(adSlot);
-	});
-
-	return Promise.resolve();
+	await selectAssetsForSlots(slots);
 };
 
 export { initElementsManager };

--- a/bundle/src/projects/commercial/modules/elements-manager/init.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/init.ts
@@ -8,7 +8,7 @@ import { renderAdvertLabel } from '../dfp/render-advert-label';
 import {
 	fetchSelectionPayload,
 	getPageTargetingForElements,
-	initTargeting,
+	selectAsset,
 } from './targeting';
 
 type PreviewParameters = {
@@ -83,8 +83,6 @@ const selectAssetsForSlots = async (slots: HTMLElement[]) => {
 	const elements = await fetchSelectionPayload();
 	const pageTargeting = getPageTargetingForElements(consentState);
 
-	const { selectAssetForSlot } = initTargeting(elements, pageTargeting);
-
 	slots.forEach((slot) => {
 		const slotName = slot.dataset.name;
 		if (!slotName) {
@@ -93,8 +91,10 @@ const selectAssetsForSlots = async (slots: HTMLElement[]) => {
 			);
 			return;
 		}
-		const slotTargeting = { slot: slot.dataset.name };
-		const asset = selectAssetForSlot(slotTargeting);
+		const asset = selectAsset(elements, {
+			...pageTargeting,
+			slot: slot.dataset.name,
+		});
 		if (asset) {
 			createIframe(slot, asset.path, {
 				width: asset.width?.toString(),

--- a/bundle/src/projects/commercial/modules/elements-manager/init.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/init.ts
@@ -72,9 +72,9 @@ const showPreview = (
 	previewParams: PreviewParameters,
 ) => {
 	const { assetPath, width, height } = previewParams;
-	slots.forEach((adSlot) => {
-		createIframe(adSlot, assetPath, { width, height });
-		void renderAdvertLabel(adSlot);
+	slots.forEach((slot) => {
+		createIframe(slot, assetPath, { width, height });
+		void renderAdvertLabel(slot);
 	});
 };
 

--- a/bundle/src/projects/commercial/modules/elements-manager/targeting.spec.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/targeting.spec.ts
@@ -1,0 +1,214 @@
+import { selectAsset } from './targeting';
+import type { Asset, GuElement } from './types';
+import { selectAtRandom } from './util';
+
+jest.mock('common/modules/experiments/ab', () => ({
+	isInVariantSynchronous: jest.fn(),
+}));
+
+jest.mock('./util', () => ({
+	...jest.requireActual('./util'),
+	// Fix the random selection function to always pick the first element by default
+	selectAtRandom: jest
+		.fn()
+		.mockImplementation(<T>(candidates: T[]) => candidates[0]),
+}));
+
+describe('selectAsset', () => {
+	it('wont select asset without any targeting', () => {
+		const elements: GuElement[] = [
+			{
+				id: 'element1',
+				assets: [{ id: 'asset1' } as Asset],
+				targeting: [{ key: 'section', value: new Set(['sport']) }],
+			},
+		];
+
+		expect(selectAsset(elements, {})).toBeUndefined();
+	});
+
+	it('will select asset with single matching value', () => {
+		const elements: GuElement[] = [
+			{
+				id: 'element1',
+				assets: [{ id: 'asset1' } as Asset],
+				targeting: [{ key: 'section', value: new Set(['sport']) }],
+			},
+		];
+
+		expect(selectAsset(elements, { section: null })).toBeUndefined();
+
+		expect(selectAsset(elements, { section: undefined })).toBeUndefined();
+
+		expect(selectAsset(elements, { section: 'sport' })).toMatchObject({
+			id: 'asset1',
+		});
+
+		expect(selectAsset(elements, { section: ['sport'] })).toMatchObject({
+			id: 'asset1',
+		});
+	});
+
+	it('will select asset only if all the keys-values match', () => {
+		const elements: GuElement[] = [
+			{
+				id: 'element1',
+				assets: [{ id: 'asset1' } as Asset],
+				targeting: [
+					{ key: 'section', value: new Set(['sport']) },
+					{ key: 'at', value: new Set(['fixed-puppies']) },
+				],
+			},
+		];
+
+		expect(selectAsset(elements, { section: 'sport' })).toBeUndefined;
+
+		expect(selectAsset(elements, { at: 'fixed-puppies' })).toBeUndefined;
+
+		expect(
+			selectAsset(elements, { section: 'sport', at: 'fixed-puppies' }),
+		).toMatchObject({
+			id: 'asset1',
+		});
+	});
+
+	it('wont select asset when values dont match', () => {
+		const elements: GuElement[] = [
+			{
+				id: 'element1',
+				assets: [{ id: 'asset1' } as Asset],
+				targeting: [{ key: 'section', value: new Set(['sport']) }],
+			},
+		];
+		expect(selectAsset(elements, { section: 'culture' })).toBeUndefined;
+	});
+
+	it('wont select asset when keys dont overlap', () => {
+		const elements: GuElement[] = [
+			{
+				id: 'element1',
+				assets: [{ id: 'asset1' } as Asset],
+				targeting: [{ key: 'at', value: new Set(['fixed-puppies']) }],
+			},
+		];
+		expect(selectAsset(elements, { section: 'culture' })).toBeUndefined;
+	});
+
+	it('element with two values for a key can be selected by two assets with the distinct keys', () => {
+		const elements: GuElement[] = [
+			{
+				id: 'element1',
+				assets: [{ id: 'asset1' } as Asset],
+				targeting: [
+					{ key: 'section', value: new Set(['sport', 'culture']) },
+				],
+			},
+		];
+
+		expect(selectAsset(elements, { section: 'sport' })).toMatchObject({
+			id: 'asset1',
+		});
+
+		expect(selectAsset(elements, { section: 'culture' })).toMatchObject({
+			id: 'asset1',
+		});
+	});
+
+	it('element with no targeting is always selected', () => {
+		const elements: GuElement[] = [
+			{
+				id: 'element1',
+				assets: [{ id: 'asset1' } as Asset],
+				targeting: [],
+			},
+		];
+
+		expect(selectAsset(elements, {})).toMatchObject({
+			id: 'asset1',
+		});
+
+		expect(
+			selectAsset(elements, {
+				at: 'fixed-puppies',
+				section: 'culture',
+				segments: ['100', '200', '300'],
+			}),
+		).toMatchObject({
+			id: 'asset1',
+		});
+	});
+
+	it('element with no asset is never selected, even with targeting matching', () => {
+		const elements: GuElement[] = [
+			{
+				id: 'element1',
+				assets: [],
+				targeting: [{ key: 'at', value: new Set(['fixed-puppies']) }],
+			},
+		];
+
+		expect(selectAsset(elements, { at: 'fixed-puppies' })).toBeUndefined;
+	});
+
+	it('elements with the same targeting are both selected', () => {
+		const elements: GuElement[] = [
+			{
+				id: 'element1',
+				assets: [{ id: 'asset1' } as Asset],
+				targeting: [{ key: 'section', value: new Set(['sport']) }],
+			},
+			{
+				id: 'element2',
+				assets: [{ id: 'asset2' } as Asset],
+				targeting: [{ key: 'section', value: new Set(['sport']) }],
+			},
+		];
+
+		expect(selectAsset(elements, { section: 'sport' })).toMatchObject({
+			id: 'asset1',
+		});
+
+		// Fix the random selection function to pick the second candidate next
+
+		(selectAtRandom as jest.Mock).mockImplementationOnce(
+			<T>(candidates: T[]) => candidates[1],
+		);
+
+		expect(selectAsset(elements, { section: 'sport' })).toMatchObject({
+			id: 'asset2',
+		});
+	});
+
+	it('both elements are selected when they have subsets of targeting that matches', () => {
+		const elements: GuElement[] = [
+			{
+				id: 'element1',
+				assets: [{ id: 'asset1' } as Asset],
+				targeting: [{ key: 'section', value: new Set(['sport']) }],
+			},
+			{
+				id: 'element2',
+				assets: [{ id: 'asset2' } as Asset],
+				targeting: [{ key: 'section', value: new Set(['culture']) }],
+			},
+		];
+
+		expect(
+			selectAsset(elements, { section: ['sport', 'culture'] }),
+		).toMatchObject({
+			id: 'asset1',
+		});
+
+		// Fix the random selection function to pick the second candidate next
+
+		(selectAtRandom as jest.Mock).mockImplementationOnce(
+			<T>(candidates: T[]) => candidates[1],
+		);
+
+		expect(
+			selectAsset(elements, { section: ['sport', 'culture'] }),
+		).toMatchObject({
+			id: 'asset2',
+		});
+	});
+});

--- a/bundle/src/projects/commercial/modules/elements-manager/targeting.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/targeting.ts
@@ -12,7 +12,6 @@ import type {
 	GuElement,
 	SerializedPayload,
 	TargetingRule,
-	TargetingRules,
 } from './types';
 
 export const fetchSelectionPayload = async (): Promise<GuElement[]> => {
@@ -105,7 +104,7 @@ const satisfiesRule = (
  */
 const satisfiesTargeting = (
 	pageTargeting: PageTargeting,
-	targetingRules: TargetingRules,
+	targetingRules: TargetingRule[],
 ): boolean =>
 	targetingRules.every((rule) => satisfiesRule(pageTargeting, rule));
 

--- a/bundle/src/projects/commercial/modules/elements-manager/targeting.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/targeting.ts
@@ -132,15 +132,12 @@ export const initTargeting = (
 	elements: GuElement[],
 	pageTargeting: PageTargeting,
 ) => {
-	const selectAssetForSlot = (slotId: string): Asset | undefined => {
-		const targeting = { ...pageTargeting, slot: slotId };
-
-		// Select all of the eligible candidates from their targeting
+	const selectAssetForSlot = (
+		slotTargeting: PageTargeting,
+	): Asset | undefined => {
+		const targeting = { ...pageTargeting, ...slotTargeting };
 		const candidates = eligibleElements(targeting, elements);
-
 		const winningElement = selectAtRandom(candidates);
-
-		// Choose an asset at random from the winning element
 		return winningElement
 			? selectAtRandom(winningElement.assets)
 			: undefined;

--- a/bundle/src/projects/commercial/modules/elements-manager/targeting.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/targeting.ts
@@ -1,0 +1,104 @@
+import type { PageTargeting } from '@guardian/commercial-core';
+import {
+	buildPageTargeting,
+	buildPageTargetingConsentless,
+} from '@guardian/commercial-core';
+import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import { isString } from 'lodash-es';
+import { commercialFeatures } from 'common/modules/commercial/commercial-features';
+import { getSynchronousParticipations } from 'common/modules/experiments/ab';
+import type {
+	Asset,
+	GuElement,
+	SelectionPayload,
+	TargetingRule,
+	TargetingRules,
+} from './types';
+
+export const fetchSelectionPayload = (): Promise<SelectionPayload> => {
+	// TODO replace this with a fetch
+	return Promise.resolve({
+		elements: [],
+	});
+};
+
+/**
+ * Obtain consented or consentless page targeting object, based on consent state.
+ */
+export const getPageTargeting = (consentState: ConsentState): PageTargeting => {
+	if (consentState.canTarget) {
+		return buildPageTargeting({
+			consentState,
+			adFree: commercialFeatures.adFree,
+			clientSideParticipations: getSynchronousParticipations(),
+		});
+	} else {
+		return buildPageTargetingConsentless(
+			consentState,
+			commercialFeatures.adFree,
+		);
+	}
+};
+
+/**
+ * Check that a single targeting role is satisfied by the page targeting object.
+ */
+const satisfiesRule = (
+	pageTargeting: PageTargeting,
+	condition: TargetingRule,
+): boolean => {
+	const targetingValue = pageTargeting[condition.key];
+	if (!targetingValue) {
+		return false;
+	} else if (isString(targetingValue)) {
+		return condition.value.has(targetingValue);
+	} else {
+		return targetingValue.some((v) => condition.value.has(v));
+	}
+};
+
+/**
+ * Check that all of the conditions in the target are satisfied
+ * by the page targeting object. This is in effect the AND conditions
+ * as supplied in the GEM UI.
+ */
+const satisfiesTargeting = (
+	pageTargeting: PageTargeting,
+	targetingRules: TargetingRules,
+): boolean =>
+	targetingRules.every((rule) => satisfiesRule(pageTargeting, rule));
+
+/**
+ * Compute the set of eligible elements for a given page targeting object.
+ */
+const eligibleElements = (
+	pageTargeting: PageTargeting,
+	elements: GuElement[],
+) =>
+	elements.filter(
+		(element) =>
+			// Element has at least one linked asset
+			element.assets.length > 0 &&
+			// The page targeting object supplied satisfies the element's targeting rules
+			satisfiesTargeting(pageTargeting, element.targeting),
+	);
+
+const selectAtRandom = <T>(candidates: T[]) =>
+	// TODO remove this type assertion when we can enable --noUncheckedIndexedAccess compiler option
+	candidates[Math.floor(Math.random() * candidates.length)] as T | undefined;
+
+export const initTargeting = (
+	{ elements }: SelectionPayload,
+	pageTargeting: PageTargeting,
+) => {
+	const selectAssetForSlot = (slotId: string): Asset | undefined => {
+		// Combine per-slot targeting to the page targeting object
+		const targeting = { ...pageTargeting, slot: slotId };
+		const candidates = eligibleElements(targeting, elements);
+		const winningElement = selectAtRandom(candidates);
+		return winningElement
+			? selectAtRandom(winningElement.assets)
+			: undefined;
+	};
+	return { selectAssetForSlot };
+};

--- a/bundle/src/projects/commercial/modules/elements-manager/targeting.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/targeting.ts
@@ -86,15 +86,17 @@ const satisfiesRule = (
 		// If there is no value in the targeting for the corresponding key then
 		// this rule can't be satisfied
 		return false;
-	} else if (isString(targetingValue)) {
+	}
+
+	if (isString(targetingValue)) {
 		// If there is a single value in the targeting for this key, check that
 		// string is present in the condition's values
 		return condition.value.has(targetingValue);
-	} else {
-		// If there's multiple values in the targeting for this key, check that
-		// at least one is present in the condition's values
-		return targetingValue.some((v) => condition.value.has(v));
 	}
+
+	// If there's multiple values in the targeting for this key, check that
+	// at least one is present in the condition's values
+	return targetingValue.some((v) => condition.value.has(v));
 };
 
 /**

--- a/bundle/src/projects/commercial/modules/elements-manager/targeting.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/targeting.ts
@@ -14,7 +14,7 @@ import type {
 	TargetingRule,
 } from './types';
 
-export const fetchSelectionPayload = async (): Promise<GuElement[]> => {
+const fetchSelectionPayload = async (): Promise<GuElement[]> => {
 	// Endpoints are required for development purposes
 	const payloadUrl = `http://localhost:3000/api/elements`;
 	const assetUrl = `http://localhost:3000/api/dev/asset`;
@@ -54,7 +54,7 @@ export const fetchSelectionPayload = async (): Promise<GuElement[]> => {
 /**
  * Obtain consented or consentless page targeting object, based on consent state.
  */
-export const getPageTargetingForElements = (
+const getPageTargetingForElements = (
 	consentState: ConsentState,
 ): PageTargeting => {
 	if (consentState.canTarget) {
@@ -129,10 +129,7 @@ const selectAtRandom = <T>(candidates: T[]) =>
 	// TODO remove this type assertion when we can enable --noUncheckedIndexedAccess compiler option
 	candidates[Math.floor(Math.random() * candidates.length)] as T | undefined;
 
-export const initTargeting = (
-	elements: GuElement[],
-	pageTargeting: PageTargeting,
-) => {
+const initTargeting = (elements: GuElement[], pageTargeting: PageTargeting) => {
 	const selectAssetForSlot = (
 		slotTargeting: PageTargeting,
 	): Asset | undefined => {
@@ -145,3 +142,5 @@ export const initTargeting = (
 	};
 	return { selectAssetForSlot };
 };
+
+export { initTargeting, getPageTargetingForElements, fetchSelectionPayload };

--- a/bundle/src/projects/commercial/modules/elements-manager/targeting.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/targeting.ts
@@ -129,18 +129,10 @@ const selectAtRandom = <T>(candidates: T[]) =>
 	// TODO remove this type assertion when we can enable --noUncheckedIndexedAccess compiler option
 	candidates[Math.floor(Math.random() * candidates.length)] as T | undefined;
 
-const initTargeting = (elements: GuElement[], pageTargeting: PageTargeting) => {
-	const selectAssetForSlot = (
-		slotTargeting: PageTargeting,
-	): Asset | undefined => {
-		const targeting = { ...pageTargeting, ...slotTargeting };
-		const candidates = eligibleElements(targeting, elements);
-		const winningElement = selectAtRandom(candidates);
-		return winningElement
-			? selectAtRandom(winningElement.assets)
-			: undefined;
-	};
-	return { selectAssetForSlot };
+const selectAsset = (elements: GuElement[], targeting: PageTargeting) => {
+	const candidates = eligibleElements(targeting, elements);
+	const winningElement = selectAtRandom(candidates);
+	return winningElement ? selectAtRandom(winningElement.assets) : undefined;
 };
 
-export { initTargeting, getPageTargetingForElements, fetchSelectionPayload };
+export { getPageTargetingForElements, fetchSelectionPayload, selectAsset };

--- a/bundle/src/projects/commercial/modules/elements-manager/targeting.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/targeting.ts
@@ -7,12 +7,8 @@ import type { ConsentState } from '@guardian/consent-management-platform/dist/ty
 import { isString } from 'lodash-es';
 import { commercialFeatures } from 'common/modules/commercial/commercial-features';
 import { getSynchronousParticipations } from 'common/modules/experiments/ab';
-import type {
-	Asset,
-	GuElement,
-	SerializedPayload,
-	TargetingRule,
-} from './types';
+import type { GuElement, SerializedPayload, TargetingRule } from './types';
+import { selectAtRandom } from './util';
 
 const fetchSelectionPayload = async (): Promise<GuElement[]> => {
 	// Endpoints are required for development purposes
@@ -124,10 +120,6 @@ const eligibleElements = (
 			// The page targeting object supplied satisfies the element's targeting rules
 			satisfiesTargeting(pageTargeting, element.targeting),
 	);
-
-const selectAtRandom = <T>(candidates: T[]) =>
-	// TODO remove this type assertion when we can enable --noUncheckedIndexedAccess compiler option
-	candidates[Math.floor(Math.random() * candidates.length)] as T | undefined;
 
 const selectAsset = (elements: GuElement[], targeting: PageTargeting) => {
 	const candidates = eligibleElements(targeting, elements);

--- a/bundle/src/projects/commercial/modules/elements-manager/types.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/types.ts
@@ -15,3 +15,17 @@ export type GuElement = {
 	targeting: TargetingRules;
 	assets: Asset[];
 };
+
+/**
+ * The type of the serialized payload that describes the elements to select
+ */
+export type SerializedPayload = Array<{
+	id: string;
+	targeting: Array<{
+		key: string;
+		// Here multiple values may occupy the same string, but are comma separated
+		// e.g. `sport,culture`
+		value: string;
+	}>;
+	assets: Asset[];
+}>;

--- a/bundle/src/projects/commercial/modules/elements-manager/types.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/types.ts
@@ -15,7 +15,3 @@ export type GuElement = {
 	targeting: TargetingRules;
 	assets: Asset[];
 };
-
-export type SelectionPayload = {
-	elements: GuElement[];
-};

--- a/bundle/src/projects/commercial/modules/elements-manager/types.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/types.ts
@@ -1,0 +1,21 @@
+export type TargetingRule = { key: string; value: Set<string> };
+
+export type TargetingRules = TargetingRule[];
+
+export type Asset = {
+	id: string;
+	path: string;
+	clickThroughUrl: string;
+	width?: number;
+	height?: number;
+};
+
+export type GuElement = {
+	id: string;
+	targeting: TargetingRules;
+	assets: Asset[];
+};
+
+export type SelectionPayload = {
+	elements: GuElement[];
+};

--- a/bundle/src/projects/commercial/modules/elements-manager/types.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/types.ts
@@ -1,7 +1,5 @@
 export type TargetingRule = { key: string; value: Set<string> };
 
-export type TargetingRules = TargetingRule[];
-
 export type Asset = {
 	id: string;
 	path: string;
@@ -12,7 +10,7 @@ export type Asset = {
 
 export type GuElement = {
 	id: string;
-	targeting: TargetingRules;
+	targeting: TargetingRule[];
 	assets: Asset[];
 };
 

--- a/bundle/src/projects/commercial/modules/elements-manager/util.ts
+++ b/bundle/src/projects/commercial/modules/elements-manager/util.ts
@@ -1,0 +1,8 @@
+const selectAtRandom = <T>(candidates: T[]) => {
+	// TODO remove this type assertion when we can enable --noUncheckedIndexedAccess compiler option
+	return candidates[Math.floor(Math.random() * candidates.length)] as
+		| T
+		| undefined;
+};
+
+export { selectAtRandom };


### PR DESCRIPTION
## What does this change?

This PR lays out the initial functionality for targeting in the GEM client.

We fetch the full set of elements, with their assets and targeting, from the endpoint introduced in [this elements-manager PR](https://github.com/guardian/elements-manager/pull/21). In production we'll retrieve an object of the same shape from the CDN. It is then the responsibility of the client to determine, for each slot, which element would be eligible to fill it.

### Summary of how this targeting works


Imagine an element has the following targeting fetched from the elements-manager UI:

```json
[
  { "key": "slot", "value": "mostpop,comments" },
  { "key": "k", "value": "commentisfree" }
]
```

For a slot to be filled by this element, the combined page and slot targeting for this slot must contain:
- the key `k` with at least one corresponding value that is `commentisfree`.
- the key `slot` with at least one corresponding value that is `mostpop` or `commentisfree`.

To compute this, we roughly follow:

- Assemble a _page_ targeting object, in the typical way. Here we check consent state and either choose the full page targeting object, or the consent-less targeting object.
- For each slot on the page, combine the previous page targeting with some slot-level targeting (at the moment just e.g. `slot: top-above-nav`.
- Check this full targeting for a slot against the retrieved elements, to determine which are eligible.
- To determine eligibility of an element, we take each of the targeting rules defined for it and check **every** one of them can be satisfied by the targeting. This is in effect _ANDing_ all of the targeting rules together. We also ensure that an element has at least one linked asset, otherwise it's considered ineligible.
- To determine if a single rule is satisfied, we check that the key is defined in the targeting and that at least one of the values  is present corresponding to that key. Checking for at least one allows users of GEM to target multiple things for a single element e.g. setting _slot is either mostpop or comments_.
- From the eligible elements, we currently just select one at random. This is considered the _winning element_.
- Select an asset at random from the winning element. This should always be present, since eligible elements have at least one linked asset.
- Fill the given slot with the asset set as an iframe `src`, as well as rendering the label.

### Caveats

- A single element's asset can appear in more than one slot on a given page. We could change this down the line, to make it more like GAM.
- No notion of _priority_ when targeting elements. At present, there's no way to target an ad test in the way you would with GAM, where it beats out all of the other elements on the page.

## Examples

Apply `k=uk` and `k=climate-crisis` targeting to target two elements to separate section fronts. Note the assets fill each of the slots on the page.

https://user-images.githubusercontent.com/8000415/225327156-3cf763c3-6141-407a-9562-ecaf45064861.mov

<hr>

Apply `slot=mostpop` and `slot=merchandising` targeting to two elements to target separate slots on an article. Note that slots default to MPU size for the moment, hence the scrolling.

https://user-images.githubusercontent.com/8000415/225328978-9dafacf5-cd91-4ef9-8c04-bacdcd769e8a.mov

## Why?

Allows for the targeting applied in the GEM UI be reflected by the placement of elements (and their assets) on the client.