### PR TITLE
Configure Prebid on fronts banner ads

### DIFF
--- a/.changeset/tidy-eyes-grab.md
+++ b/.changeset/tidy-eyes-grab.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Enable Prebid for fronts-banner-ads. Configure prebid vendors so that correct size is used for these slots.

--- a/src/projects/commercial/modules/header-bidding/prebid-types.ts
+++ b/src/projects/commercial/modules/header-bidding/prebid-types.ts
@@ -93,9 +93,13 @@ export type PrebidAdYouLikeParams = {
 	placement: string;
 };
 
-export type PrebidCriteoParams = {
-	networkId: number;
-};
+export type PrebidCriteoParams =
+	| {
+			networkId: number;
+	  }
+	| {
+			zoneId: number;
+	  };
 
 export type PrebidSmartParams = {
 	siteId: number;

--- a/src/projects/commercial/modules/header-bidding/prebid-types.ts
+++ b/src/projects/commercial/modules/header-bidding/prebid-types.ts
@@ -47,6 +47,7 @@ export type PrebidSonobiParams = {
 export type PrebidPubmaticParams = {
 	publisherId: string;
 	adSlot: string;
+	placementId?: string;
 };
 
 export type PrebidIndexExchangeParams = {

--- a/src/projects/commercial/modules/header-bidding/prebid/appnexus.ts
+++ b/src/projects/commercial/modules/header-bidding/prebid/appnexus.ts
@@ -3,6 +3,7 @@ import { buildAppNexusTargetingObject } from '../../../../common/modules/commerc
 import { isInAuOrNz } from '../../../../common/modules/commercial/geo-utils';
 import type { HeaderBiddingSize } from '../prebid-types';
 import {
+	containsBillboardNotLeaderboard,
 	containsLeaderboard,
 	containsLeaderboardOrBillboard,
 	containsMpu,
@@ -36,6 +37,7 @@ const getAppNexusInvCode = (sizes: HeaderBiddingSize[]): string | undefined => {
 
 export const getAppNexusDirectPlacementId = (
 	sizes: HeaderBiddingSize[],
+	isInFrontsBannerVariant: boolean,
 ): string => {
 	if (isInAuOrNz()) {
 		return '11016434';
@@ -44,6 +46,13 @@ export const getAppNexusDirectPlacementId = (
 	const defaultPlacementId = '9251752';
 	switch (getBreakpointKey()) {
 		case 'D':
+			if (isInFrontsBannerVariant) {
+				// The only prebid compatible size for fronts-banner-ads is the billboard (970x250)
+				// This check is to distinguish from the top-above-nav which includes a leaderboard
+				if (containsBillboardNotLeaderboard(sizes)) {
+					return '30017511';
+				}
+			}
 			if (containsMpuOrDmpu(sizes)) {
 				return '9251752';
 			}
@@ -72,6 +81,7 @@ export const getAppNexusDirectPlacementId = (
 export const getAppNexusDirectBidParams = (
 	sizes: HeaderBiddingSize[],
 	pageTargeting: PageTargeting,
+	isInFrontsBannerVariant: boolean,
 ): AppNexusDirectBidParams => {
 	if (isInAuOrNz() && window.guardian.config.switches.prebidAppnexusInvcode) {
 		const invCode = getAppNexusInvCode(sizes);
@@ -87,7 +97,10 @@ export const getAppNexusDirectBidParams = (
 		}
 	}
 	return {
-		placementId: getAppNexusDirectPlacementId(sizes),
+		placementId: getAppNexusDirectPlacementId(
+			sizes,
+			isInFrontsBannerVariant,
+		),
 		keywords: buildAppNexusTargetingObject(pageTargeting),
 	};
 };

--- a/src/projects/commercial/modules/header-bidding/prebid/bid-config.spec.ts
+++ b/src/projects/commercial/modules/header-bidding/prebid/bid-config.spec.ts
@@ -11,6 +11,7 @@ import { isInVariantSynchronous as isInVariantSynchronous_ } from '../../../../c
 import type { HeaderBiddingSize, PrebidBidder } from '../prebid-types';
 import {
 	containsBillboard as containsBillboard_,
+	containsBillboardNotLeaderboard as containsBillboardNotLeaderboard_,
 	containsDmpu as containsDmpu_,
 	containsLeaderboard as containsLeaderboard_,
 	containsLeaderboardOrBillboard as containsLeaderboardOrBillboard_,
@@ -65,6 +66,8 @@ const containsDmpu = containsDmpu_ as jest.Mock;
 const containsLeaderboard = containsLeaderboard_ as jest.Mock;
 const containsLeaderboardOrBillboard =
 	containsLeaderboardOrBillboard_ as jest.Mock;
+const containsBillboardNotLeaderboard =
+	containsBillboardNotLeaderboard_ as jest.Mock;
 const containsMobileSticky = containsMobileSticky_ as jest.Mock;
 const containsMpu = containsMpu_ as jest.Mock;
 const containsMpuOrDmpu = containsMpuOrDmpu_ as jest.Mock;
@@ -147,6 +150,21 @@ describe('getImprovePlacementId', () => {
 
 	test('should return -1 if no cases match', () => {
 		expect(getImprovePlacementId([createAdSize(1, 2)], false)).toBe(-1);
+	});
+
+	test('should give the expected values when in the fronts banner test in uk on desktop', () => {
+		isInUk.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('D');
+		containsMpuOrDmpu.mockReturnValue(false);
+		containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+		containsBillboardNotLeaderboard.mockReturnValue(true);
+
+		expect(getImprovePlacementId([createAdSize(970, 250)], true)).toEqual(
+			22987847,
+		);
+		expect(getImprovePlacementId([createAdSize(970, 250)], false)).toEqual(
+			1116397,
+		);
 	});
 
 	test('should return the expected values when geolocated in UK and on desktop device', () => {
@@ -341,7 +359,7 @@ describe('indexExchangeBidders', () => {
 			createAdSize(300, 250),
 			createAdSize(300, 600),
 		];
-		const bidders: PrebidBidder[] = indexExchangeBidders(slotSizes);
+		const bidders: PrebidBidder[] = indexExchangeBidders(slotSizes, false);
 		expect(bidders).toEqual([
 			expect.objectContaining<Partial<PrebidBidder>>({
 				name: 'ix',
@@ -361,7 +379,7 @@ describe('indexExchangeBidders', () => {
 			createAdSize(300, 250),
 			createAdSize(300, 600),
 		];
-		const bidders: PrebidBidder[] = indexExchangeBidders(slotSizes);
+		const bidders: PrebidBidder[] = indexExchangeBidders(slotSizes, false);
 		expect(bidders[0].bidParams('type', [createAdSize(1, 2)])).toEqual({
 			siteId: '123456',
 			size: [300, 250],

--- a/src/projects/commercial/modules/header-bidding/prebid/bid-config.spec.ts
+++ b/src/projects/commercial/modules/header-bidding/prebid/bid-config.spec.ts
@@ -30,6 +30,10 @@ import {
 	stripMobileSuffix as stripMobileSuffix_,
 } from '../utils';
 import { _, bids } from './bid-config';
+import {
+	getImprovePlacementId,
+	getImproveSkinPlacementId,
+} from './improve-digital';
 
 const mockPageTargeting = {} as unknown as PageTargeting;
 
@@ -42,8 +46,6 @@ const getBidders = () =>
 
 const {
 	getIndexSiteId,
-	getImprovePlacementId,
-	getImproveSkinPlacementId,
 	getXaxisPlacementId,
 	getTrustXAdUnitId,
 	indexExchangeBidders,
@@ -139,11 +141,12 @@ describe('getImprovePlacementId', () => {
 			[createAdSize(728, 90)],
 			[createAdSize(1, 2)],
 		];
-		return prebidSizes.map(getImprovePlacementId);
+
+		return prebidSizes.map((size) => getImprovePlacementId(size, false));
 	};
 
 	test('should return -1 if no cases match', () => {
-		expect(getImprovePlacementId([createAdSize(1, 2)])).toBe(-1);
+		expect(getImprovePlacementId([createAdSize(1, 2)], false)).toBe(-1);
 	});
 
 	test('should return the expected values when geolocated in UK and on desktop device', () => {
@@ -667,7 +670,7 @@ describe('getXaxisPlacementId', () => {
 	};
 
 	test('should return -1 if no cases match', () => {
-		expect(getImprovePlacementId([createAdSize(1, 2)])).toBe(-1);
+		expect(getImprovePlacementId([createAdSize(1, 2)], false)).toBe(-1);
 	});
 
 	test('should return the expected values for desktop device', () => {

--- a/src/projects/commercial/modules/header-bidding/prebid/bid-config.ts
+++ b/src/projects/commercial/modules/header-bidding/prebid/bid-config.ts
@@ -8,7 +8,6 @@ import {
 } from '../../../../common/modules/commercial/build-page-targeting';
 import {
 	isInAuOrNz,
-	isInRow,
 	isInUk,
 	isInUsa,
 	isInUsOrCa,
@@ -52,9 +51,13 @@ import {
 	shouldUseOzoneAdaptor,
 	stripDfpAdPrefixFrom,
 	stripMobileSuffix,
-	stripTrailingNumbersAbove1,
 } from '../utils';
 import { getAppNexusDirectBidParams } from './appnexus';
+import {
+	getImprovePlacementId,
+	getImproveSizeParam,
+	getImproveSkinPlacementId,
+} from './improve-digital';
 
 const isArticle = window.guardian.config.page.contentType === 'Article';
 
@@ -123,105 +126,6 @@ const getIndexSiteId = (): string => {
 		(s: PrebidIndexSite) => s.bp === getBreakpointKey(),
 	);
 	return site?.id ? site.id.toString() : '';
-};
-
-const getImprovePlacementId = (sizes: HeaderBiddingSize[]): number => {
-	if (isInUk()) {
-		switch (getBreakpointKey()) {
-			case 'D': // Desktop
-				if (containsMpuOrDmpu(sizes)) {
-					return 1116396;
-				}
-				if (containsLeaderboardOrBillboard(sizes)) {
-					return 1116397;
-				}
-				return -1;
-			case 'M': // Mobile
-				if (containsMpuOrDmpu(sizes)) {
-					return 1116400;
-				}
-				return -1;
-			case 'T': // Tablet
-				if (containsMpuOrDmpu(sizes)) {
-					return 1116398;
-				}
-				if (containsLeaderboardOrBillboard(sizes)) {
-					return 1116399;
-				}
-				return -1;
-			default:
-				return -1;
-		}
-	}
-	if (isInRow()) {
-		switch (getBreakpointKey()) {
-			case 'D': // Desktop
-				if (containsMpuOrDmpu(sizes)) {
-					return 1116420;
-				}
-				if (containsLeaderboardOrBillboard(sizes)) {
-					return 1116421;
-				}
-				return -1;
-			case 'M': // Mobile
-				if (containsMpuOrDmpu(sizes)) {
-					return 1116424;
-				}
-				return -1;
-			case 'T': // Tablet
-				if (containsMpuOrDmpu(sizes)) {
-					return 1116422;
-				}
-				if (containsLeaderboardOrBillboard(sizes)) {
-					return 1116423;
-				}
-				return -1;
-			default:
-				return -1;
-		}
-	}
-	return -1;
-};
-
-const getImproveSkinPlacementId = (): number => {
-	if (isInUk()) {
-		switch (getBreakpointKey()) {
-			case 'D': // Desktop
-				return 22526482;
-			default:
-				return -1;
-		}
-	}
-	if (isInRow()) {
-		switch (getBreakpointKey()) {
-			case 'D': // Desktop
-				return 22526483;
-			default:
-				return -1;
-		}
-	}
-	return -1;
-};
-
-// Improve has to have single size as parameter if slot doesn't accept multiple sizes,
-// because it uses same placement ID for multiple slot sizes and has no other size information
-const getImproveSizeParam = (
-	slotId: string,
-): {
-	w?: number;
-	h?: number;
-} => {
-	const key = stripTrailingNumbersAbove1(stripMobileSuffix(slotId));
-	return key &&
-		(key.endsWith('mostpop') ||
-			key.endsWith('comments') ||
-			key.endsWith('inline1') ||
-			(key.endsWith('inline') && !isDesktopAndArticle))
-		? {
-				w: 300,
-				h: 250,
-		  }
-		: {};
 };
 
 const getXaxisPlacementId = (sizes: HeaderBiddingSize[]): number => {
@@ -422,8 +326,8 @@ const improveDigitalBidder: PrebidBidder = {
 		slotId: string,
 		sizes: HeaderBiddingSize[],
 	): PrebidImproveParams => ({
-		placementId: getImprovePlacementId(sizes),
-		size: getImproveSizeParam(slotId),
+		placementId: getImprovePlacementId(sizes, isInFrontsBannerVariant),
+		size: getImproveSizeParam(slotId, isDesktopAndArticle),
 	}),
 };
 
@@ -585,8 +489,6 @@ export const bids = (
 
 export const _ = {
 	getIndexSiteId,
-	getImprovePlacementId,
-	getImproveSkinPlacementId,
 	getXaxisPlacementId,
 	getTrustXAdUnitId,
 	indexExchangeBidders,

--- a/src/projects/commercial/modules/header-bidding/prebid/bid-config.ts
+++ b/src/projects/commercial/modules/header-bidding/prebid/bid-config.ts
@@ -417,9 +417,10 @@ const smartBidder: PrebidBidder = {
 // There's an IX bidder for every size that the slot can take
 const indexExchangeBidders = (
 	slotSizes: HeaderBiddingSize[],
+	isInVariant: boolean,
 ): PrebidBidder[] => {
 	let indexSiteId = getIndexSiteId();
-	if (isInFrontsBannerVariant) {
+	if (isInVariant) {
 		// The only prebid compatible size for fronts-banner-ads is the billboard (970x250)
 		// This check is to distinguish from the top-above-nav slot, which includes a leaderboard
 		if (containsBillboardNotLeaderboard(slotSizes)) {
@@ -471,7 +472,10 @@ const currentBidders = (
 		.filter(([shouldInclude]) => inPbTestOr(shouldInclude))
 		.map(([, bidder]) => bidder);
 
-	const allBidders = indexExchangeBidders(slotSizes).concat(otherBidders);
+	const allBidders = indexExchangeBidders(
+		slotSizes,
+		isInFrontsBannerVariant,
+	).concat(otherBidders);
 	return isPbTestOn()
 		? biddersBeingTested(allBidders)
 		: biddersSwitchedOn(allBidders);

--- a/src/projects/commercial/modules/header-bidding/prebid/bid-config.ts
+++ b/src/projects/commercial/modules/header-bidding/prebid/bid-config.ts
@@ -417,10 +417,10 @@ const smartBidder: PrebidBidder = {
 // There's an IX bidder for every size that the slot can take
 const indexExchangeBidders = (
 	slotSizes: HeaderBiddingSize[],
-	isInVariant: boolean,
+	isInFrontsBannerVariant: boolean,
 ): PrebidBidder[] => {
 	let indexSiteId = getIndexSiteId();
-	if (isInVariant) {
+	if (isInFrontsBannerVariant) {
 		// The only prebid compatible size for fronts-banner-ads is the billboard (970x250)
 		// This check is to distinguish from the top-above-nav slot, which includes a leaderboard
 		if (containsBillboardNotLeaderboard(slotSizes)) {

--- a/src/projects/commercial/modules/header-bidding/prebid/improve-digital.ts
+++ b/src/projects/commercial/modules/header-bidding/prebid/improve-digital.ts
@@ -1,0 +1,129 @@
+import {
+	isInRow,
+	isInUk,
+} from '../../../../common/modules/commercial/geo-utils';
+import type { HeaderBiddingSize } from '../prebid-types';
+import {
+	containsBillboardNotLeaderboard,
+	containsLeaderboardOrBillboard,
+	containsMpuOrDmpu,
+	getBreakpointKey,
+	stripMobileSuffix,
+	stripTrailingNumbersAbove1,
+} from '../utils';
+
+const getImprovePlacementId = (
+	sizes: HeaderBiddingSize[],
+	isInFrontsBannerVariant: boolean,
+): number => {
+	if (isInUk()) {
+		switch (getBreakpointKey()) {
+			case 'D': // Desktop
+				if (isInFrontsBannerVariant) {
+					// The only prebid compatible size for fronts-banner-ads is the billboard (970x250)
+					// This check is to distinguish from the top-above-nav which includes a leaderboard
+					if (containsBillboardNotLeaderboard(sizes)) {
+						return 22987847;
+					}
+				}
+				if (containsMpuOrDmpu(sizes)) {
+					return 1116396;
+				}
+				if (containsLeaderboardOrBillboard(sizes)) {
+					return 1116397;
+				}
+				return -1;
+			case 'M': // Mobile
+				if (containsMpuOrDmpu(sizes)) {
+					return 1116400;
+				}
+				return -1;
+			case 'T': // Tablet
+				if (containsMpuOrDmpu(sizes)) {
+					return 1116398;
+				}
+				if (containsLeaderboardOrBillboard(sizes)) {
+					return 1116399;
+				}
+				return -1;
+			default:
+				return -1;
+		}
+	}
+	if (isInRow()) {
+		switch (getBreakpointKey()) {
+			case 'D': // Desktop
+				if (containsMpuOrDmpu(sizes)) {
+					return 1116420;
+				}
+				if (containsLeaderboardOrBillboard(sizes)) {
+					return 1116421;
+				}
+				return -1;
+			case 'M': // Mobile
+				if (containsMpuOrDmpu(sizes)) {
+					return 1116424;
+				}
+				return -1;
+			case 'T': // Tablet
+				if (containsMpuOrDmpu(sizes)) {
+					return 1116422;
+				}
+				if (containsLeaderboardOrBillboard(sizes)) {
+					return 1116423;
+				}
+				return -1;
+			default:
+				return -1;
+		}
+	}
+	return -1;
+};
+
+const getImproveSkinPlacementId = (): number => {
+	if (isInUk()) {
+		switch (getBreakpointKey()) {
+			case 'D': // Desktop
+				return 22526482;
+			default:
+				return -1;
+		}
+	}
+	if (isInRow()) {
+		switch (getBreakpointKey()) {
+			case 'D': // Desktop
+				return 22526483;
+			default:
+				return -1;
+		}
+	}
+	return -1;
+};
+
+// Improve has to have single size as parameter if slot doesn't accept multiple sizes,
+// because it uses same placement ID for multiple slot sizes and has no other size information
+const getImproveSizeParam = (
+	slotId: string,
+	isDesktopAndArticle: boolean,
+): {
+	w?: number;
+	h?: number;
+} => {
+	const key = stripTrailingNumbersAbove1(stripMobileSuffix(slotId));
+	return key &&
+		(key.endsWith('mostpop') ||
+			key.endsWith('comments') ||
+			key.endsWith('inline1') ||
+			(key.endsWith('inline') && !isDesktopAndArticle))
+		? {
+				w: 300,
+				h: 250,
+		  }
+		: {};
+};
+
+export {
+	getImprovePlacementId,
+	getImproveSkinPlacementId,
+	getImproveSizeParam,
+};

--- a/src/projects/commercial/modules/header-bidding/slot-config.ts
+++ b/src/projects/commercial/modules/header-bidding/slot-config.ts
@@ -62,6 +62,10 @@ const getHeaderBiddingKey = (
 		return 'inline';
 	}
 
+	if (name?.includes('fronts-banner')) {
+		return 'fronts-banner';
+	}
+
 	return undefined;
 };
 
@@ -199,6 +203,7 @@ export const getHeaderBiddingAdSlots = (
 ): HeaderBiddingSlot[] => {
 	const breakpoint = getHbBreakpoint();
 	const headerBiddingSlots = filterByAdvert(ad, breakpoint, getSlots());
+
 	return headerBiddingSlots
 		.map(filterBySizeMapping(ad.sizes[breakpoint]))
 		.map(slotFlatMap)

--- a/src/projects/commercial/modules/header-bidding/utils.ts
+++ b/src/projects/commercial/modules/header-bidding/utils.ts
@@ -84,6 +84,10 @@ export const containsLeaderboard = (sizes: HeaderBiddingSize[]): boolean =>
 export const containsBillboard = (sizes: HeaderBiddingSize[]): boolean =>
 	contains(sizes, createAdSize(970, 250));
 
+export const containsBillboardNotLeaderboard = (
+	sizes: HeaderBiddingSize[],
+): boolean => containsBillboard(sizes) && !containsLeaderboard(sizes);
+
 export const containsMpuOrDmpu = (sizes: HeaderBiddingSize[]): boolean =>
 	containsMpu(sizes) || containsDmpu(sizes);
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

- Fixes a bug that enables prebid to be run on fronts banner ads.
- Configures the following vendors to be able to identify and bid on fronts-banner-ads: Improve; Pubmatic; Appnexus; Index; Smart; Criteo.

## Why?

So that we can run header-bidding on the fronts banner ads