### PR TITLE
fix github-script in label beta release workflow

### DIFF
--- a/.github/workflows/beta-release-on-label.yml
+++ b/.github/workflows/beta-release-on-label.yml
@@ -60,7 +60,7 @@ jobs:
           script: |
             const publishedPackages = ${{ steps.changeset.outputs.publishedPackages }};
             const version = publishedPackages[0].version;
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## What does this change?
This was a [breaking change](https://github.com/actions/github-script#breaking-changes-in-v5) that I didn't notice when upgrading github-script to v6
