### PR TITLE
Increase inline merch test participation to 20%

### DIFF
--- a/.changeset/empty-squids-guess.md
+++ b/.changeset/empty-squids-guess.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Increase inline merch AB test audience size to 20%

--- a/src/projects/common/modules/experiments/tests/limit-inline-merch.ts
+++ b/src/projects/common/modules/experiments/tests/limit-inline-merch.ts
@@ -7,7 +7,7 @@ export const limitInlineMerch: ABTest = {
 	author: '@chrislomaxjones',
 	description:
 		'Test the impact of limiting the eligibility of inline merchandising ad slots',
-	audience: 10 / 100,
+	audience: 20 / 100,
 	audienceOffset: 40 / 100,
 	audienceCriteria:
 		'Article pages eligible for rendering an inline merchandising ad slot',


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure your title is prefixed with one of these:

- fix: (patch release)
- feat: (minor release)

These can be used but will not trigger a release:

build: | chore: | ci: | docs: | style: | refactor: | perf: | test:

To trigger a major release, add ! to the prefix. Any prefix can do this, e.g.:

- refactor!: drop support for Node 6
- fix!: remove old conflicting method

-->

## What does this change?

Increase the audience size for the inline merch AB test to 20% (that's 10% in the variant and 10% in the control).

## Why?

We've seen lower traffic than expected in this test, most likely due to how current marketing campaigns are setup (the number of eligible pages is dependent on the campaigns running, so if we don't have many campaigns, or don't target popular keywords, then we'll get less traffic). To reach significance sooner, we'll increase the audience size.
