### PR TITLE
Enhance sendBeacon testing

### DIFF
--- a/src/bootstraps/standalone.commercial.ts
+++ b/src/bootstraps/standalone.commercial.ts
@@ -182,8 +182,8 @@ const bootCommercial = async (): Promise<void> => {
 	const shouldTestBeacon = Math.random() <= 1 / 10000;
 	if (shouldTestBeacon) {
 		amIUsed(
-			'spacefinder.ts',
-			'isIframeLoaded',
+			'standalone.commercial.ts',
+			'bootCommercial',
 			{ userAgent: navigator.userAgent },
 			1,
 		);

--- a/src/bootstraps/standalone.commercial.ts
+++ b/src/bootstraps/standalone.commercial.ts
@@ -181,7 +181,12 @@ const bootCommercial = async (): Promise<void> => {
 	//this will be removed when we have enough data
 	const shouldTestBeacon = Math.random() <= 1 / 10000;
 	if (shouldTestBeacon) {
-		amIUsed('spacefinder.ts', 'isIframeLoaded', undefined, 1);
+		amIUsed(
+			'spacefinder.ts',
+			'isIframeLoaded',
+			{ userAgent: navigator.userAgent },
+			1,
+		);
 	}
 
 	// Init Commercial event timers

--- a/src/bootstraps/standalone.commercial.ts
+++ b/src/bootstraps/standalone.commercial.ts
@@ -18,6 +18,7 @@ import {
 } from '@guardian/consent-management-platform';
 import { log } from '@guardian/libs';
 import { EventTimer } from 'core/event-timer';
+import { amIUsed } from 'projects/commercial/am-i-used';
 import { reportError } from '../lib/report-error';
 import { catchErrorsWithContext } from '../lib/robust';
 import { initAdblockAsk } from '../projects/commercial/adblock-ask';
@@ -175,6 +176,13 @@ const recordCommercialMetrics = () => {
 
 const bootCommercial = async (): Promise<void> => {
 	log('commercial', '📦 standalone.commercial.ts', __webpack_public_path__);
+
+	//adding an amiused call for a very small proportion of users to test sendBeacon vs fetch
+	//this will be removed when we have enough data
+	const shouldTestBeacon = Math.random() <= 1 / 10000;
+	if (shouldTestBeacon) {
+		amIUsed('spacefinder.ts', 'isIframeLoaded', undefined, 1);
+	}
 
 	// Init Commercial event timers
 	EventTimer.init();

--- a/src/projects/commercial/am-i-used.spec.ts
+++ b/src/projects/commercial/am-i-used.spec.ts
@@ -27,14 +27,14 @@ describe('amIUsed', () => {
 
 	test('should send an event when switches.sentinelLogger is true', () => {
 		window.guardian.config.switches.sentinelLogger = true;
-		amIUsed('moduleName', 'functionName', undefined, 0);
+		amIUsed('moduleName', 'functionName');
 		expect(navigator.sendBeacon).toHaveBeenCalledTimes(1);
 	});
 
 	test('should use the correct logging CODE endpoint', () => {
 		window.guardian.config.switches.sentinelLogger = true;
 		window.guardian.config.page.isDev = true;
-		amIUsed('moduleName', 'functionName', undefined, 0);
+		amIUsed('moduleName', 'functionName');
 		expect(navigator.sendBeacon).toHaveBeenCalledWith(
 			CODE_ENDPOINT,
 			expect.any(String),
@@ -44,7 +44,7 @@ describe('amIUsed', () => {
 	test('should use the correct logging DEV endpoint', () => {
 		window.guardian.config.switches.sentinelLogger = true;
 		window.guardian.config.page.isDev = false;
-		amIUsed('moduleName', 'functionName', undefined, 0);
+		amIUsed('moduleName', 'functionName');
 		expect(navigator.sendBeacon).toHaveBeenCalledWith(
 			PROD_ENDPOINT,
 			expect.any(String),
@@ -54,7 +54,7 @@ describe('amIUsed', () => {
 	test('should not attach any extra properties if the property parameter is not passed', () => {
 		window.guardian.config.switches.sentinelLogger = true;
 		window.guardian.config.page.isDev = true;
-		amIUsed('moduleName', 'functionName', undefined, 0);
+		amIUsed('moduleName', 'functionName');
 		expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
 			[
 				CODE_ENDPOINT,
@@ -73,7 +73,7 @@ describe('amIUsed', () => {
 	test('should attach extra properties if they are passed as a parameter', () => {
 		window.guardian.config.switches.sentinelLogger = true;
 		window.guardian.config.page.isDev = true;
-		amIUsed('moduleName', 'functionName', { comment: 'test' }, 0);
+		amIUsed('moduleName', 'functionName', { comment: 'test' });
 		expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
 			[
 				CODE_ENDPOINT,
@@ -93,15 +93,10 @@ describe('amIUsed', () => {
 	test('should chain optional parameters to the properties array', () => {
 		window.guardian.config.switches.sentinelLogger = true;
 		window.guardian.config.page.isDev = true;
-		amIUsed(
-			'moduleName',
-			'functionName',
-			{
-				conditionA: 'true',
-				conditionB: 'false',
-			},
-			0,
-		);
+		amIUsed('moduleName', 'functionName', {
+			conditionA: 'true',
+			conditionB: 'false',
+		});
 		expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
 			[
 				CODE_ENDPOINT,
@@ -122,7 +117,7 @@ describe('amIUsed', () => {
 	test('should correctly assign commercial.amiused as a label', () => {
 		window.guardian.config.switches.sentinelLogger = true;
 		window.guardian.config.page.isDev = true;
-		amIUsed('moduleName', 'functionName', undefined, 0);
+		amIUsed('moduleName', 'functionName');
 		expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
 			[
 				CODE_ENDPOINT,

--- a/src/projects/commercial/am-i-used.ts
+++ b/src/projects/commercial/am-i-used.ts
@@ -28,7 +28,7 @@ const amIUsed = (
 	parameters?: Partial<
 		Record<string, string> & Record<RestrictedKeys, never>
 	>,
-	sampling: number = 1 / 100,
+	sampling = 0,
 ): void => {
 	// The function will return early if the sentinelLogger switch is disabled.
 	if (!window.guardian.config.switches.sentinelLogger) return;

--- a/src/projects/commercial/am-i-used.ts
+++ b/src/projects/commercial/am-i-used.ts
@@ -56,6 +56,9 @@ const amIUsed = (
 			: properties,
 	};
 
+	//The code below is for testing the reliability of the sendBeacon method compared to fetch
+	//There is a possibility that sendBeacon may not be as reliable as we think: https://volument.com/blog/sendbeacon-is-broken
+
 	const shouldTestBeacon = Math.random() <= sampling;
 
 	if (shouldTestBeacon) {


### PR DESCRIPTION
## What does this change?
- Set default sendBeacon test sampling rate to zero, and update the function test file to reflect that
- Call amiused in the bootCommercial function for 0.01% of cases, to test the reliability of sendBeacon vs fetch
- Send the UserAgent details in the amiused testing logs

## Why?
We will no longer use the actual amiused call (in spacefinder.ts) to test the reliability of sendBeacon vs fetch. This is because we don't know if there might be bias in the situations in which this function is called, perhaps in the browsers or different user setups, and this could lead to bias in our results. Instead, we will call amiused 0.01% of the times that the bootCommercial function in the standalone file runs. We know this script should run for all users who see google ads, and this should give us a more reliable sample of users.

We're setting the sampling for this test to 1 in 10,000 users (0.01%) to start, and will increase or decrease if we're not satisfied with the test numbers that we have coming through.

We are also going to include the UserAgent details in the test calls, so that we can spot any potential patterns between browsers and the respective reliability of sendBeacon vs fetch.

Our data comes through in BigQuery containing the user agent details and a label showing which method was used to send the data:
<img width="1140" alt="Screenshot 2023-06-15 at 15 59 04" src="https://github.com/guardian/commercial/assets/108270776/de577680-6ff4-4711-9ae4-d33ba283f9a6">
