### PR TITLE
fix: build dev & prod by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"main": "dist/cjs/core/index.js",
 	"module": "dist/esm/core/index.js",
 	"scripts": {
-		"build": "npm-run-all clean --parallel compile:core:* build:prod",
+		"build": "npm-run-all clean --parallel compile:core:* build:prod build:dev",
 		"build:dev": "webpack -c webpack.config.dev.js",
 		"build:prod": "webpack -c webpack.config.prod.js",
 		"clean": "rm -rf dist",


### PR DESCRIPTION
## What does this change?
make `yarn build` build both the dev and prod bundles

## Why?
Frontend when running locally is requesting the bundle without a hash, simply copying the file without the hash doesn't work as the separated chunks will still be requested with the hash in the URL (prebid.js and consentless), probably because webpack works out the paths at compile time?

A quick solution is to build both dev and prod so that they both will end up in the npm package and either can be used.