### PR TITLE
feat: Permit dynamic `exclusion` slots

### DIFF
--- a/core/src/create-ad-slot.ts
+++ b/core/src/create-ad-slot.ts
@@ -14,6 +14,7 @@ type SlotName =
 	| 'comments-expanded'
 	| 'comments'
 	| 'epic'
+	| 'exclusion'
 	| 'high-merch-lucky'
 	| 'high-merch-paid'
 	| 'high-merch'


### PR DESCRIPTION
## What does this change?

Allow `exclusion` named slots to be created by the `createAdSlot` function.

## Why?

An exclusion slot is a special slot that can be used to exclude Opt Out Advertising from an entire page.

We currently server-side render `exclusion` slots, but we could client-side render them once we know we'll be making requests to Opt Out. This PR is the first step to achieve this.
