### PR TITLE
chore: bump @percy/cli to 1.24.0

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -13,7 +13,7 @@
 		"@babel/core": "^7.0.1",
 		"@babel/preset-env": "^7.0.0",
 		"@cypress/webpack-preprocessor": "^5.16.1",
-		"@percy/cli": "^1.20.1",
+		"@percy/cli": "^1.24.0",
 		"@percy/cypress": "^3.1.2",
 		"babel-loader": "^9",
 		"cypress": "^12.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1951,105 +1951,105 @@
   dependencies:
     "@octokit/openapi-types" "^16.0.0"
 
-"@percy/cli-app@1.20.3":
-  version "1.20.3"
-  resolved "https://registry.yarnpkg.com/@percy/cli-app/-/cli-app-1.20.3.tgz#d9d2327c9fa2f0d659d4d24452292ea7601a705b"
-  integrity sha512-j3GExC86a0joAMhGDlWfAByQNI8W3lYNLEf9fUFUj9zxf0WveAL7bHHfNUDOj9zv+p6Nd4iSXtk4O92j2aRvGw==
+"@percy/cli-app@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-app/-/cli-app-1.24.0.tgz#1d5bfb392a40e496dd1ba98b3b4f6e66388e9fd7"
+  integrity sha512-z7ksv+SvdgDuAZ4WDnluuLuS72xb18DKauuwikSKipdICHHFQuXdRc0ngloADC/6IFzp0JhiukiRanntbBkPvg==
   dependencies:
-    "@percy/cli-command" "1.20.3"
-    "@percy/cli-exec" "1.20.3"
+    "@percy/cli-command" "1.24.0"
+    "@percy/cli-exec" "1.24.0"
 
-"@percy/cli-build@1.20.3":
-  version "1.20.3"
-  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.20.3.tgz#11f70dda905316e9af90d85f6472cd7c3e11b585"
-  integrity sha512-htccNTvztwyUMZZaShadJ9c3WqbI9tiFNdwZOaEuzxr6ndp6m2nNH0WNe6Qxd4DlgNQveCY3jnWti9vMsQxwCg==
+"@percy/cli-build@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.24.0.tgz#409b9ef214fa94edba4b702954fbeb87c1819b9f"
+  integrity sha512-p/wmO0OzqJ2Uou7QNAdxioqKmxu7U+6Al02GvVhYcPja/MkVjfJT/jDl+XstXawR76txQW9QWrNsK5YOAWUupQ==
   dependencies:
-    "@percy/cli-command" "1.20.3"
+    "@percy/cli-command" "1.24.0"
 
-"@percy/cli-command@1.20.3":
-  version "1.20.3"
-  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.20.3.tgz#0a5cb5a782e8a0525bbf4c34380047c9d1600354"
-  integrity sha512-kqf7oAy9DTqMNSUCHdpuF18f1HUjrQrvBH7sshseQ/1QAALQZZj/T5f9MqGaiPxE/nwQxiL3c3XGwaqMA0HVtw==
+"@percy/cli-command@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.24.0.tgz#36b51e1e41c10db8ceb3f9bbd624e8199a16cee7"
+  integrity sha512-n4qyDdUc+TiX/YykGg59IS1DBmm4UdA7ZaiTdw/D5AZohzwwVbwL+Q4QMYqcohtfYZ/F8UT7Qy3Jma3+YKTnxw==
   dependencies:
-    "@percy/config" "1.20.3"
-    "@percy/core" "1.20.3"
-    "@percy/logger" "1.20.3"
+    "@percy/config" "1.24.0"
+    "@percy/core" "1.24.0"
+    "@percy/logger" "1.24.0"
 
-"@percy/cli-config@1.20.3":
-  version "1.20.3"
-  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.20.3.tgz#fef3d144506dd0ebbac46a6d3610b921aa1cbf21"
-  integrity sha512-k3pegN1ZY9vQFRezrqKfiBMkLNnLRnStPc0LsqCbyEKb46EmQXsIkqGX5I0GU0YxLf9sZl7vPch3Qrt9qkT1Ww==
+"@percy/cli-config@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.24.0.tgz#5a62eb9cb1d2e772481dffa6efcd75a0e6604c0f"
+  integrity sha512-7T70Y3vC0hIGBe+WOmdzspN8N5uflBRwuPoRXn2PdzxvH55hUhCGFT/Wxb8C6rTMJ9k++POkxMoQaSErVANYYg==
   dependencies:
-    "@percy/cli-command" "1.20.3"
+    "@percy/cli-command" "1.24.0"
 
-"@percy/cli-exec@1.20.3":
-  version "1.20.3"
-  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.20.3.tgz#3d8b640b75b5a11554ead77a4f6420d187d0ebc5"
-  integrity sha512-AtQeJffpZgbWSGlR/gPCvFOnVn8IGZrDaX+AJ/BYsBaqBBWk6vMekO6/BMFPooWvg00gNIl1JNWXhwQo2ONm/Q==
+"@percy/cli-exec@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.24.0.tgz#02f8c6a417ef13303c7ab692a080480c9cb7d9ce"
+  integrity sha512-T5B8HLjPde0js5lkO14uk02QZKmgxILjALh5SX9VFL2Qx4cUXw+A29epPPv6OLI2x2oww8e5nTdlnmykX8n4kQ==
   dependencies:
-    "@percy/cli-command" "1.20.3"
+    "@percy/cli-command" "1.24.0"
     cross-spawn "^7.0.3"
     which "^2.0.2"
 
-"@percy/cli-snapshot@1.20.3":
-  version "1.20.3"
-  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.20.3.tgz#1556288eff281c22e80401b7d144658ca3e28e8c"
-  integrity sha512-OywFkxomp3IpAFy94nixgFkby9pYdNhSod0eMHevSk5yg6bMY8NoH+Ow4/eQeJJWy3koyQ2JE5KVFxn2yQNQaw==
+"@percy/cli-snapshot@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.24.0.tgz#6516710bc095158bcb20ece4ba4861214d4cc428"
+  integrity sha512-zxoE1SbdTvUlP7QAjTs7+M7U8cHEDF1ec7ov06m1i+bul68YhZ0S+P4a1Mbt6oWBsAxjYz06h4jnq32JitbSDg==
   dependencies:
-    "@percy/cli-command" "1.20.3"
+    "@percy/cli-command" "1.24.0"
     yaml "^2.0.0"
 
-"@percy/cli-upload@1.20.3":
-  version "1.20.3"
-  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.20.3.tgz#4059dc8308e8e78b2473455bd0d92e8d1b7a43f6"
-  integrity sha512-Ex3cmonRuKeZRsoUSgYq+1Sxt1P8otQCr6b0C08iHewjZ09NTMbgHBQY8AyxyzABlg+YkkuFw0f9o4jxr0HGHg==
+"@percy/cli-upload@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.24.0.tgz#a6761d93d66668fd3182ee3c22efbebba5e74751"
+  integrity sha512-/4XNzMAhbccYSsPhw/KWRVjnd13nd17LB178dVNX4UEtaETDbBF+VZSlU3scgs8mlpuqY8b8bHDaSJNfI71UwQ==
   dependencies:
-    "@percy/cli-command" "1.20.3"
+    "@percy/cli-command" "1.24.0"
     fast-glob "^3.2.11"
     image-size "^1.0.0"
 
-"@percy/cli@^1.20.1":
-  version "1.20.3"
-  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.20.3.tgz#66c3381f9d77f1d907026caa1fbb77fabec9cc42"
-  integrity sha512-tH3MmMnnPU2dZWZ1J6N++ZJr2QOs2voUeg2p+SyqRNkry7wZRNQyFIO8awIbq+CErq5XkzeeIQ9WntvWACP9Kg==
+"@percy/cli@^1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.24.0.tgz#260555b8990404ed63e08b0d3db4a7f6e49bfb1d"
+  integrity sha512-n8dxQfA2GoPk468EQ+sO7P/P5sBl3Q+s7UrljQhf4wPt4l+CBmoxMML8Ib71MyISzwxY7bOSw2QMr26r6n06/A==
   dependencies:
-    "@percy/cli-app" "1.20.3"
-    "@percy/cli-build" "1.20.3"
-    "@percy/cli-command" "1.20.3"
-    "@percy/cli-config" "1.20.3"
-    "@percy/cli-exec" "1.20.3"
-    "@percy/cli-snapshot" "1.20.3"
-    "@percy/cli-upload" "1.20.3"
-    "@percy/client" "1.20.3"
-    "@percy/logger" "1.20.3"
+    "@percy/cli-app" "1.24.0"
+    "@percy/cli-build" "1.24.0"
+    "@percy/cli-command" "1.24.0"
+    "@percy/cli-config" "1.24.0"
+    "@percy/cli-exec" "1.24.0"
+    "@percy/cli-snapshot" "1.24.0"
+    "@percy/cli-upload" "1.24.0"
+    "@percy/client" "1.24.0"
+    "@percy/logger" "1.24.0"
 
-"@percy/client@1.20.3":
-  version "1.20.3"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.20.3.tgz#9eaf6c513b410d339f71c98f99fc66519f290a4c"
-  integrity sha512-tVrJdPLqT6/S+vBhfaBiwASmoaTZHLtB9Awqq6BM8BfSsyP1fwptLvhBRe7oNGdxJwvTuPtxXtSxJ1xakp1Khg==
+"@percy/client@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.24.0.tgz#b72696269f0925a06571bfa4e75ee8d632c63da2"
+  integrity sha512-mCMIGryE+0oxJN6v+riZ+XqnubEL9rajLOJI7xNOj5gNBNNvwgvkpTiNId9d6LNZVhA7dN9ZHTW+zFK+i4nU8A==
   dependencies:
-    "@percy/env" "1.20.3"
-    "@percy/logger" "1.20.3"
+    "@percy/env" "1.24.0"
+    "@percy/logger" "1.24.0"
 
-"@percy/config@1.20.3":
-  version "1.20.3"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.20.3.tgz#641431e10be415968352a46c53d6a7ed6fa4268e"
-  integrity sha512-n3R6L7jhE2QywPG5yaLde1FDsxxHfGPx/dr7VYIkGuptY0uuE8tpMiPEsJZka7Pr3ApspZmAgbg+Jesrc2PO6w==
+"@percy/config@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.24.0.tgz#41e606b021a44385a795dd01820405a72c5f5579"
+  integrity sha512-FOV8VkW/MjLI7PXzKSjxFBK7z0ND1s8LtXuLQNIrux3oiCKHIVBAQWIV86LLnXSSn+G5i3tfQua9YED5ATyNFQ==
   dependencies:
-    "@percy/logger" "1.20.3"
+    "@percy/logger" "1.24.0"
     ajv "^8.6.2"
     cosmiconfig "^7.0.0"
     yaml "^2.0.0"
 
-"@percy/core@1.20.3":
-  version "1.20.3"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.20.3.tgz#42f29ea20c0618d37ac0ccda540c82ad1317ab51"
-  integrity sha512-Peg9M9Fdwxd3DUh4ijYu3zp7CDlqTK4su5g/r8wLyuxBQss25XbmmXJ0/f+WiXfwas40E5JBxbmedQKBjLHn2w==
+"@percy/core@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.24.0.tgz#1e35c4fb4c0851fed1f92a32e39b26519d774e1c"
+  integrity sha512-wys1k3RmENOWT4MeS2+8yGHNqzYuy64lqPi36dFoHwZHzSGHH52+6EPPDb+gXLFIxBUHVTwbdaNimstIO3F9Ww==
   dependencies:
-    "@percy/client" "1.20.3"
-    "@percy/config" "1.20.3"
-    "@percy/dom" "1.20.3"
-    "@percy/logger" "1.20.3"
+    "@percy/client" "1.24.0"
+    "@percy/config" "1.24.0"
+    "@percy/dom" "1.24.0"
+    "@percy/logger" "1.24.0"
     content-disposition "^0.5.4"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
@@ -2067,20 +2067,20 @@
   dependencies:
     "@percy/sdk-utils" "^1.3.1"
 
-"@percy/dom@1.20.3":
-  version "1.20.3"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.20.3.tgz#529d09144af9abd9423de40774c2a1e9fc88acf7"
-  integrity sha512-cHzWR9IFVia4fp9EDBGWE3/GCQa4OFyRnUsrS5hFLrx+ZNy2QyUqHriOcISDPEb9MY/tNNg2fWkLrIcEW9DtRA==
+"@percy/dom@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.24.0.tgz#48529fe344123b30ef3153c5218725eab5bcfc4f"
+  integrity sha512-URMLvsOPkCKayx/Wtyj5IymmIhzrtf4en6IKeW2sSTsm7X+kJQ+3wOa3017mX3HXJPIS5xEJKpiCR7hP9BtcUA==
 
-"@percy/env@1.20.3":
-  version "1.20.3"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.20.3.tgz#cbd10dc23ab0e949506223c0f6b6bf14eeafab8e"
-  integrity sha512-hT70WSml3+853egmuXO7bwQNTNJ4nEjKKLd0OkS08/IGNt6iEaQM7MniUvkVZKcZkSMIwxHcMZYTFoC1cAV8+A==
+"@percy/env@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.24.0.tgz#c8942c3580a305ce6b7148627644654ddd88d047"
+  integrity sha512-fUUWWDZJ71kv+Po5yOaoS8t7eLmQL5NN6hqRdLhgqN9PZnu+OKIGaeK1GNaTWiHL9+zANRBc1pZjQWhRlleWVA==
 
-"@percy/logger@1.20.3":
-  version "1.20.3"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.20.3.tgz#09f5a4b2067cd0de45bf1bed78cc0cd95216a605"
-  integrity sha512-m9xbKtHtfodcfRCGugwannwl0D3U65Cs0TdirZoorWA4FEEgSQvo9N9cKhbPgGC15102CKx2HfRWSvdEsBpP8w==
+"@percy/logger@1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.24.0.tgz#427db543680f27d95f9a2169c8cd7fbfbbdada39"
+  integrity sha512-yaAo08FMED1o8jZycTEnTob1CZIVGaNluJc4R9fCRw7wWS88IAu4F9sdbzUZQZwZ/QGvtfI+55dNQaaesk69Bw==
 
 "@percy/sdk-utils@^1.3.1":
   version "1.20.3"


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Upgrade Percy to latest

## Why?

Maybe fix some flakiness with Percy runs failing to report in GitHub checks?