### PR TITLE
feat: Add section slot targeting to fronts banner slots

### DIFF
--- a/bundle/src/projects/commercial/modules/dfp/Advert.ts
+++ b/bundle/src/projects/commercial/modules/dfp/Advert.ts
@@ -103,12 +103,17 @@ class Advert {
 	constructor(
 		adSlotNode: HTMLElement,
 		additionalSizeMapping: SizeMapping = {},
+		slotTargeting: Record<string, string> = {},
 	) {
 		this.id = adSlotNode.id;
 		this.node = adSlotNode;
 		this.sizes = this.generateSizeMapping(additionalSizeMapping);
 
-		const slotDefinition = defineSlot(adSlotNode, this.sizes);
+		const slotDefinition = defineSlot(
+			adSlotNode,
+			this.sizes,
+			slotTargeting,
+		);
 
 		this.slot = slotDefinition.slot;
 		this.whenSlotReady = slotDefinition.slotReady;

--- a/bundle/src/projects/commercial/modules/dfp/add-slot.ts
+++ b/bundle/src/projects/commercial/modules/dfp/add-slot.ts
@@ -21,11 +21,16 @@ const addSlot = (
 	adSlot: HTMLElement,
 	forceDisplay: boolean,
 	additionalSizes?: SizeMapping,
+	slotTargeting?: Record<string, string>,
 ): Promise<Advert | null> => {
 	return new Promise((resolve) => {
 		window.googletag.cmd.push(() => {
 			if (!(adSlot.id in dfpEnv.advertIds)) {
-				const advert = createAdvert(adSlot, additionalSizes);
+				const advert = createAdvert(
+					adSlot,
+					additionalSizes,
+					slotTargeting,
+				);
 				if (advert === null) return;
 				// dynamically add ad slot
 				displayAd(advert, forceDisplay);

--- a/bundle/src/projects/commercial/modules/dfp/create-advert.ts
+++ b/bundle/src/projects/commercial/modules/dfp/create-advert.ts
@@ -6,9 +6,10 @@ import { Advert } from './Advert';
 const createAdvert = (
 	adSlot: HTMLElement,
 	additionalSizes?: SizeMapping,
+	slotTargeting?: Record<string, string>,
 ): Advert | null => {
 	try {
-		const advert = new Advert(adSlot, additionalSizes);
+		const advert = new Advert(adSlot, additionalSizes, slotTargeting);
 		return advert;
 	} catch (error) {
 		const errMsg = `Could not create advert. Ad slot: ${

--- a/bundle/src/projects/commercial/modules/dfp/define-slot.ts
+++ b/bundle/src/projects/commercial/modules/dfp/define-slot.ts
@@ -110,6 +110,7 @@ const allowSafeFrameToExpand = (slot: googletag.Slot) => {
 const defineSlot = (
 	adSlotNode: HTMLElement,
 	sizeMapping: SizeMapping,
+	slotTargeting: Record<string, string> = {},
 ): { slot: googletag.Slot; slotReady: Promise<void> } => {
 	const slotTarget = adSlotNode.getAttribute('data-name') as SlotName;
 	const id = adSlotNode.id;
@@ -255,6 +256,10 @@ const defineSlot = (
 	if (slotFabric) {
 		slot.setTargeting('slot-fabric', slotFabric);
 	}
+
+	Object.entries(slotTargeting).forEach(([key, value]) => {
+		slot?.setTargeting(key, value);
+	});
 
 	slot.addService(window.googletag.pubads()).setTargeting('slot', slotTarget);
 

--- a/bundle/src/projects/commercial/modules/fronts-banner-adverts.ts
+++ b/bundle/src/projects/commercial/modules/fronts-banner-adverts.ts
@@ -27,6 +27,10 @@ const insertAdvertAboveSection = async (section: string, advertNum: number) => {
 		adContainer.className = 'ad-slot-container fronts-banner-container';
 		adContainer.appendChild(ad);
 
+		const slotTargeting = {
+			'front-section': sectionNode.id,
+		};
+
 		void fastdom
 			.mutate(() => {
 				sectionNode.parentElement?.insertBefore(
@@ -35,7 +39,7 @@ const insertAdvertAboveSection = async (section: string, advertNum: number) => {
 				);
 			})
 			.then(() => {
-				void addSlot(ad, false);
+				void addSlot(ad, false, {}, slotTargeting);
 			});
 	});
 };


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?
Add section slot targeting to fronts banner slots

## Why?
Following on from #877, this adds a targeting key-value to the slot for the section it is adjacent to, to enable contextual targeting for these slots.
