### PR TITLE
chore!: Permissions for Github Actions

### DIFF
--- a/.github/workflows/beta-release-on-label.yml
+++ b/.github/workflows/beta-release-on-label.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     types: [labeled]
 
+permissions: write-all
+
 jobs:
   has-permission:
     name: Check permissions

--- a/.github/workflows/ci-bundle.yml
+++ b/.github/workflows/ci-bundle.yml
@@ -7,6 +7,8 @@ on:
     branches-ignore:
       - "gh-pages"
 
+permissions: write-all
+
 defaults:
   run:
     working-directory: ./bundle

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -7,6 +7,8 @@ on:
     branches-ignore:
       - "gh-pages"
 
+permissions: write-all
+
 defaults:
   run:
     working-directory: ./core


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Add `permission: write-all` to each of the Github actions that release NPM packages.

## Why?

Attempt to fix an issue where we're unable to release packages due to permission issues.
