### PR TITLE
chore: Fix beta release versioning

### DIFF
--- a/.github/workflows/beta-release-on-label.yml
+++ b/.github/workflows/beta-release-on-label.yml
@@ -45,7 +45,7 @@ jobs:
         run: yarn build
 
       - name: Grab last version
-        run: yarn version --new-version $(git tag -l | grep @guardian/commercial-\* |  sed -E 's|.*([0-9]+\.[0-9]+\.[0-9]+(-beta.[0-9]+)?)|\1|g' | tail -1) --no-git-tag-version
+        run: yarn version --new-version $(git tag -l | grep v\* |  sed -E 's|.*([0-9]+\.[0-9]+\.[0-9]+(-beta.[0-9]+)?)|\1|g' | tail -1) --no-git-tag-version
 
       - name: Bump prerelease version
         run: yarn version --prerelease --preid beta --no-git-tag-version


### PR DESCRIPTION
## What does this change?
Amends the grep command in the beta release script to return the latest release version tags.

## Why?
The beta release versioning was using out of date versions because it was searching the git tag entries to find the latest versions. Now that bundle and core are merged, the release version tags are no longer prefixed with commerical-bundle or commercial-core in the tags, and are now just **v8.0.0**, for example. By removing the **@guardian/commercial** prefix from the grep command, we will find the latest tag version and assign the correct version number to the beta release.

Basically, tags used to look like this:
<img width="294" alt="Screenshot 2023-06-01 at 14 32 18" src="https://github.com/guardian/commercial/assets/108270776/afcdd606-b6e5-4481-a1ba-8cce8747a245">

And they now look like this:
<img width="55" alt="Screenshot 2023-06-01 at 14 32 49" src="https://github.com/guardian/commercial/assets/108270776/767f8bf7-6fa4-428d-9571-420240939ed1">

So we need to update the grep code accordingly.
