### PR TITLE
feat: Render the `exclusion` slot from the Opt Out script

### DIFF
--- a/bundle/package.json
+++ b/bundle/package.json
@@ -90,7 +90,7 @@
 	},
 	"dependencies": {
 		"@guardian/ab-core": "^4.0.0",
-		"@guardian/commercial-core": "^5.4.4",
+		"@guardian/commercial-core": "^6.1.0",
 		"@guardian/consent-management-platform": "^12.0.0",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/libs": "^14.0.0",

--- a/bundle/src/bootstraps/commercial.consentless.ts
+++ b/bundle/src/bootstraps/commercial.consentless.ts
@@ -1,5 +1,6 @@
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import { initArticleInline } from 'commercial/modules/consentless/dynamic/article-inline';
+import { initExclusionSlot } from 'commercial/modules/consentless/dynamic/exclusion-slot';
 import { initLiveblogInline } from 'commercial/modules/consentless/dynamic/liveblog-inline';
 import { initFixedSlots } from 'commercial/modules/consentless/init-fixed-slots';
 import { initConsentless } from 'commercial/modules/consentless/prepare-ootag';
@@ -23,6 +24,7 @@ const bootConsentless = async (consentState: ConsentState): Promise<void> => {
 		setAdTestCookie(),
 		setAdTestInLabelsCookie(),
 		initConsentless(consentState),
+		initExclusionSlot(),
 		initFixedSlots(),
 		initArticleInline(),
 		initLiveblogInline(),

--- a/bundle/src/projects/commercial/modules/consentless/dynamic/exclusion-slot.ts
+++ b/bundle/src/projects/commercial/modules/consentless/dynamic/exclusion-slot.ts
@@ -1,0 +1,25 @@
+import { createAdSlot } from '@guardian/commercial-core';
+import fastdom from '../../../../../lib/fastdom-promise';
+import { defineSlot } from '../define-slot';
+
+/**
+ * This is responsible for inserting an _exclusion_ ad slot into the DOM
+ *
+ * This is a special type of ad which, when filled, blocks
+ * all other ads on the page. This allows us to run "exclusion
+ * campaigns" against certain breaking news pages.
+ *
+ * Exclusion ads are used for consentless advertising only.
+ * GAM has a different mechanism to achieve the same thing.
+ */
+const initExclusionSlot = async (): Promise<void> => {
+	const adSlot = createAdSlot('exclusion');
+
+	// Insert the slot into the body of the page
+	// It doesn't particularly matter where we insert it, since it doesn't render anything
+	await fastdom.mutate(() => document.body.appendChild(adSlot));
+
+	defineSlot(adSlot, 'exclusion');
+};
+
+export { initExclusionSlot };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1297,12 +1297,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-4.0.0.tgz#50c1fc076437e594b367f6e8d9469a3d9b97a78e"
   integrity sha512-l6Ot/anisLKyoLZOp8koW7Ia5JFOtmZkB0sfgdWajv5+N0w0UScUVoImEdPlFstM1anSd3FvV8D3UgYkRzAang==
 
-"@guardian/commercial-core@^5.4.4":
-  version "5.4.4"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-5.4.4.tgz#671064c6fb495b6876c43520b6b9d622cd20b450"
-  integrity sha512-mYerRRQ5YXfUr8hINbLn1MEe6JLa0S7E/yAJIfSSVc1TC1BrsZ2LUnZ6rN3ZWy8ktgFLFAWUgJHZgF+dvYF58g==
-  dependencies:
-    type-fest "2.12.2"
+"@guardian/commercial-core@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-6.1.0.tgz#62112b56e9ff4cdc8abd045cec0dfb9600583fb9"
+  integrity sha512-gopAGdiPmMuRCWnRn8XTVY2UsOtHI6LnFnDqAJfnNejorHv2mVMzU26fK8lQ/89mUAewQDk0HO95eVb+J32EJA==
 
 "@guardian/consent-management-platform@^12.0.0":
   version "12.0.0"


### PR DESCRIPTION
## What does this change?

This PR completes the work in https://github.com/guardian/dotcom-rendering/pull/7551 and https://github.com/guardian/frontend/pull/26070, where we switch from server side rendering the `exclusion` slot to rendering it client-side.

We add a new module `initExclusionSlot` which simply creates a new `exclusion` ad slot div and defines a corresponding Opt Out slot. This will get picked up when we make the request to the Opt Out server.

## Why?

From the code:
> This is a special type of ad which, when filled, blocks all other ads on the page. This allows us to run "exclusion campaigns" against certain breaking news pages.
>  
> Exclusion ads are used for consentless advertising only. GAM has a different mechanism to achieve the same thing.

By switching to rendering it client-side, we can avoid having to deal with the slot as an edge case when not running Opt Out (which is the majority of pageviews, especially at minute since it's behind a zero percent test).