### PR TITLE
feat: Add new `allkw` targeting key

### DIFF
--- a/core/src/targeting/build-page-targeting.spec.ts
+++ b/core/src/targeting/build-page-targeting.spec.ts
@@ -196,6 +196,12 @@ describe('Build Page Targeting', () => {
 		expect(pageTargeting.cc).toEqual('US');
 		expect(pageTargeting.rp).toEqual('dotcom-platform');
 		expect(pageTargeting.rc).toEqual('7');
+		expect(pageTargeting.allkw).toEqual([
+			'footballweekly',
+			'prince-charles-letters',
+			'uk/uk',
+			'prince-charles',
+		]);
 	});
 
 	it('should set correct personalized ad (pa) param', () => {
@@ -426,6 +432,7 @@ describe('Build Page Targeting', () => {
 			si: 't',
 			skinsize: 's',
 			urlkw: ['footballweekly'],
+			allkw: ['footballweekly'],
 		});
 	});
 

--- a/core/src/targeting/build-page-targeting.ts
+++ b/core/src/targeting/build-page-targeting.ts
@@ -70,10 +70,6 @@ const filterValues = (pageTargets: Record<string, unknown>) => {
 	return filtered;
 };
 
-const concatUnique = (a: string[], b: string[]): string[] => [
-	...new Set([...a, ...b]),
-];
-
 type BuildPageTargetingParams = {
 	adFree: boolean;
 	clientSideParticipations: Participations;
@@ -91,6 +87,10 @@ const buildPageTargeting = ({
 
 	const adFreeTargeting: { af?: True } = adFree ? { af: 't' } : {};
 
+	const sharedAdTargeting = page.sharedAdTargeting
+		? getSharedTargeting(page.sharedAdTargeting)
+		: {};
+
 	const contentTargeting: ContentTargeting = getContentTargeting({
 		webPublicationDate: page.webPublicationDate,
 		eligibleForDCR: page.dcrCouldRender,
@@ -101,6 +101,7 @@ const buildPageTargeting = ({
 		section: page.section,
 		sensitive: page.isSensitive,
 		videoLength: page.videoDuration,
+		keywords: sharedAdTargeting.k ?? [],
 	});
 
 	const getReferrer = () => document.referrer || '';
@@ -132,18 +133,10 @@ const buildPageTargeting = ({
 			!cmp.hasInitialised() || cmp.willShowPrivacyMessageSync(),
 	});
 
-	const sharedAdTargeting = page.sharedAdTargeting
-		? getSharedTargeting(page.sharedAdTargeting)
-		: {};
-
 	const personalisedTargeting = getPersonalisedTargeting({
 		state: consentState,
 		youtube,
 	});
-
-	const otherTargeting = {
-		allkw: concatUnique(contentTargeting.urlkw, sharedAdTargeting.k ?? []),
-	};
 
 	const pageTargets: PageTargeting = {
 		...personalisedTargeting,
@@ -152,7 +145,6 @@ const buildPageTargeting = ({
 		...contentTargeting,
 		...sessionTargeting,
 		...viewportTargeting,
-		...otherTargeting,
 	};
 
 	// filter !(string | string[]) and empty values

--- a/core/src/targeting/build-page-targeting.ts
+++ b/core/src/targeting/build-page-targeting.ts
@@ -46,6 +46,7 @@ type PageTargeting = PartialWithNulls<
 		skinsize: 'l' | 's';
 		urlkw: string[]; // URL KeyWords
 		vl: string; // Video Length
+		allkw: string[]; // Concatenated urlkw and k so they can be used in the same targeting key reducing the number of keys
 
 		// And more
 		[_: string]: string | string[];
@@ -68,6 +69,10 @@ const filterValues = (pageTargets: Record<string, unknown>) => {
 	}
 	return filtered;
 };
+
+const concatUnique = (a: string[], b: string[]): string[] => [
+	...new Set([...a, ...b]),
+];
 
 type BuildPageTargetingParams = {
 	adFree: boolean;
@@ -136,6 +141,10 @@ const buildPageTargeting = ({
 		youtube,
 	});
 
+	const otherTargeting = {
+		allkw: concatUnique(contentTargeting.urlkw, sharedAdTargeting.k ?? []),
+	};
+
 	const pageTargets: PageTargeting = {
 		...personalisedTargeting,
 		...sharedAdTargeting,
@@ -143,6 +152,7 @@ const buildPageTargeting = ({
 		...contentTargeting,
 		...sessionTargeting,
 		...viewportTargeting,
+		...otherTargeting,
 	};
 
 	// filter !(string | string[]) and empty values

--- a/core/src/targeting/content.spec.ts
+++ b/core/src/targeting/content.spec.ts
@@ -9,6 +9,7 @@ const defaultValues: Parameters<typeof getContentTargeting>[0] = {
 	section: 'uk-news',
 	eligibleForDCR: false,
 	webPublicationDate: 608857200,
+	keywords: ['keyword'],
 };
 
 describe('Content Targeting', () => {

--- a/core/src/targeting/content.ts
+++ b/core/src/targeting/content.ts
@@ -86,6 +86,8 @@ type ContentTargeting = {
 	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=195087
 	 */
 	vl: null | (typeof videoLengths)[number];
+
+	allkw: string[];
 };
 
 /* -- Methods -- */
@@ -103,6 +105,10 @@ const getUrlKeywords = (url: SharedTargeting['url']): string[] => {
 
 	return isString(lastSegment) ? lastSegment.split('-').filter(Boolean) : [];
 };
+
+const concatUnique = (a: string[], b: string[]): string[] => [
+	...new Set([...a, ...b]),
+];
 
 // "0" means content < 2 hours old
 // "1" means content between 2 hours and 24 hours old.
@@ -140,6 +146,7 @@ type Content = {
 	sensitive: boolean;
 	videoLength?: number;
 	webPublicationDate: number;
+	keywords: string[];
 };
 
 const getContentTargeting = ({
@@ -150,15 +157,18 @@ const getContentTargeting = ({
 	sensitive,
 	videoLength,
 	webPublicationDate,
+	keywords,
 }: Content): ContentTargeting => {
+	const urlkw = getUrlKeywords(path);
 	return {
 		dcre: eligibleForDCR ? 't' : 'f',
 		rc: calculateRecentlyPublishedBucket(webPublicationDate),
 		rp: renderingPlatform,
 		s: section,
 		sens: sensitive ? 't' : 'f',
-		urlkw: getUrlKeywords(path),
+		urlkw,
 		vl: videoLength ? getVideoLength(videoLength) : null,
+		allkw: concatUnique(urlkw, keywords),
 	};
 };
 

--- a/core/src/targeting/content.ts
+++ b/core/src/targeting/content.ts
@@ -87,6 +87,13 @@ type ContentTargeting = {
 	 */
 	vl: null | (typeof videoLengths)[number];
 
+	/**
+	 * **All** **K**ey**w**ords - [see on Ad Manager][gam]
+	 * This is a list of all keywords on the page, including the section and the URL keywords
+	 * Type: _Dynamic_
+	 *
+	 * [gam]: https://admanager.google.com/59666047#inventory/custom_targeting/detail/custom_key_id=13995840
+	 */
 	allkw: string[];
 };
 


### PR DESCRIPTION
## What does this change?
Add a targeting key `allkw` that is the unique values from both `urlkw` and `k`

## Why?
Excerpt from the ticket:

> The reason for a new key-value is that there still remains a number of use cases for just using urlkw and just k. However, the new key-value will populate when either are present - which helps resolve issues (e.g. from Google, where they want to block 100s of distinct keywords regardless of it it's in the URL or editorial keywords).