### PR TITLE
Use head of guardian/prebid.js fork

### DIFF
--- a/.changeset/hot-lemons-hug.md
+++ b/.changeset/hot-lemons-hug.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Use guardian prebid fork head

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",
 		"ophan-tracker-js": "^1.4.0",
-		"prebid.js": "guardian/prebid.js#2e3b96d",
+		"prebid.js": "guardian/prebid.js",
 		"process": "^0.11.10",
 		"raven-js": "^3.27.2",
 		"tslib": "^2.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6944,7 +6944,7 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-prebid.js@guardian/prebid.js#2e3b96d:
+prebid.js@guardian/prebid.js:
   version "7.26.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
   dependencies:


### PR DESCRIPTION
## What does this change?

We are seeing the prebid.js entry in yarn lockfiles intermittently switch to a format that causes issues for snyk in DCR and Frontend e.g.:

https://github.com/guardian/dotcom-rendering/pull/8049
https://github.com/guardian/frontend/pull/25995
https://github.com/guardian/frontend/pull/25947

Good: `"prebid.js@github:guardian/prebid.js#2e3b96d":`
Bad: `prebid.js@guardian/prebid.js#2e3b96d:`

Instead of referencing a commit we can just use head of [guardian/prebid.js](https://github.com/guardian/prebid.js) which _might_ mean a consistent lockfile format and snyk is happier with.

ps. I am sure there were 'reasons' to use commit hashes as part of the dependency that I struggle to recall now. But I think using head should be okay as long as we know that merges into the fork main will immediately be picked up by consumers.
