### PR TITLE
Deploy via Riff Raff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,3 +116,41 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  riff-raff:
+    name: Upload Riff Raff Artifacts
+    needs: [build, test, lint, types]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: ./.github/actions/setup-node-env
+
+      - name: Fetch build
+        uses: actions/download-artifact@v4
+        with:
+          name: prod-bundle
+          path: dist/bundle/prod
+
+      - name: Riff-Raff Upload
+        uses: guardian/actions-riff-raff@v4
+        with:
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          projectName: dotcom::commercial-bundle
+          configPath: ./riff-raff.yaml
+          contentDirectories: |
+            frontend-static/test_commercial_bundles:
+              - dist/bundle/prod/js
+            commercial-bundle-path:
+              - dist/bundle/prod/cloudformation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
         run: pnpm build
 
       - name: Save build
-        if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: dist
@@ -139,8 +138,8 @@ jobs:
       - name: Fetch build
         uses: actions/download-artifact@v4
         with:
-          name: prod-bundle
-          path: dist/bundle/prod
+          name: dist
+          path: dist
 
       - name: Riff-Raff Upload
         uses: guardian/actions-riff-raff@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
           projectName: dotcom::commercial-bundle
           configPath: ./riff-raff.yaml
           contentDirectories: |
-            frontend-static/test_commercial_bundles:
-              - dist/bundle/prod/js
+            frontend-static/commercial:
+              - dist/riff-raff/js/commercial
             commercial-bundle-path:
-              - dist/bundle/prod/cloudformation
+              - dist/riff-raff/cloudformation

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ dist
 .changeset
 README.md
 CHANGELOG.md
+riff-raff.yaml
 .vscode/settings.json
 playwright-report/
 pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
 	"main": "dist/cjs/core/index.js",
 	"module": "dist/esm/core/index.js",
 	"scripts": {
-		"build": "npm-run-all clean --parallel compile:core:* build:prod build:dev",
+		"build": "npm-run-all clean --parallel compile:core:* build:prod build:dev build:riff-raff",
 		"build:dev": "webpack -c webpack.config.dev.mjs",
 		"build:prod": "webpack -c webpack.config.prod.mjs",
+		"build:riff-raff": "webpack -c webpack.config.riff-raff.mjs",
 		"clean": "rm -rf dist",
 		"compile:core:common": "tsc --project ./tsconfig.core.json --outDir ./dist/cjs --module CommonJS",
 		"compile:core:esm": "tsc --project ./tsconfig.core.json --outDir ./dist/esm",

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -4,7 +4,7 @@ allowedStages:
   - CODE
   - DEV
 deployments:
-  frontend-static/test_commercial_bundles:
+  frontend-static/commercial:
     type: aws-s3
     parameters:
       bucketSsmKey: /account/services/dotcom-static.bucket
@@ -18,4 +18,4 @@ deployments:
         CODE: code.json
         PROD: prod.json
     dependencies:
-      - frontend-static/test_commercial_bundles
+      - frontend-static/commercial

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,0 +1,21 @@
+regions: [eu-west-1]
+stacks: [frontend]
+allowedStages:
+  - CODE
+  - DEV
+deployments:
+  frontend-static/test_commercial_bundles:
+    type: aws-s3
+    parameters:
+      bucketSsmKey: /account/services/dotcom-static.bucket
+      cacheControl: public, max-age=315360000, immutable
+      prefixStack: false
+      publicReadAcl: false
+  commercial-bundle-path:
+    type: cloud-formation
+    parameters:
+      templateStagePaths:
+        CODE: code.json
+        PROD: prod.json
+    dependencies:
+      - frontend-static/test_commercial_bundles

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -2,7 +2,7 @@ regions: [eu-west-1]
 stacks: [frontend]
 allowedStages:
   - CODE
-  - DEV
+  - PROD
 deployments:
   frontend-static/commercial:
     type: aws-s3

--- a/src/commercial.ts
+++ b/src/commercial.ts
@@ -7,14 +7,14 @@ const decideAssetsPath = () => {
 	if (process.env.OVERRIDE_BUNDLE_PATH) {
 		return process.env.OVERRIDE_BUNDLE_PATH;
 	}
-	if (process.env.RIFFRAFF_DEPLOY) {
-		return page.assetsPath;
-	}
+
 	const assetsPath = frontendAssetsFullURL ?? page.assetsPath;
 	return `${assetsPath}javascripts/commercial/`;
 };
 
-__webpack_public_path__ = decideAssetsPath();
+if (!process.env.RIFFRAFF_DEPLOY) {
+	__webpack_public_path__ = decideAssetsPath();
+}
 
 /**
  * Choose whether to launch Googletag or Opt Out tag (ootag) based on consent state

--- a/src/commercial.ts
+++ b/src/commercial.ts
@@ -1,16 +1,17 @@
 import { getConsentFor, onConsent } from '@guardian/libs';
 import { commercialFeatures } from './lib/commercial-features';
 
-const { page } = window.guardian.config;
+const { frontendAssetsFullURL, page } = window.guardian.config;
 
 const decideAssetsPath = () => {
 	if (process.env.OVERRIDE_BUNDLE_PATH) {
 		return process.env.OVERRIDE_BUNDLE_PATH;
 	}
-	// TEMP
-	// Adjust the path we use to fetch dynamic imports to match the
-	// bucket key we use to deploy via Riff-Raff
-	return `${page.assetsPath}test_commercial_bundles/`;
+	if (process.env.RIFFRAFF_DEPLOY) {
+		return page.assetsPath;
+	}
+	const assetsPath = frontendAssetsFullURL ?? page.assetsPath;
+	return `${assetsPath}javascripts/commercial/`;
 };
 
 __webpack_public_path__ = decideAssetsPath();

--- a/src/commercial.ts
+++ b/src/commercial.ts
@@ -1,14 +1,16 @@
 import { getConsentFor, onConsent } from '@guardian/libs';
 import { commercialFeatures } from './lib/commercial-features';
 
-const { frontendAssetsFullURL, page } = window.guardian.config;
+const { page } = window.guardian.config;
 
 const decideAssetsPath = () => {
 	if (process.env.OVERRIDE_BUNDLE_PATH) {
 		return process.env.OVERRIDE_BUNDLE_PATH;
 	}
-	const assetsPath = frontendAssetsFullURL ?? page.assetsPath;
-	return `${assetsPath}javascripts/commercial/`;
+	// TEMP
+	// Adjust the path we use to fetch dynamic imports to match the
+	// bucket key we use to deploy via Riff-Raff
+	return `${page.assetsPath}test_commercial_bundles/`;
 };
 
 __webpack_public_path__ = decideAssetsPath();

--- a/webpack.config.prod.mjs
+++ b/webpack.config.prod.mjs
@@ -8,51 +8,6 @@ import config from './webpack.config.mjs';
 
 const { DefinePlugin } = webpack;
 
-class GenerateCloudformation {
-	apply = (compiler) => {
-		compiler.hooks.afterEmit.tap('AfterEmitPlugin', (compilation) => {
-			const entry = compilation.entrypoints.get('commercial-standalone');
-
-			const stages = ['code', 'prod'];
-			stages.forEach((stage) => {
-				const cloudformation = {
-					Resources: {
-						BundlePath: {
-							Type: 'AWS::SSM::Parameter',
-							Properties: {
-								Name: `/frontend${stage === 'code' ? '/code' : ''}/commercial.bundlePath`,
-								Type: 'String',
-								Value: entry?.getFiles()[0],
-							},
-						},
-					},
-				};
-
-				const output = JSON.stringify(cloudformation, null, 2);
-				const outputPath = join(
-					import.meta.dirname,
-					'dist',
-					'bundle',
-					'prod',
-					'cloudformation',
-					`${stage}.json`,
-				);
-				compiler.outputFileSystem.mkdirSync(
-					join(
-						import.meta.dirname,
-						'dist',
-						'bundle',
-						'prod',
-						'cloudformation',
-					),
-					{ recursive: true },
-				);
-				compiler.outputFileSystem.writeFileSync(outputPath, output);
-			});
-		});
-	};
-}
-
 const gitCommitSHA = () => {
 	try {
 		const commitSHA = execSync('git rev-parse HEAD').toString().trim();
@@ -70,7 +25,7 @@ export default merge(config, {
 	output: {
 		filename: `${prefix}graun.standalone.commercial.js`,
 		chunkFilename: `${prefix}graun.[name].commercial.js`,
-		path: join(import.meta.dirname, 'dist', 'bundle', 'prod', 'js'),
+		path: join(import.meta.dirname, 'dist', 'bundle', 'prod'),
 		clean: true,
 	},
 	devtool: 'source-map',
@@ -86,7 +41,6 @@ export default merge(config, {
 			'process.env.OVERRIDE_BUNDLE_PATH': JSON.stringify(false),
 			...gitCommitSHA(),
 		}),
-		new GenerateCloudformation(),
 	],
 	optimization: {
 		minimize: true,

--- a/webpack.config.riff-raff.mjs
+++ b/webpack.config.riff-raff.mjs
@@ -1,0 +1,110 @@
+import { execSync } from 'child_process';
+import { join } from 'path';
+import TerserPlugin from 'terser-webpack-plugin';
+import webpack from 'webpack';
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
+import { merge } from 'webpack-merge';
+import config from './webpack.config.mjs';
+
+const { DefinePlugin } = webpack;
+
+class GenerateCloudformation {
+	apply = (compiler) => {
+		compiler.hooks.afterEmit.tap('AfterEmitPlugin', (compilation) => {
+			const entry = compilation.entrypoints.get('commercial-standalone');
+
+			const hashedFilePath = entry?.getFiles()[0];
+
+			if (!hashedFilePath) {
+				throw new Error(
+					'Could not find hashed file for commercial-standalone',
+				);
+			}
+
+			const stages = ['code', 'prod'];
+			stages.forEach((stage) => {
+				/**
+				 * This small bit of cloudformation will update the SSM parameter that frontend
+				 * reads to get the bundle path.
+				 */
+				const cloudformation = {
+					Resources: {
+						BundlePath: {
+							Type: 'AWS::SSM::Parameter',
+							Properties: {
+								/**
+								 * DEV and PROD will use the same path, changing the DEV path is
+								 * overidden locally if needed
+								 */
+								Name: `/frontend${stage === 'code' ? '/code' : ''}/commercial.bundlePath`,
+								Type: 'String',
+								Value: hashedFilePath,
+							},
+						},
+					},
+				};
+
+				const output = JSON.stringify(cloudformation, null, 2);
+				const outputPath = join(
+					import.meta.dirname,
+					'dist',
+					'riff-raff',
+					'cloudformation',
+					`${stage}.json`,
+				);
+				compiler.outputFileSystem.mkdirSync(
+					join(
+						import.meta.dirname,
+						'dist',
+						'riff-raff',
+						'cloudformation',
+					),
+					{ recursive: true },
+				);
+				compiler.outputFileSystem.writeFileSync(outputPath, output);
+			});
+		});
+	};
+}
+
+const gitCommitSHA = () => {
+	try {
+		const commitSHA = execSync('git rev-parse HEAD').toString().trim();
+		return { 'process.env.COMMIT_SHA': JSON.stringify(commitSHA) };
+	} catch (_) {
+		return {};
+	}
+};
+
+const prefix = process.env.BUNDLE_PREFIX ?? '[chunkhash]/';
+
+// eslint-disable-next-line import/no-default-export -- webpack config
+export default merge(config, {
+	mode: 'production',
+	output: {
+		filename: `commercial/${prefix}graun.standalone.commercial.js`,
+		chunkFilename: `commercial/${prefix}graun.[name].commercial.js`,
+		path: join(import.meta.dirname, 'dist', 'riff-raff', 'js'),
+		clean: true,
+	},
+	devtool: 'source-map',
+	plugins: [
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call -- circular-dependency-plugin is not typed
+		new BundleAnalyzerPlugin({
+			reportFilename: './commercial-bundle-analyzer-report.html',
+			analyzerMode: 'static',
+			openAnalyzer: false,
+		}),
+		new DefinePlugin({
+			'process.env.NODE_ENV': JSON.stringify('production'),
+			'process.env.OVERRIDE_BUNDLE_PATH': JSON.stringify(false),
+			'process.env.RIFFRAFF_DEPLOY': JSON.stringify(true),
+			...gitCommitSHA(),
+		}),
+		new GenerateCloudformation(),
+	],
+	optimization: {
+		minimize: true,
+		minimizer: [new TerserPlugin()],
+	},
+});

--- a/webpack.config.riff-raff.mjs
+++ b/webpack.config.riff-raff.mjs
@@ -85,6 +85,7 @@ export default merge(config, {
 		filename: `commercial/${prefix}graun.standalone.commercial.js`,
 		chunkFilename: `commercial/${prefix}graun.[name].commercial.js`,
 		path: join(import.meta.dirname, 'dist', 'riff-raff', 'js'),
+		publicPath: 'auto',
 		clean: true,
 	},
 	devtool: 'source-map',

--- a/webpack.config.riff-raff.mjs
+++ b/webpack.config.riff-raff.mjs
@@ -32,17 +32,25 @@ class GenerateCloudformation {
 						BundlePath: {
 							Type: 'AWS::SSM::Parameter',
 							Properties: {
-								/**
-								 * DEV and PROD will use the same path, changing the DEV path is
-								 * overidden locally if needed
-								 */
-								Name: `/frontend${stage === 'code' ? '/code' : ''}/commercial.bundlePath`,
+								Name: `/frontend/${stage}/commercial.bundlePath`,
 								Type: 'String',
 								Value: hashedFilePath,
 							},
 						},
 					},
 				};
+
+				// If we're in prod, we also want to update the dev bundle path
+				if (stage === 'prod') {
+					cloudformation.Resources.DevBundlePath = {
+						Type: 'AWS::SSM::Parameter',
+						Properties: {
+							Name: '/frontend/dev/commercial.bundlePath',
+							Type: 'String',
+							Value: hashedFilePath,
+						},
+					};
+				}
 
 				const output = JSON.stringify(cloudformation, null, 2);
 				const outputPath = join(


### PR DESCRIPTION
## What does this change?
Add riff-raff to upload commercial bundle to the frontend static s3 bucket and cloudformation to update a key with the location of the commercial bundle for each stage.

This PR adds a new webpack config to build a variant of the commercial bundle suitable for deploying in this way (simply a change to the webpack public path config), the new webpack config also creates the cloudformation to update the parameter store key with the hashed path of the bundle.

It also introduces a riff-raff.yml and github action to upload the assets and cloudformation.

## Why?
Deploying commercial at the moment is a very arduous process with poor developer experience, it requires adding a changeset, releasing a version, waiting 3 times for checks to run in the commercial repo (feature PR, version bump PR and on main). Then bumping the version in frontend rebuilding and redeploying the entirety of it just to change a script on the page.