### PR TITLE
fix: Allow Teads on liveblog server-side inserted inline ads

### DIFF
--- a/bundle/src/projects/commercial/modules/dfp/fill-advert-slots.ts
+++ b/bundle/src/projects/commercial/modules/dfp/fill-advert-slots.ts
@@ -19,6 +19,7 @@ import { queueAdvert } from './queue-advert';
 const decideAdditionalSizes = (adSlot: HTMLElement): SizeMapping => {
 	const { contentType } = window.guardian.config.page;
 	const { name } = adSlot.dataset;
+
 	if (contentType === 'Gallery' && name?.includes('inline')) {
 		return {
 			desktop: [adSizes.billboard, createAdSize(900, 250)],
@@ -29,6 +30,11 @@ const decideAdditionalSizes = (adSlot: HTMLElement): SizeMapping => {
 	) {
 		return {
 			desktop: [adSizes.billboard],
+		};
+	} else if (contentType === 'LiveBlog' && name?.includes('inline')) {
+		return {
+			phablet: [adSizes.outstreamDesktop, adSizes.outstreamGoogleDesktop],
+			desktop: [adSizes.outstreamDesktop, adSizes.outstreamGoogleDesktop],
 		};
 	} else {
 		return {};
@@ -81,6 +87,7 @@ const fillAdvertSlots = async (): Promise<void> => {
 		)
 		.map((adSlot) => {
 			const additionalSizes = decideAdditionalSizes(adSlot);
+
 			return createAdvert(adSlot, additionalSizes);
 		})
 		.filter((advert): advert is Advert => advert !== null);


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Adds the Outstream ad sizes to server-side inserted inline ads.

## Why?

So that we can show Outstream ads (Teads) on liveblog pages when the advert slots are inserted server-side.
