### PR TITLE
chore!: bump commercial core in bundle

### DIFF
--- a/bundle/package.json
+++ b/bundle/package.json
@@ -90,7 +90,7 @@
 	},
 	"dependencies": {
 		"@guardian/ab-core": "^4.0.0",
-		"@guardian/commercial-core": "^6.3.0",
+		"@guardian/commercial-core": "^7.0.0",
 		"@guardian/consent-management-platform": "^13.0.2",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/libs": "^14.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1297,10 +1297,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-4.0.0.tgz#50c1fc076437e594b367f6e8d9469a3d9b97a78e"
   integrity sha512-l6Ot/anisLKyoLZOp8koW7Ia5JFOtmZkB0sfgdWajv5+N0w0UScUVoImEdPlFstM1anSd3FvV8D3UgYkRzAang==
 
-"@guardian/commercial-core@^6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-6.3.0.tgz#9a56db885482adbe3ae1b184a046906d3157d371"
-  integrity sha512-+CxVVLD1BA/XYGF+TQsp0N+55TEIEGQstP1AUJ3RfdnN7pvTh4ZnypLGmLZ3l/WhRsnHIIa7Deu7tt2+4AeE2w==
+"@guardian/commercial-core@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-7.0.0.tgz#2bde098699e8d8121028bd03d10481e8664f8e06"
+  integrity sha512-ByfukhmfJ2sF5mCyVq5XSRyOdBp0w+MOTpOp361wjZ6a2KHSgSC8VQucgSQHtQ7v05O0jJ53XFkSrGc2TUworA==
 
 "@guardian/consent-management-platform@^13.0.2":
   version "13.0.2"


### PR DESCRIPTION
## What does this change?

Bump version of commercial core in commercial bundle to accommodate update of consent-management-platform.
https://github.com/guardian/consent-management-platform/releases/tag/v13.0.2 
https://github.com/guardian/commercial/releases/tag/%40guardian%2Fcommercial-core-v7.0.0 

## Why?

To pick up changes of vendor id.