### PR TITLE
feat: Add front-banner ad slot

### DIFF
--- a/bundle/src/projects/commercial/modules/header-bidding/request-bids.ts
+++ b/bundle/src/projects/commercial/modules/header-bidding/request-bids.ts
@@ -8,7 +8,10 @@ const retainTopAboveNavSlotSize = (
 	advertSize: Advert['size'],
 	hbSlot: HeaderBiddingSlot,
 ): HeaderBiddingSlot[] => {
-	if (hbSlot.key !== 'top-above-nav') {
+	if (
+		hbSlot.key !== 'top-above-nav' &&
+		!hbSlot.key.includes('front-banner')
+	) {
 		return [hbSlot];
 	}
 

--- a/bundle/src/projects/commercial/modules/header-bidding/request-bids.ts
+++ b/bundle/src/projects/commercial/modules/header-bidding/request-bids.ts
@@ -10,7 +10,7 @@ const retainTopAboveNavSlotSize = (
 ): HeaderBiddingSlot[] => {
 	if (
 		hbSlot.key !== 'top-above-nav' &&
-		!hbSlot.key.includes('front-banner')
+		!hbSlot.key.startsWith('front-banner')
 	) {
 		return [hbSlot];
 	}

--- a/bundle/src/projects/commercial/modules/header-bidding/slot-config.ts
+++ b/bundle/src/projects/commercial/modules/header-bidding/slot-config.ts
@@ -115,6 +115,9 @@ const getSlots = (): HeaderBiddingSizeMapping => {
 			tablet: [adSizes.leaderboard],
 			mobile: [adSizes.mpu],
 		},
+		'front-banner': {
+			desktop: [adSizes.billboard],
+		},
 		inline: {
 			desktop: isArticle
 				? [adSizes.skyscraper, adSizes.halfPage, adSizes.mpu]

--- a/bundle/src/projects/commercial/modules/header-bidding/types.d.ts
+++ b/bundle/src/projects/commercial/modules/header-bidding/types.d.ts
@@ -11,9 +11,13 @@ declare global {
 		| 'mostpop'
 		| 'right'
 		| 'top-above-nav'
+		| `front-banner-${number}`
 		| `inline${number}`;
 
-	type HeaderBiddingSizeKey = HeaderBiddingSlotName | 'inline';
+	type HeaderBiddingSizeKey =
+		| HeaderBiddingSlotName
+		| 'inline'
+		| 'front-banner';
 
 	type HeaderBiddingSlot = {
 		key: HeaderBiddingSizeKey;

--- a/core/src/ad-sizes.ts
+++ b/core/src/ad-sizes.ts
@@ -95,6 +95,7 @@ type SlotName =
 	| 'crossword-banner'
 	| 'epic'
 	| 'exclusion'
+	| 'front-banner'
 	| 'im'
 	| 'inline'
 	| 'merchandising-high-lucky'
@@ -269,6 +270,15 @@ const slotSizeMappings: SlotSizeMappings = {
 			adSizes.leaderboard,
 			createAdSize(940, 230),
 			createAdSize(900, 250),
+			adSizes.billboard,
+			adSizes.fabric,
+			adSizes.fluid,
+		],
+	},
+	'front-banner': {
+		desktop: [
+			adSizes.outOfPage,
+			adSizes.empty,
 			adSizes.billboard,
 			adSizes.fabric,
 			adSizes.fluid,

--- a/core/src/create-ad-slot.ts
+++ b/core/src/create-ad-slot.ts
@@ -15,6 +15,7 @@ type SlotName =
 	| 'comments'
 	| 'epic'
 	| 'exclusion'
+	| 'front-banner'
 	| 'high-merch-lucky'
 	| 'high-merch-paid'
 	| 'high-merch'


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Adds the `front-banner` ad slot type.

## Why?

So that we can target this new type of slot with banner style ads on fronts pages

## Screenshots

![image](https://github.com/guardian/commercial/assets/9574885/431fa845-9561-4f89-99ce-0a633f58b30c)
