### PR TITLE
fix: Skip loading Opt Out if in the elements-manager test

### DIFF
--- a/bundle/src/bootstraps/standalone.commercial.ts
+++ b/bundle/src/bootstraps/standalone.commercial.ts
@@ -221,7 +221,7 @@ const chooseAdvertisingTag = async () => {
 	// Only load the Opt Out tag in TCF regions when there is no consent for Googletag
 	if (consentState.tcfv2 && !getConsentFor('googletag', consentState)) {
 		// Don't load OptOut (for now) if loading Elements Manager
-		if (!isInVariantSynchronous(elementsManager, 'variant')) {
+		if (isInVariantSynchronous(elementsManager, 'variant')) {
 			return;
 		}
 


### PR DESCRIPTION
## What does this change?

When in the elements-manager variant, don't load the consentless bundle.

## Why

Fix so we can properly enter the consentless AB test.