### PR TITLE
chore: bump percy to v1.24.2

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -13,7 +13,7 @@
 		"@babel/core": "^7.0.1",
 		"@babel/preset-env": "^7.0.0",
 		"@cypress/webpack-preprocessor": "^5.16.1",
-		"@percy/cli": "^1.24.0",
+		"@percy/cli": "^1.24.2",
 		"@percy/cypress": "^3.1.2",
 		"babel-loader": "^9",
 		"cypress": "^12.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1951,105 +1951,105 @@
   dependencies:
     "@octokit/openapi-types" "^16.0.0"
 
-"@percy/cli-app@1.24.0":
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/@percy/cli-app/-/cli-app-1.24.0.tgz#1d5bfb392a40e496dd1ba98b3b4f6e66388e9fd7"
-  integrity sha512-z7ksv+SvdgDuAZ4WDnluuLuS72xb18DKauuwikSKipdICHHFQuXdRc0ngloADC/6IFzp0JhiukiRanntbBkPvg==
+"@percy/cli-app@1.24.2":
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-app/-/cli-app-1.24.2.tgz#139c8f8dbd75b6bd6856744ce813120658fa3088"
+  integrity sha512-OFSKEFILXBbLUylaYdQMWpgcV1YbRuXUiXrLDn6k6yNXzn5KlN/5UWhukvf4xgjmoZu61tOj71J0pKnxWKFvRw==
   dependencies:
-    "@percy/cli-command" "1.24.0"
-    "@percy/cli-exec" "1.24.0"
+    "@percy/cli-command" "1.24.2"
+    "@percy/cli-exec" "1.24.2"
 
-"@percy/cli-build@1.24.0":
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.24.0.tgz#409b9ef214fa94edba4b702954fbeb87c1819b9f"
-  integrity sha512-p/wmO0OzqJ2Uou7QNAdxioqKmxu7U+6Al02GvVhYcPja/MkVjfJT/jDl+XstXawR76txQW9QWrNsK5YOAWUupQ==
+"@percy/cli-build@1.24.2":
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.24.2.tgz#6990e579954337335c09ea37fdbbf4252fa9727d"
+  integrity sha512-gc+HNPC9zm2PP6Tb71PMB5xKmW6yG0xqgicrHeqpgIAww3IfJHchzntqOP2wLwB7X5DixzuiIhKwr/dwdkkgXw==
   dependencies:
-    "@percy/cli-command" "1.24.0"
+    "@percy/cli-command" "1.24.2"
 
-"@percy/cli-command@1.24.0":
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.24.0.tgz#36b51e1e41c10db8ceb3f9bbd624e8199a16cee7"
-  integrity sha512-n4qyDdUc+TiX/YykGg59IS1DBmm4UdA7ZaiTdw/D5AZohzwwVbwL+Q4QMYqcohtfYZ/F8UT7Qy3Jma3+YKTnxw==
+"@percy/cli-command@1.24.2":
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.24.2.tgz#eead1c394ef2cf4a44b4ec9c99ad6d1f7fad1145"
+  integrity sha512-n0wB7thn768dtgwNAvyibp1UgeqpRqTJKV+j7/2mfQ1QEtI09ABpFzJ4nMQ6/rciv0LkIO85TiKD7vD/MPPzcQ==
   dependencies:
-    "@percy/config" "1.24.0"
-    "@percy/core" "1.24.0"
-    "@percy/logger" "1.24.0"
+    "@percy/config" "1.24.2"
+    "@percy/core" "1.24.2"
+    "@percy/logger" "1.24.2"
 
-"@percy/cli-config@1.24.0":
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.24.0.tgz#5a62eb9cb1d2e772481dffa6efcd75a0e6604c0f"
-  integrity sha512-7T70Y3vC0hIGBe+WOmdzspN8N5uflBRwuPoRXn2PdzxvH55hUhCGFT/Wxb8C6rTMJ9k++POkxMoQaSErVANYYg==
+"@percy/cli-config@1.24.2":
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.24.2.tgz#c68fb1363b93fcc3456743a6425cd3b877c4d384"
+  integrity sha512-dt8S96FfQYlvoP1JK+fh9aSTA8BA5qGEcztTZu2tCBTx3DTNwyDIeiuIiCyFJ0+zoZQaq9SjQ8CUAx20bzmPLw==
   dependencies:
-    "@percy/cli-command" "1.24.0"
+    "@percy/cli-command" "1.24.2"
 
-"@percy/cli-exec@1.24.0":
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.24.0.tgz#02f8c6a417ef13303c7ab692a080480c9cb7d9ce"
-  integrity sha512-T5B8HLjPde0js5lkO14uk02QZKmgxILjALh5SX9VFL2Qx4cUXw+A29epPPv6OLI2x2oww8e5nTdlnmykX8n4kQ==
+"@percy/cli-exec@1.24.2":
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.24.2.tgz#519522d67eae8b92cf274cfd7bf23ca1d6092709"
+  integrity sha512-hulbUG/Q/JRnD8Mcx+1cvSDhfl2dcULddj9pnv5VSVMrp/52EkVEEBzH05vB84XVrF+oJpOg224c7n0aMDtJdw==
   dependencies:
-    "@percy/cli-command" "1.24.0"
+    "@percy/cli-command" "1.24.2"
     cross-spawn "^7.0.3"
     which "^2.0.2"
 
-"@percy/cli-snapshot@1.24.0":
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.24.0.tgz#6516710bc095158bcb20ece4ba4861214d4cc428"
-  integrity sha512-zxoE1SbdTvUlP7QAjTs7+M7U8cHEDF1ec7ov06m1i+bul68YhZ0S+P4a1Mbt6oWBsAxjYz06h4jnq32JitbSDg==
+"@percy/cli-snapshot@1.24.2":
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.24.2.tgz#9b3f2b2c39994dc40d7d31a13e98078f7387c2a8"
+  integrity sha512-seGl7kc359Lg+G4YGRu/RNxZGPDxDijp6BwYr51JcO53OJIkrmOXmQ8mgibzRkJxqsxLSNxv5h1ywxySG0uyYA==
   dependencies:
-    "@percy/cli-command" "1.24.0"
+    "@percy/cli-command" "1.24.2"
     yaml "^2.0.0"
 
-"@percy/cli-upload@1.24.0":
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.24.0.tgz#a6761d93d66668fd3182ee3c22efbebba5e74751"
-  integrity sha512-/4XNzMAhbccYSsPhw/KWRVjnd13nd17LB178dVNX4UEtaETDbBF+VZSlU3scgs8mlpuqY8b8bHDaSJNfI71UwQ==
+"@percy/cli-upload@1.24.2":
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.24.2.tgz#ee4340d71ce6342e8f270a87c433c44ab09f682f"
+  integrity sha512-qGDBa+m5OSkctTBdRXP4h4O2Y4DJULz+xSztGju6djGBXBuZRpN88bPvuymhTCQnGa7FIGuUKCfuujLOw6cWsg==
   dependencies:
-    "@percy/cli-command" "1.24.0"
+    "@percy/cli-command" "1.24.2"
     fast-glob "^3.2.11"
     image-size "^1.0.0"
 
-"@percy/cli@^1.24.0":
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.24.0.tgz#260555b8990404ed63e08b0d3db4a7f6e49bfb1d"
-  integrity sha512-n8dxQfA2GoPk468EQ+sO7P/P5sBl3Q+s7UrljQhf4wPt4l+CBmoxMML8Ib71MyISzwxY7bOSw2QMr26r6n06/A==
+"@percy/cli@^1.24.2":
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.24.2.tgz#8a2588b0acabcff9a99883007387abb325c62b86"
+  integrity sha512-FFD6V0LOztEs58DmnSYOoh36ZCl9P0s9UVe/bhkyvN2aUR/3XYAxzFAjgkPgP/v66fEIc4vfpvLVnSeozKZdIg==
   dependencies:
-    "@percy/cli-app" "1.24.0"
-    "@percy/cli-build" "1.24.0"
-    "@percy/cli-command" "1.24.0"
-    "@percy/cli-config" "1.24.0"
-    "@percy/cli-exec" "1.24.0"
-    "@percy/cli-snapshot" "1.24.0"
-    "@percy/cli-upload" "1.24.0"
-    "@percy/client" "1.24.0"
-    "@percy/logger" "1.24.0"
+    "@percy/cli-app" "1.24.2"
+    "@percy/cli-build" "1.24.2"
+    "@percy/cli-command" "1.24.2"
+    "@percy/cli-config" "1.24.2"
+    "@percy/cli-exec" "1.24.2"
+    "@percy/cli-snapshot" "1.24.2"
+    "@percy/cli-upload" "1.24.2"
+    "@percy/client" "1.24.2"
+    "@percy/logger" "1.24.2"
 
-"@percy/client@1.24.0":
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.24.0.tgz#b72696269f0925a06571bfa4e75ee8d632c63da2"
-  integrity sha512-mCMIGryE+0oxJN6v+riZ+XqnubEL9rajLOJI7xNOj5gNBNNvwgvkpTiNId9d6LNZVhA7dN9ZHTW+zFK+i4nU8A==
+"@percy/client@1.24.2":
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.24.2.tgz#b4ab27b2180ea445c67a70012995559ae05bc9fe"
+  integrity sha512-ey9WGxwlWFPWGgqU+LpaixHFDeczKRD5YzYT0oIZ+q8/2zpodlGDuezM6f+0wNSZpIIZWPwReHuosjkVSXgpfw==
   dependencies:
-    "@percy/env" "1.24.0"
-    "@percy/logger" "1.24.0"
+    "@percy/env" "1.24.2"
+    "@percy/logger" "1.24.2"
 
-"@percy/config@1.24.0":
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.24.0.tgz#41e606b021a44385a795dd01820405a72c5f5579"
-  integrity sha512-FOV8VkW/MjLI7PXzKSjxFBK7z0ND1s8LtXuLQNIrux3oiCKHIVBAQWIV86LLnXSSn+G5i3tfQua9YED5ATyNFQ==
+"@percy/config@1.24.2":
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.24.2.tgz#653cd0f39a8d8f17bf9e0e7b151ba4b57a4adf1b"
+  integrity sha512-RD/cORj4dIxtTTsbbPgE2iN23N5XL1FRuVj37R0xcbJbnyPDuFc8TJER9Z4pdeUtfh+E2iG+SRj+OyP28yGjKQ==
   dependencies:
-    "@percy/logger" "1.24.0"
+    "@percy/logger" "1.24.2"
     ajv "^8.6.2"
-    cosmiconfig "^7.0.0"
+    cosmiconfig "^8.0.0"
     yaml "^2.0.0"
 
-"@percy/core@1.24.0":
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.24.0.tgz#1e35c4fb4c0851fed1f92a32e39b26519d774e1c"
-  integrity sha512-wys1k3RmENOWT4MeS2+8yGHNqzYuy64lqPi36dFoHwZHzSGHH52+6EPPDb+gXLFIxBUHVTwbdaNimstIO3F9Ww==
+"@percy/core@1.24.2":
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.24.2.tgz#7b38a24abaff81a74b6ea747b0361f0ec1b61fba"
+  integrity sha512-gGzZdVO+/CF7jIUqpXeFzG8AvbSJzZ21duZGrp9I7rD8AQd6PIq/kXjO9QNShoSi+tnC1GvfKw3Gorr3tGhpaw==
   dependencies:
-    "@percy/client" "1.24.0"
-    "@percy/config" "1.24.0"
-    "@percy/dom" "1.24.0"
-    "@percy/logger" "1.24.0"
+    "@percy/client" "1.24.2"
+    "@percy/config" "1.24.2"
+    "@percy/dom" "1.24.2"
+    "@percy/logger" "1.24.2"
     content-disposition "^0.5.4"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
@@ -2067,20 +2067,20 @@
   dependencies:
     "@percy/sdk-utils" "^1.3.1"
 
-"@percy/dom@1.24.0":
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.24.0.tgz#48529fe344123b30ef3153c5218725eab5bcfc4f"
-  integrity sha512-URMLvsOPkCKayx/Wtyj5IymmIhzrtf4en6IKeW2sSTsm7X+kJQ+3wOa3017mX3HXJPIS5xEJKpiCR7hP9BtcUA==
+"@percy/dom@1.24.2":
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.24.2.tgz#827f6b7b36d57003d52ba3ee9df6ac9f119d9242"
+  integrity sha512-C5nRMpHNGKS8xPflmYJCO2x6870wiR7TagMx+KOiIHfMEx/4LZhwPP4dkVS4WGeCfcKHOhi8BkJnhuSbL7WWDw==
 
-"@percy/env@1.24.0":
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.24.0.tgz#c8942c3580a305ce6b7148627644654ddd88d047"
-  integrity sha512-fUUWWDZJ71kv+Po5yOaoS8t7eLmQL5NN6hqRdLhgqN9PZnu+OKIGaeK1GNaTWiHL9+zANRBc1pZjQWhRlleWVA==
+"@percy/env@1.24.2":
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.24.2.tgz#57b3a7791e703c5ab0feea67c8e7e462a95915be"
+  integrity sha512-y2uzAF4jojzuBPOaY/TxA5WwvxfXFv4UKlgbVBGWVDwmgG9ZO/ahUqRTyvG4bgC48NNAeckNxKgADQG5oWR6+g==
 
-"@percy/logger@1.24.0":
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.24.0.tgz#427db543680f27d95f9a2169c8cd7fbfbbdada39"
-  integrity sha512-yaAo08FMED1o8jZycTEnTob1CZIVGaNluJc4R9fCRw7wWS88IAu4F9sdbzUZQZwZ/QGvtfI+55dNQaaesk69Bw==
+"@percy/logger@1.24.2":
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.24.2.tgz#90fd3e717e9aa4a9397185dfffebf24bd7aca2c4"
+  integrity sha512-wsmDUsY6MOmjE9TvkF/voL1r6btAMxIPggYOE6JIenrUc6ZBxIPZ9SYJWA63w8v4KWsRUOMqPBRCEUy7VpnPEw==
 
 "@percy/sdk-utils@^1.3.1":
   version "1.20.3"


### PR DESCRIPTION
## What does this change?

Bumps Percy from 1.24.0 -> 1.24.2

## Why?

Partially fixes a [high severity issue](https://github.com/guardian/commercial/security/dependabot/21) identified by Dependabot, introduced through an old version of cosmiconfig, which is used by 1.24.0 of Percy.