### PR TITLE
feat: Add new fronts-banner ad slot

### DIFF
--- a/core/src/ad-sizes.ts
+++ b/core/src/ad-sizes.ts
@@ -95,6 +95,7 @@ type SlotName =
 	| 'crossword-banner'
 	| 'epic'
 	| 'exclusion'
+	| 'fronts-banner'
 	| 'im'
 	| 'inline'
 	| 'merchandising-high-lucky'
@@ -269,6 +270,15 @@ const slotSizeMappings: SlotSizeMappings = {
 			adSizes.leaderboard,
 			createAdSize(940, 230),
 			createAdSize(900, 250),
+			adSizes.billboard,
+			adSizes.fabric,
+			adSizes.fluid,
+		],
+	},
+	'fronts-banner': {
+		desktop: [
+			adSizes.outOfPage,
+			adSizes.empty,
 			adSizes.billboard,
 			adSizes.fabric,
 			adSizes.fluid,

--- a/core/src/create-ad-slot.ts
+++ b/core/src/create-ad-slot.ts
@@ -15,6 +15,7 @@ type SlotName =
 	| 'comments'
 	| 'epic'
 	| 'exclusion'
+	| 'fronts-banner'
 	| 'high-merch-lucky'
 	| 'high-merch-paid'
 	| 'high-merch'


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Adds the fronts-banner ad slot type.

## Why?

So that we can target this new type of slot with banner style ads on fronts pages
