### PR TITLE
Remove usage of mobileStickyLeaderboard and mobileStickyPrebid switches

### DIFF
--- a/.changeset/twenty-numbers-dress.md
+++ b/.changeset/twenty-numbers-dress.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+remove usage of mobileStickyLeaderboard and mobileStickyPrebid switches

--- a/src/lib/header-bidding/slot-config.spec.ts
+++ b/src/lib/header-bidding/slot-config.spec.ts
@@ -115,7 +115,6 @@ describe('getPrebidAdSlots', () => {
 
 	test('should return the correct mobile-sticky slot at breakpoint M', () => {
 		(getBreakpointKey as jest.Mock).mockReturnValue('M');
-		window.guardian.config.switches.mobileStickyPrebid = true;
 		(shouldIncludeMobileSticky as jest.Mock).mockReturnValue(true);
 		expect(
 			getHeaderBiddingAdSlots(

--- a/src/lib/header-bidding/slot-config.ts
+++ b/src/lib/header-bidding/slot-config.ts
@@ -184,11 +184,7 @@ const getSlots = (): HeaderBiddingSizeMapping => {
 			],
 		},
 		'mobile-sticky': {
-			mobile:
-				shouldIncludeMobileSticky() &&
-				window.guardian.config.switches.mobileStickyPrebid
-					? [adSizes.mobilesticky]
-					: [],
+			mobile: shouldIncludeMobileSticky() ? [adSizes.mobilesticky] : [],
 		},
 		'crossword-banner': {
 			desktop: isCrossword ? [adSizes.leaderboard] : [],

--- a/src/lib/header-bidding/utils.spec.ts
+++ b/src/lib/header-bidding/utils.spec.ts
@@ -346,9 +346,9 @@ describe('Utils', () => {
 	const regions: CountryCode[] = ['US', 'CA', 'AU', 'NZ'];
 
 	regions.forEach((region) => {
-		test(`should include mobile sticky if geolocation is ${region}, switch is ON and content is Article on mobiles`, () => {
+		test(`should include mobile sticky if geolocation is ${region} and content is Article on mobiles`, () => {
 			window.guardian.config.page.contentType = 'Article';
-			window.guardian.config.switches.mobileStickyLeaderboard = true;
+
 			getCountryCode.mockReturnValue(region);
 			matchesBreakpoints.mockReturnValue(true);
 			expect(shouldIncludeMobileSticky()).toBe(true);
@@ -357,16 +357,7 @@ describe('Utils', () => {
 
 	test('shouldIncludeMobileSticky should be false if all conditions true except content type ', () => {
 		window.guardian.config.page.contentType = 'Network Front';
-		window.guardian.config.switches.mobileStickyLeaderboard = true;
 		matchesBreakpoints.mockReturnValue(true);
-		getCountryCode.mockReturnValue('US');
-		expect(shouldIncludeMobileSticky()).toBe(false);
-	});
-
-	test('shouldIncludeMobileSticky should be false if all conditions true except switch', () => {
-		window.guardian.config.page.contentType = 'Article';
-		matchesBreakpoints.mockReturnValue(true);
-		window.guardian.config.switches.mobileStickyLeaderboard = false;
 		getCountryCode.mockReturnValue('US');
 		expect(shouldIncludeMobileSticky()).toBe(false);
 	});
@@ -374,7 +365,6 @@ describe('Utils', () => {
 	test('shouldIncludeMobileSticky should be false if all conditions true except isHosted condition', () => {
 		window.guardian.config.page.contentType = 'Article';
 		matchesBreakpoints.mockReturnValue(true);
-		window.guardian.config.switches.mobileStickyLeaderboard = true;
 		window.guardian.config.page.isHosted = true;
 		getCountryCode.mockReturnValue('US');
 		expect(shouldIncludeMobileSticky()).toBe(false);
@@ -382,7 +372,6 @@ describe('Utils', () => {
 
 	test('shouldIncludeMobileSticky should be false if all conditions true except continent', () => {
 		window.guardian.config.page.contentType = 'Article';
-		window.guardian.config.switches.mobileStickyLeaderboard = true;
 		matchesBreakpoints.mockReturnValue(true);
 		getCountryCode.mockReturnValue('GB');
 		expect(shouldIncludeMobileSticky()).toBe(false);
@@ -390,7 +379,6 @@ describe('Utils', () => {
 
 	test('shouldIncludeMobileSticky should be false if all conditions true except mobile', () => {
 		window.guardian.config.page.contentType = 'Article';
-		window.guardian.config.switches.mobileStickyLeaderboard = true;
 		matchesBreakpoints.mockReturnValue(false);
 		getCountryCode.mockReturnValue('US');
 		expect(shouldIncludeMobileSticky()).toBe(false);
@@ -398,7 +386,6 @@ describe('Utils', () => {
 
 	test('shouldIncludeMobileSticky should be true if test param exists irrespective of other conditions', () => {
 		window.guardian.config.page.contentType = 'Network Front';
-		window.guardian.config.switches.mobileStickyLeaderboard = false;
 		matchesBreakpoints.mockReturnValue(false);
 		getCountryCode.mockReturnValue('US');
 		window.location.hash = '#mobile-sticky';

--- a/src/lib/header-bidding/utils.ts
+++ b/src/lib/header-bidding/utils.ts
@@ -188,11 +188,10 @@ export const shouldIncludeSmart = (): boolean => isInUk() || isInRow();
 export const shouldIncludeMobileSticky = once(
 	(): boolean =>
 		window.location.hash.includes('#mobile-sticky') ||
-		(!!window.guardian.config.switches.mobileStickyLeaderboard &&
-			matchesBreakpoints({
-				min: 'mobile',
-				max: 'mobileLandscape',
-			}) &&
+		(matchesBreakpoints({
+			min: 'mobile',
+			max: 'mobileLandscape',
+		}) &&
 			(isInUsOrCa() || isInAuOrNz()) &&
 			window.guardian.config.page.contentType === 'Article' &&
 			!window.guardian.config.page.isHosted),


### PR DESCRIPTION
## What does this change?
Remove usage of mobileStickyLeaderboard and mobileStickyPrebid switches, mobile sticky (floating ad at the bottom in aus/nz/usa/canada) will now be permanently enabled and require a PR to disable.

## Why?
These have been enabled since their inception and it's been determined the switches are no longer required