### PR TITLE
feat: Bake commit hash into bundle

### DIFF
--- a/.changeset/stale-pets-remember.md
+++ b/.changeset/stale-pets-remember.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Log the commit SHA of the current build to the browser console

--- a/src/standalone.commercial.ts
+++ b/src/standalone.commercial.ts
@@ -173,6 +173,12 @@ const recordCommercialMetrics = () => {
 
 const bootCommercial = async (): Promise<void> => {
 	log('commercial', '📦 standalone.commercial.ts', __webpack_public_path__);
+	if (process.env.COMMIT_SHA) {
+		log(
+			'commercial',
+			`@guardian/commercial commit ${process.env.COMMIT_SHA}`,
+		);
+	}
 
 	//adding an amiused call for a very small proportion of users to test sendBeacon vs fetch
 	//this will be removed when we have enough data

--- a/src/standalone.commercial.ts
+++ b/src/standalone.commercial.ts
@@ -176,7 +176,7 @@ const bootCommercial = async (): Promise<void> => {
 	if (process.env.COMMIT_SHA) {
 		log(
 			'commercial',
-			`@guardian/commercial commit ${process.env.COMMIT_SHA}`,
+			`@guardian/commercial commit https://github.com/guardian/commercial/blob/${process.env.COMMIT_SHA}`,
 		);
 	}
 

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -5,6 +5,16 @@ const BundleAnalyzerPlugin =
 const config = require('./webpack.config.js');
 const TerserPlugin = require('terser-webpack-plugin');
 const path = require('path');
+const { execSync } = require('child_process');
+
+const gitCommitSHA = () => {
+	try {
+		const commitSHA = execSync('git rev-parse HEAD').toString().trim();
+		return { 'process.env.COMMIT_SHA': JSON.stringify(commitSHA) };
+	} catch (_) {
+		return {};
+	}
+};
 
 module.exports = webpackMerge.smart(config, {
 	mode: 'production',
@@ -24,6 +34,7 @@ module.exports = webpackMerge.smart(config, {
 		new webpack.DefinePlugin({
 			'process.env.NODE_ENV': JSON.stringify('production'),
 			'process.env.OVERRIDE_BUNDLE_PATH': JSON.stringify(false),
+			...gitCommitSHA(),
 		}),
 	],
 	optimization: {


### PR DESCRIPTION
## What does this change?

This PR bakes the commit SHA into the bundle and logs it to the browser console.

![Screenshot 2023-06-12 at 10 46 34](https://github.com/guardian/commercial/assets/8000415/b9f70224-6b80-4794-a953-c68e74a5ce0a)

## Why?

This should make it easier to tell which version of the Commercial bundle is running on CODE/Production.
