### PR TITLE
fix: Add <ul> to spacefinder ignore list

### DIFF
--- a/bundle/src/projects/commercial/modules/article-body-adverts.ts
+++ b/bundle/src/projects/commercial/modules/article-body-adverts.ts
@@ -155,9 +155,11 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 	const tweakpoint = getCurrentTweakpoint();
 	const hasLeftCol = ['leftCol', 'wide'].includes(tweakpoint);
 
-	const ignoreList = hasLeftCol
-		? ` > :not(p):not(h2):not(.${adSlotContainerClass}):not(#sign-in-gate):not([data-spacefinder-role="richLink"]):not([data-spacefinder-role="thumbnail"])`
-		: ` > :not(p):not(h2):not(.${adSlotContainerClass}):not(#sign-in-gate)`;
+	let ignoreList = ` > :not(p):not(h2):not(ul):not(.${adSlotContainerClass}):not(#sign-in-gate)`;
+	if (hasLeftCol) {
+		ignoreList +=
+			':not([data-spacefinder-role="richLink"]):not([data-spacefinder-role="thumbnail"])';
+	}
 
 	const isImmersive = window.guardian.config.page.isImmersive;
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

This change removes `<ul>` elements from the list of elements that Spacefinder avoids placing ads close to. Spacefinder will now be able to place ads close to a bulleted list.

## Why?

Some elements in an article are not suitable to place ads next to or close to. For example, an advert too close to a full-width image would not look good when rendered on the page. A bulleted list is regular article content and should not be avoided when trying to place ads. This change will not insert ads immediately above a bulleted list, as adverts are only inserted above paragraph `p` tags.


## Screenshots

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://github.com/guardian/commercial/assets/9574885/c90b1752-ab5d-497d-bd15-58f740f2052c
[after]: https://github.com/guardian/commercial/assets/9574885/2f63aaa0-f7b4-49bf-b438-2a5adcc0db07