### PR TITLE
fix: Revert "fix: build dev & prod by default"

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"main": "dist/cjs/core/index.js",
 	"module": "dist/esm/core/index.js",
 	"scripts": {
-		"build": "npm-run-all clean --parallel compile:core:* build:prod build:dev",
+		"build": "npm-run-all clean --parallel compile:core:* build:prod",
 		"build:dev": "webpack -c webpack.config.dev.js",
 		"build:prod": "webpack -c webpack.config.prod.js",
 		"clean": "rm -rf dist",


### PR DESCRIPTION
Reverts guardian/commercial#886 remove the dev build from the package for now, causing issues with the URL hash on frontend