### PR TITLE
chore!: fix semantic-release conventionalcommits ! syntax

### DIFF
--- a/bundle/.releaserc.json
+++ b/bundle/.releaserc.json
@@ -2,10 +2,19 @@
 	"extends": "semantic-release-monorepo",
 	"branches": "main",
 	"plugins": [
-		"@semantic-release/commit-analyzer",
-		"@semantic-release/release-notes-generator",
+		[
+			"@semantic-release/commit-analyzer",
+			{
+				"preset": "conventionalcommits"
+			}
+		],
+		[
+			"@semantic-release/release-notes-generator",
+			{
+				"preset": "conventionalcommits"
+			}
+		],
 		"@semantic-release/npm",
 		"@semantic-release/github"
-	],
-	"preset": "conventionalcommits"
+	]
 }

--- a/core/.releaserc.json
+++ b/core/.releaserc.json
@@ -2,10 +2,19 @@
 	"extends": "semantic-release-monorepo",
 	"branches": "main",
 	"plugins": [
-		"@semantic-release/commit-analyzer",
-		"@semantic-release/release-notes-generator",
+		[
+			"@semantic-release/commit-analyzer",
+			{
+				"preset": "conventionalcommits"
+			}
+		],
+		[
+			"@semantic-release/release-notes-generator",
+			{
+				"preset": "conventionalcommits"
+			}
+		],
 		"@semantic-release/npm",
 		"@semantic-release/github"
-	],
-	"preset": "conventionalcommits"
+	]
 }


### PR DESCRIPTION
## What does this change?

[conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) syntax should allow a `!` postfix to commit types to signal a major release to semantic-release.

At some point the conventionalcommits preset configuration for semantic-release stopped working for `!` with types (`build, chore, ci, docs, style, refactor, perf, test`) and now only work for `fix` or `feat`.

A related discussion around `!` is here:
https://github.com/semantic-release/semantic-release/issues/2339

The current preset configuration looks correct [according to the docs](https://semantic-release.gitbook.io/semantic-release/usage/plugins#plugin-options-configuration) but [this post](https://github.com/semantic-release/semantic-release/issues/2339#issuecomment-1451987883) suggested a change to the way the preset is applied to the semantic-release plugins.

Using this handy guide to run semantic-release dry-run locally:
https://blog.elantha.com/semantic-release-local-dry-run/

I can see that the preset change does now pick up a major release:

before:
```
[semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: docs!: Update node instructions
[semantic-release] [@semantic-release/commit-analyzer] › ℹ  The commit should not trigger a release
```

after:
```
[semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: docs!: Update node instructions
[semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is major
```

I am deliberately using `chore!` for this PR to test if a major release is performed (we have backed up major releases which have not happened so imo this is okay).
