### PR TITLE
feat: Add data attribute to opinion banner ad container

### DIFF
--- a/src/projects/commercial/modules/fronts-banner-adverts.ts
+++ b/src/projects/commercial/modules/fronts-banner-adverts.ts
@@ -25,6 +25,13 @@ const insertAdvertAboveSection = async (section: string, advertNum: number) => {
 
 		const adContainer = document.createElement('div');
 		adContainer.className = 'ad-slot-container fronts-banner-container';
+
+		// To distinguish between the variant and control in the page view table. Following the AB test advice given here:
+		// https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md#getting-the-results
+		if (section === 'opinion') {
+			adContainer.dataset.component = 'opinion-banner-ad';
+		}
+
 		adContainer.appendChild(ad);
 
 		const slotTargeting = {


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Add data attribute to opinion banner ad container

## Why?

So we can get results from the AB test: https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md#getting-the-results
