### PR TITLE
Try updating reference to Github API to fix beta release version comments

### DIFF
--- a/.changeset/kind-tables-build.md
+++ b/.changeset/kind-tables-build.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Update beta release workflow command

--- a/.github/workflows/beta-release-on-label.yml
+++ b/.github/workflows/beta-release-on-label.yml
@@ -60,7 +60,7 @@ jobs:
           script: |
             const publishedPackages = ${{ steps.changeset.outputs.publishedPackages }};
             const version = publishedPackages[0].version;
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## What does this change?
Updates the reference to the Github API in the beta release workflow.

## Why?
This is so that the beta release flow can comment the version on pull requests. The previous way was deprecated and was causing errors when creating beta releases.