### PR TITLE
build both dev and prod to subdirectories in the dist folder

### DIFF
--- a/.changeset/witty-pianos-give.md
+++ b/.changeset/witty-pianos-give.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': major
+---
+
+Move built bundle files to `prod` and `dev` subdirectories in the dist folder and have both in npm, so they can both be used, this is a breaking change as the path to the files/entrypoints will change.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"main": "dist/cjs/core/index.js",
 	"module": "dist/esm/core/index.js",
 	"scripts": {
-		"build": "npm-run-all clean --parallel compile:core:* build:prod",
+		"build": "npm-run-all clean --parallel compile:core:* build:prod build:dev",
 		"build:dev": "webpack -c webpack.config.dev.js",
 		"build:prod": "webpack -c webpack.config.prod.js",
 		"clean": "rm -rf dist",

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack');
 const webpackMerge = require('webpack-merge');
 const config = require('./webpack.config.js');
+const path = require('path');
 
 const port = 3031;
 const overrideBundlePath = `http://localhost:${port}/`;
@@ -13,6 +14,8 @@ module.exports = webpackMerge.smart(config, {
 	output: {
 		filename: `graun.standalone.commercial.js`,
 		chunkFilename: `graun.[name].commercial.js`,
+		path: path.join(__dirname, 'dist', 'bundle', 'dev'),
+		clean: true,
 	},
 	plugins: shouldOverrideBundle
 		? [

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -4,13 +4,15 @@ const BundleAnalyzerPlugin =
 	require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const config = require('./webpack.config.js');
 const TerserPlugin = require('terser-webpack-plugin');
+const path = require('path');
 
 module.exports = webpackMerge.smart(config, {
 	mode: 'production',
 	output: {
 		filename: `[chunkhash]/graun.standalone.commercial.js`,
 		chunkFilename: `[chunkhash]/graun.[name].commercial.js`,
-		clean: false,
+		path: path.join(__dirname, 'dist', 'bundle', 'prod'),
+		clean: true,
 	},
 	devtool: 'source-map',
 	plugins: [


### PR DESCRIPTION
## What does this change?
Move built bundle files to `prod` and `dev` subdirectories in the dist/bundle folder and have both in npm, so they can both be used, this is a breaking change as the path to the files/entrypoints will change.

## Why?
frontend when running locally wants the unhashed files to be available, webpack bakes in the hashes for chunks like prebid and consentless so we need to provide a build without them.