### PR TITLE
fix: Add labels to consentless merchandising slots

### DIFF
--- a/.github/workflows/beta-release-on-label.yml
+++ b/.github/workflows/beta-release-on-label.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version-file: ".nvmrc"
+          node-version: "16.13.2"
           cache: "yarn"
 
       - name: Install dependencies

--- a/.github/workflows/beta-release-on-label.yml
+++ b/.github/workflows/beta-release-on-label.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: "16.13.2"
+          node-version: "16.14.0"
           cache: "yarn"
 
       - name: Install dependencies

--- a/bundle/src/projects/commercial/modules/consentless/render-advert-label.spec.ts
+++ b/bundle/src/projects/commercial/modules/consentless/render-advert-label.spec.ts
@@ -11,6 +11,10 @@ const adverts: Record<string, string> = {
         <div class="js-ad-slot"></div>`,
 	labelDisabled: `
         <div class="js-ad-slot" data-label="false"></div>`,
+	frame: `
+        <div class="js-ad-slot ad-slot--frame"></div>`,
+	uh: `
+        <div class="js-ad-slot u-h"></div>`,
 };
 
 const createAd = (html: string) => {
@@ -40,6 +44,22 @@ describe('Rendering advert labels', () => {
 
 	it('Will not add a label if it has an attribute data-label="false"', async () => {
 		createAd(adverts['labelDisabled']);
+		return renderConsentlessAdvertLabel(getAd()).then(() => {
+			const dataLabelShow = getAd().getAttribute('data-label-show');
+			expect(dataLabelShow).toBeFalsy();
+		});
+	});
+
+	it('Will not add a label to frame ads', async () => {
+		createAd(adverts['frame']);
+		return renderConsentlessAdvertLabel(getAd()).then(() => {
+			const dataLabelShow = getAd().getAttribute('data-label-show');
+			expect(dataLabelShow).toBeFalsy();
+		});
+	});
+
+	it('Will not add a label to an ad slot with a hidden u-h class', async () => {
+		createAd(adverts['uh']);
 		return renderConsentlessAdvertLabel(getAd()).then(() => {
 			const dataLabelShow = getAd().getAttribute('data-label-show');
 			expect(dataLabelShow).toBeFalsy();

--- a/bundle/src/projects/commercial/modules/consentless/render-advert-label.spec.ts
+++ b/bundle/src/projects/commercial/modules/consentless/render-advert-label.spec.ts
@@ -11,12 +11,6 @@ const adverts: Record<string, string> = {
         <div class="js-ad-slot"></div>`,
 	labelDisabled: `
         <div class="js-ad-slot" data-label="false"></div>`,
-	frame: `
-        <div class="js-ad-slot ad-slot--frame"></div>`,
-	uh: `
-        <div class="js-ad-slot u-h"></div>`,
-	topAboveNav: `
-        <div class="js-ad-slot" id="dfp-ad--top-above-nav"></div>`,
 };
 
 const createAd = (html: string) => {
@@ -49,30 +43,6 @@ describe('Rendering advert labels', () => {
 		return renderConsentlessAdvertLabel(getAd()).then(() => {
 			const dataLabelShow = getAd().getAttribute('data-label-show');
 			expect(dataLabelShow).toBeFalsy();
-		});
-	});
-
-	it('Will not add a label to frame ads', async () => {
-		createAd(adverts['frame']);
-		return renderConsentlessAdvertLabel(getAd()).then(() => {
-			const dataLabelShow = getAd().getAttribute('data-label-show');
-			expect(dataLabelShow).toBeFalsy();
-		});
-	});
-
-	it('Will not add a label to an ad slot with a hidden u-h class', async () => {
-		createAd(adverts['uh']);
-		return renderConsentlessAdvertLabel(getAd()).then(() => {
-			const dataLabelShow = getAd().getAttribute('data-label-show');
-			expect(dataLabelShow).toBeFalsy();
-		});
-	});
-
-	it('When the ad is top above nav and the label is NOT toggleable, render the label dynamically', async () => {
-		createAd(adverts['topAboveNav']);
-		return renderConsentlessAdvertLabel(getAd()).then(() => {
-			const dataLabelShow = getAd().getAttribute('data-label-show');
-			expect(dataLabelShow).toBeTruthy();
 		});
 	});
 });

--- a/bundle/src/projects/commercial/modules/consentless/render-advert-label.ts
+++ b/bundle/src/projects/commercial/modules/consentless/render-advert-label.ts
@@ -5,7 +5,14 @@
 */
 import crossIcon from 'svgs/icon/cross.svg';
 import fastdom from '../../../../lib/fastdom-promise';
-import { shouldRenderLabel } from '../dfp/render-advert-label';
+
+const shouldRenderConsentlessLabel = (adSlotNode: HTMLElement): boolean => {
+	if (adSlotNode.getAttribute('data-label') === 'false') {
+		return false;
+	}
+
+	return true;
+};
 
 export const createAdCloseDiv = (): HTMLElement => {
 	const closeDiv: HTMLElement = document.createElement('button');
@@ -24,7 +31,7 @@ export const renderConsentlessAdvertLabel = (
 	adSlotNode: HTMLElement,
 ): Promise<Promise<void>> => {
 	return fastdom.measure(() => {
-		if (shouldRenderLabel(adSlotNode)) {
+		if (shouldRenderConsentlessLabel(adSlotNode)) {
 			//Assigning the ad label text like this allows us to conditionally add extra text to it
 			//eg. for the ad test labelling for google ads
 			const adLabelContent = `Advertisement`;

--- a/bundle/src/projects/commercial/modules/consentless/render-advert-label.ts
+++ b/bundle/src/projects/commercial/modules/consentless/render-advert-label.ts
@@ -7,7 +7,11 @@ import crossIcon from 'svgs/icon/cross.svg';
 import fastdom from '../../../../lib/fastdom-promise';
 
 const shouldRenderConsentlessLabel = (adSlotNode: HTMLElement): boolean => {
-	if (adSlotNode.getAttribute('data-label') === 'false') {
+	if (
+		adSlotNode.getAttribute('data-label') === 'false' &&
+		(!adSlotNode.classList.contains('ad-slot--merchandising-high') ||
+			!adSlotNode.classList.contains('ad-slot--merchandising'))
+	) {
 		return false;
 	}
 

--- a/bundle/src/projects/commercial/modules/consentless/render-advert-label.ts
+++ b/bundle/src/projects/commercial/modules/consentless/render-advert-label.ts
@@ -8,9 +8,18 @@ import fastdom from '../../../../lib/fastdom-promise';
 
 const shouldRenderConsentlessLabel = (adSlotNode: HTMLElement): boolean => {
 	if (
-		adSlotNode.getAttribute('data-label') === 'false' &&
-		(!adSlotNode.classList.contains('ad-slot--merchandising-high') ||
-			!adSlotNode.classList.contains('ad-slot--merchandising'))
+		adSlotNode.classList.contains('ad-slot--merchandising') ||
+		adSlotNode.classList.contains('ad-slot--merchandising-high')
+	) {
+		return true;
+	}
+	if (
+		adSlotNode.classList.contains('ad-slot--frame') ||
+		adSlotNode.classList.contains('ad-slot--gc') ||
+		adSlotNode.classList.contains('u-h') ||
+		// set for out-of-page (1x1) and empty (2x2) ads
+		adSlotNode.classList.contains('ad-slot--collapse') ||
+		adSlotNode.getAttribute('data-label') === 'false'
 	) {
 		return false;
 	}


### PR DESCRIPTION
## What does this change?

- Fixes the beta release action by using a slightly older version of node to preform the beta release
- Changes the consentless label rendering logic to add labels to merchandising slots, as these are used to display ads in consentless, instead of in house content

Before:
<img width="1247" alt="Screenshot 2023-05-16 at 17 50 31" src="https://github.com/guardian/commercial/assets/108270776/0f7ddd06-3884-481d-9f89-aae27d7f6494">

After:
<img width="1064" alt="Screenshot 2023-05-17 at 10 09 50" src="https://github.com/guardian/commercial/assets/108270776/d8241d94-3325-47c9-be3d-cc40da7384eb">


