### PR TITLE
Adds frozen-lockfile to yarn install in ci

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8659,7 +8659,7 @@ postcss-selector-parser@^6.0.10:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-prebid.js@guardian/prebid.js#2e3b96d:
+"prebid.js@github:guardian/prebid.js#2e3b96d":
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:


### PR DESCRIPTION
## What does this change?

Adds `--frozen-lockfile` to yarn install in ci

## Why?

So that unintentional changes in yarn lock will cause the build to fail