### PR TITLE
ci: Remove coveralls from ci-core action

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -29,14 +29,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Run unit tests
-        run: yarn test --coverage --ci
-
-      - name: Report coverage
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          base-path: ./core
-          path-to-lcov: ./core/coverage/lcov.info
+        run: yarn test --ci
 
   lint:
     name: Lint

--- a/core/README.md
+++ b/core/README.md
@@ -3,7 +3,6 @@
 [![npm (scoped)](https://img.shields.io/npm/v/@guardian/commercial-core)](https://www.npmjs.com/package/@guardian/commercial-core)
 [![ES version](https://badgen.net/badge/ES/2020/cyan)](https://tc39.es/ecma262/2020/)
 [![npm type definitions](https://img.shields.io/npm/types/@guardian/commercial-core)](https://www.typescriptlang.org/)
-[![Coverage Status](https://coveralls.io/repos/github/guardian/commercial-core/badge.svg?branch=main)](https://coveralls.io/github/guardian/commercial-core?branch=main)
 
 > Guardian advertising business logic
 


### PR DESCRIPTION
## What does this change?

Remove coveralls from ci-core action

## Why?

Coveralls is not currently bringing us value. The CI check in GitHub often hangs with the message "Expected — Waiting for status to be reported". We have disabled the check on GitHub PRs. This change deletes the action from the CI workflow.