### PR TITLE
chore!: bump consent-management-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
 	},
 	"dependencies": {
 		"@guardian/ab-core": "^4.0.0",
-		"@guardian/consent-management-platform": "^13.0.2",
+		"@guardian/consent-management-platform": "^13.2.0",
 		"@guardian/core-web-vitals": "^4.0.0",
 		"@guardian/libs": "^14.0.0",
 		"@guardian/source-foundations": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1288,10 +1288,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-4.0.0.tgz#50c1fc076437e594b367f6e8d9469a3d9b97a78e"
   integrity sha512-l6Ot/anisLKyoLZOp8koW7Ia5JFOtmZkB0sfgdWajv5+N0w0UScUVoImEdPlFstM1anSd3FvV8D3UgYkRzAang==
 
-"@guardian/consent-management-platform@^13.0.2":
-  version "13.0.2"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.0.2.tgz#3625f10ca355e1f0296f17fbf8eee3fffd693b95"
-  integrity sha512-rhuDQeZW//WJue9Uhj5JgWc7juV18CgwpOJXcmzYUkYcvi1wcf+kW/BvqfJjNjyd/kpx5eNQ2pCZtj4HuTQBEA==
+"@guardian/consent-management-platform@^13.2.0":
+  version "13.2.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.2.0.tgz#089dcd6b3b7883e281d8764ac7557d1a3a627ae5"
+  integrity sha512-1ggVotJaJad2k7w1QAKffnxSRigEiU1ztWNxu0SncNvnsF90BJ8wMCTECsyp/xMhJFIm1DSVJyIucBzzc7VYRg==
 
 "@guardian/core-web-vitals@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
## What does this change?

Bumps the @guardian/consent-management-platform to version 13.2.0 which includes a deny list and associated code to remove any outstanding non-essential 1st party cookies and local storage when a reader changes their consent towards reject-all from a different consent.

Release notes: https://github.com/guardian/consent-management-platform/releases/tag/v13.2.0 

## Why?

This is the first step of the cookie remediation project to improve our processes.