### PR TITLE
feat: YouTube targeting updates

### DIFF
--- a/core/src/targeting/youtube-ima.spec.ts
+++ b/core/src/targeting/youtube-ima.spec.ts
@@ -28,7 +28,7 @@ describe('Builds an IMA ad tag URL', () => {
 			clientSideParticipations: {},
 		});
 		expect(adTagURL).toEqual(
-			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=yt_embed_ima%3D1%26at%3DadTestValue',
+			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=at%3DadTestValue',
 		);
 	});
 	it('encodes custom parameters', () => {
@@ -52,7 +52,7 @@ describe('Builds an IMA ad tag URL', () => {
 		expect(adTagURL).toEqual(
 			// this is a real ad tag url that you can paste into Google's VAST tag checker:
 			// https://googleads.github.io/googleads-ima-html5/vsi/
-			'https://pubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=yt_embed_ima%3D1%26param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%252Chello4%26param6%3D%253D%2526%252C%26at%3Dfixed-puppies%26encodeMe%3D%253D%2526%252C',
+			'https://pubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%252Chello4%26param6%3D%253D%2526%252C%26at%3Dfixed-puppies%26encodeMe%3D%253D%2526%252C',
 		);
 	});
 	it('uses provided custom parameters if page targeting throws an exception', () => {

--- a/core/src/targeting/youtube-ima.spec.ts
+++ b/core/src/targeting/youtube-ima.spec.ts
@@ -28,7 +28,7 @@ describe('Builds an IMA ad tag URL', () => {
 			clientSideParticipations: {},
 		});
 		expect(adTagURL).toEqual(
-			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=at%3DadTestValue',
+			'https://pubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=yt_embed_ima%3D1%26at%3DadTestValue',
 		);
 	});
 	it('encodes custom parameters', () => {
@@ -52,7 +52,7 @@ describe('Builds an IMA ad tag URL', () => {
 		expect(adTagURL).toEqual(
 			// this is a real ad tag url that you can paste into Google's VAST tag checker:
 			// https://googleads.github.io/googleads-ima-html5/vsi/
-			'https://pubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%252Chello4%26param6%3D%253D%2526%252C%26at%3Dfixed-puppies%26encodeMe%3D%253D%2526%252C',
+			'https://pubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=yt_embed_ima%3D1%26param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%252Chello4%26param6%3D%253D%2526%252C%26at%3Dfixed-puppies%26encodeMe%3D%253D%2526%252C',
 		);
 	});
 	it('uses provided custom parameters if page targeting throws an exception', () => {

--- a/core/src/targeting/youtube-ima.ts
+++ b/core/src/targeting/youtube-ima.ts
@@ -43,10 +43,7 @@ const mergeCustomParamsWithTargeting = (
 		log('commercial', 'Error building YouTube IMA custom params', e);
 		return customParams;
 	}
-	// TODO: 19/04/2023 This is a temporary update to assist reporting for a YouTube IMA test
-	const tempParams = { yt_embed_ima: '1' };
 	const mergedCustomParams = {
-		...tempParams,
 		...customParams,
 		...pageTargeting,
 	};

--- a/core/src/targeting/youtube-ima.ts
+++ b/core/src/targeting/youtube-ima.ts
@@ -43,7 +43,13 @@ const mergeCustomParamsWithTargeting = (
 		log('commercial', 'Error building YouTube IMA custom params', e);
 		return customParams;
 	}
-	const mergedCustomParams = { ...customParams, ...pageTargeting };
+	// TODO: 19/04/2023 This is a temporary update to assist reporting for a YouTube IMA test
+	const tempParams = { yt_embed_ima: '1' };
+	const mergedCustomParams = {
+		...tempParams,
+		...customParams,
+		...pageTargeting,
+	};
 	return mergedCustomParams;
 };
 

--- a/core/src/targeting/youtube.spec.ts
+++ b/core/src/targeting/youtube.spec.ts
@@ -30,7 +30,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 				adTagParameters: {
 					iu: 'someAdUnit',
 					cust_params: encodeURIComponent(
-						'yt_embed_ima=0&param1=param1&param2=param2&permutive=1,2,3&si=t',
+						'param1=param1&param2=param2&permutive=1,2,3&si=t&yt_embed_ima=0',
 					),
 				},
 				restrictedDataProcessor: false,
@@ -56,7 +56,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 				adTagParameters: {
 					iu: 'someAdUnit',
 					cust_params: encodeURIComponent(
-						'yt_embed_ima=0&param1=param1&param2=param2&permutive=1,2,3&si=t',
+						'param1=param1&param2=param2&permutive=1,2,3&si=t&yt_embed_ima=0',
 					),
 				},
 				restrictedDataProcessor: true,
@@ -82,7 +82,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 				adTagParameters: {
 					iu: 'someAdUnit',
 					cust_params: encodeURIComponent(
-						'yt_embed_ima=0&param1=param1&param2=param2&permutive=1,2,3&si=f',
+						'param1=param1&param2=param2&permutive=1,2,3&si=f&yt_embed_ima=0',
 					),
 				},
 				restrictedDataProcessor: false,
@@ -108,7 +108,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 				adTagParameters: {
 					iu: 'someAdUnit',
 					cust_params: encodeURIComponent(
-						'yt_embed_ima=0&param1=param1&param2=param2&permutive=1,2,3&si=t',
+						'param1=param1&param2=param2&permutive=1,2,3&si=t&yt_embed_ima=0',
 					),
 				},
 				restrictedDataProcessor: false,
@@ -134,7 +134,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 				adTagParameters: {
 					iu: 'someAdUnit',
 					cust_params: encodeURIComponent(
-						'yt_embed_ima=0&param1=param1&param2=param2&permutive=1,2,3&si=t',
+						'param1=param1&param2=param2&permutive=1,2,3&si=t&yt_embed_ima=0',
 					),
 				},
 				restrictedDataProcessor: true,
@@ -166,7 +166,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 					cmpVcd: 'someTcString',
 					cmpGvcd: 'someAddtlConsent',
 					cust_params: encodeURIComponent(
-						'yt_embed_ima=0&param1=param1&param2=param2&permutive=1,2,3&si=t',
+						'param1=param1&param2=param2&permutive=1,2,3&si=t&yt_embed_ima=0',
 					),
 				},
 				nonPersonalizedAd: false,
@@ -198,7 +198,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 					cmpVcd: 'someTcString',
 					cmpGvcd: 'someAddtlConsent',
 					cust_params: encodeURIComponent(
-						'yt_embed_ima=0&param1=param1&param2=param2&permutive=1,2,3&si=t',
+						'param1=param1&param2=param2&permutive=1,2,3&si=t&yt_embed_ima=0',
 					),
 				},
 				nonPersonalizedAd: true,
@@ -230,7 +230,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 					cmpVcd: 'someTcString',
 					cmpGvcd: 'someAddtlConsent',
 					cust_params: encodeURIComponent(
-						'yt_embed_ima=0&param1=param1&param2=param2&permutive=1,2,3&si=t',
+						'param1=param1&param2=param2&permutive=1,2,3&si=t&yt_embed_ima=0',
 					),
 				},
 				nonPersonalizedAd: false,

--- a/core/src/targeting/youtube.spec.ts
+++ b/core/src/targeting/youtube.spec.ts
@@ -30,7 +30,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 				adTagParameters: {
 					iu: 'someAdUnit',
 					cust_params: encodeURIComponent(
-						'param1=param1&param2=param2&permutive=1,2,3&si=t',
+						'yt_embed_ima=0&param1=param1&param2=param2&permutive=1,2,3&si=t',
 					),
 				},
 				restrictedDataProcessor: false,
@@ -56,7 +56,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 				adTagParameters: {
 					iu: 'someAdUnit',
 					cust_params: encodeURIComponent(
-						'param1=param1&param2=param2&permutive=1,2,3&si=t',
+						'yt_embed_ima=0&param1=param1&param2=param2&permutive=1,2,3&si=t',
 					),
 				},
 				restrictedDataProcessor: true,
@@ -82,7 +82,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 				adTagParameters: {
 					iu: 'someAdUnit',
 					cust_params: encodeURIComponent(
-						'param1=param1&param2=param2&permutive=1,2,3&si=f',
+						'yt_embed_ima=0&param1=param1&param2=param2&permutive=1,2,3&si=f',
 					),
 				},
 				restrictedDataProcessor: false,
@@ -108,7 +108,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 				adTagParameters: {
 					iu: 'someAdUnit',
 					cust_params: encodeURIComponent(
-						'param1=param1&param2=param2&permutive=1,2,3&si=t',
+						'yt_embed_ima=0&param1=param1&param2=param2&permutive=1,2,3&si=t',
 					),
 				},
 				restrictedDataProcessor: false,
@@ -134,7 +134,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 				adTagParameters: {
 					iu: 'someAdUnit',
 					cust_params: encodeURIComponent(
-						'param1=param1&param2=param2&permutive=1,2,3&si=t',
+						'yt_embed_ima=0&param1=param1&param2=param2&permutive=1,2,3&si=t',
 					),
 				},
 				restrictedDataProcessor: true,
@@ -166,7 +166,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 					cmpVcd: 'someTcString',
 					cmpGvcd: 'someAddtlConsent',
 					cust_params: encodeURIComponent(
-						'param1=param1&param2=param2&permutive=1,2,3&si=t',
+						'yt_embed_ima=0&param1=param1&param2=param2&permutive=1,2,3&si=t',
 					),
 				},
 				nonPersonalizedAd: false,
@@ -198,7 +198,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 					cmpVcd: 'someTcString',
 					cmpGvcd: 'someAddtlConsent',
 					cust_params: encodeURIComponent(
-						'param1=param1&param2=param2&permutive=1,2,3&si=t',
+						'yt_embed_ima=0&param1=param1&param2=param2&permutive=1,2,3&si=t',
 					),
 				},
 				nonPersonalizedAd: true,
@@ -230,7 +230,7 @@ describe('YouTube Ad Targeting Object for consent frameworks', () => {
 					cmpVcd: 'someTcString',
 					cmpGvcd: 'someAddtlConsent',
 					cust_params: encodeURIComponent(
-						'param1=param1&param2=param2&permutive=1,2,3&si=t',
+						'yt_embed_ima=0&param1=param1&param2=param2&permutive=1,2,3&si=t',
 					),
 				},
 				nonPersonalizedAd: false,

--- a/core/src/targeting/youtube.ts
+++ b/core/src/targeting/youtube.ts
@@ -19,10 +19,8 @@ const buildAdsConfig = (
 	customParams: CustomParams,
 	clientSideParticipations: Participations,
 ): AdsConfig => {
-	// TODO: 19/04/2023 This is a temporary fix to help reporting for a YouTube IMA test
-	const tempParams = {
-		yt_embed_ima: '0',
-	};
+	// TODO: 19/04/2023 This is a temporary update to assist reporting for a YouTube IMA test
+	const tempParams = { yt_embed_ima: '0' };
 	const mergedCustomParams = {
 		...tempParams,
 		...customParams,

--- a/core/src/targeting/youtube.ts
+++ b/core/src/targeting/youtube.ts
@@ -19,7 +19,12 @@ const buildAdsConfig = (
 	customParams: CustomParams,
 	clientSideParticipations: Participations,
 ): AdsConfig => {
+	// TODO: 19/04/2023 This is a temporary fix to help reporting for a YouTube IMA test
+	const tempParams = {
+		yt_embed_ima: '0',
+	};
 	const mergedCustomParams = {
+		...tempParams,
 		...customParams,
 		...buildPageTargeting({
 			adFree: false,

--- a/core/src/targeting/youtube.ts
+++ b/core/src/targeting/youtube.ts
@@ -19,10 +19,7 @@ const buildAdsConfig = (
 	customParams: CustomParams,
 	clientSideParticipations: Participations,
 ): AdsConfig => {
-	// TODO: 19/04/2023 This is a temporary update to assist reporting for a YouTube IMA test
-	const tempParams = { yt_embed_ima: '0' };
 	const mergedCustomParams = {
-		...tempParams,
 		...customParams,
 		...buildPageTargeting({
 			adFree: false,
@@ -30,6 +27,8 @@ const buildAdsConfig = (
 			consentState: cmpConsent,
 			youtube: true,
 		}),
+		// 19/04/2023 This is a temporary update to assist reporting for a YouTube IMA test
+		yt_embed_ima: '0',
 	};
 
 	const defaultAdsConfig: AdsConfigBasic = {


### PR DESCRIPTION
## What does this change?

YouTube targeting updates to assist reporting for a YouTube IMA test

When the user is not part of the IMA integration test (i.e. regular YouTube targeting) then we add a `yt_embed_ima=0` to the ad targeting so it is easier for Google to distinguish between the two ad requests.


