### PR TITLE
Document meaning of “properties” and “metric” and prepare automatic sorting based on data type 

### DIFF
--- a/.changeset/late-ants-relate.md
+++ b/.changeset/late-ants-relate.md
@@ -1,0 +1,8 @@
+---
+'@guardian/commercial': minor
+---
+
+Automatically sort data based on it’s type.
+
+- `number` will be sent as `metrics` (and as string for legacy data analysis)
+- `string` will be sent as `properties`

--- a/src/core/event-timer.ts
+++ b/src/core/event-timer.ts
@@ -251,3 +251,4 @@ class EventTimer {
 }
 
 export { EventTimer };
+export type { EventTimerProperties };

--- a/src/core/send-commercial-metrics.spec.ts
+++ b/src/core/send-commercial-metrics.spec.ts
@@ -12,7 +12,7 @@ const {
 	mapEventTimerPropertiesToString,
 	reset,
 	roundTimeStamp,
-	transformToObjectEntries,
+	transformObjectToData,
 } = _;
 
 jest.mock('@guardian/consent-management-platform');
@@ -582,7 +582,6 @@ describe('send commercial metrics', () => {
 					Endpoints.PROD,
 					JSON.stringify({
 						...defaultMetrics,
-						metrics: [],
 					}),
 				],
 			]);
@@ -593,34 +592,27 @@ describe('send commercial metrics', () => {
 describe('send commercial metrics helpers', () => {
 	it('can transform event timer properties into object entries', () => {
 		expect(
-			transformToObjectEntries({
+			transformObjectToData({
 				type: undefined,
 				downlink: 1,
 				effectiveType: '4g',
 			}),
-		).toEqual([
-			['type', undefined],
-			['downlink', 1],
-			['effectiveType', '4g'],
-		]);
+		).toEqual({
+			metrics: [{ name: 'downlink', value: 1 }],
+			properties: [{ name: 'effectiveType', value: '4g' }],
+		});
 	});
 
 	it('can map event timer properties to the required format', () => {
 		expect(
-			mapEventTimerPropertiesToString([
-				['downlink', 1],
-				['effectiveType', '4g'],
-			]),
-		).toEqual([
-			{
-				name: 'downlink',
-				value: '1',
-			},
-			{
-				name: 'effectiveType',
-				value: '4g',
-			},
-		]);
+			mapEventTimerPropertiesToString({
+				downlink: 1,
+				effectiveType: '4g',
+			}),
+		).toEqual({
+			downlink: '1',
+			effectiveType: '4g',
+		});
 	});
 
 	it('can round up the value of timestamps', () => {


### PR DESCRIPTION
## What does this change?

Automatically sort `EventTimer` keys:
- **`properties`**: `string` or categorical to describe qualitative data
- **`metrics`**: `number` or numerical to describe quantitative data

Keep legacy data around to prevent a breaking change.

### Metrics

For numerical data of type `number`.
Anything that can be measured discretely or continuously:
- size of element
- number of elements
- duration of event
- occurrences of event

See [Quantitative Data](https://en.wikibooks.org/wiki/Statistics/Different_Types_of_Data/Quantitative_and_Qualitative_Data#Quantitative_data) on wiki.

```ts
const data: Metric[] = [
	{ name: "time on page", value: 10_320 },
	{ name: "height of banner", value: 360 },
	{ name: "cumulative layout shift", value: 0.0625 },
];
```

### Properties

For categorical data of type `string`.

Anything that can be identified with distinct labels:
- edition
- host name
- name of element
- type of connection

See [Qualitative Data](https://en.wikibooks.org/wiki/Statistics/Different_Types_of_Data/Quantitative_and_Qualitative_Data#Qualitative_data) on wiki.

```ts
const data: Property[] = [
	{ name: "edition", value: "UK" },
	{ name: "content ID", value: "/2023/feb/23/…" },
	{ name: "connection type", value: "4g" },
]
```

## Why?

The distinction between “properties” and “metrics” is confusing:
- the file is called “metrics”, but deals with both types
- event “properties” can be `number` (numerical) or `string` (categorical) but currently are only recorded as strings
- data transformation is required in our warehouse to convert some types because of the current confusion
  - following, #773 we struggled to find the data because it was not where we expected it
  
This is a rework of #798 