### PR TITLE
Cypress tests use containerised DCR

### DIFF
--- a/.github/workflows/e2e-cypress.yml
+++ b/.github/workflows/e2e-cypress.yml
@@ -15,6 +15,15 @@ jobs:
       fail-fast: false
       matrix:
         group: [1, 2, 3, 4, 5]
+    services:
+      DCR:
+        # We always run our commercial code against the latest main of DCR
+        image: ghcr.io/guardian/dotcom-rendering:main
+        ports:
+          - 3030:3030
+        env:
+          PORT: 3030
+          COMMERCIAL_BUNDLE_URL: http://localhost:3031/graun.standalone.commercial.js
     steps:
       # Commercial
       - name: Checkout
@@ -30,35 +39,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
         working-directory: ./commercial
-
-      # DCR
-      - name: Checkout DCR
-        uses: actions/checkout@v3
-        with:
-          repository: guardian/dotcom-rendering
-          path: ./dcr
-
-      - name: Setup DCR node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: './dcr/.nvmrc'
-
-      - name: Install DCR dependencies
-        run: yarn install --frozen-lockfile
-        working-directory: ./dcr
-        env:
-          NODE_ENV: production
-
-      - name: Build DCR
-        run: make build
-        working-directory: ./dcr/dotcom-rendering
-
-      - name: Start DCR server
-        run: make start-ci & npx wait-on -v -i 1000 http://localhost:3030
-        working-directory: ./dcr/dotcom-rendering
-        env:
-          PORT: 3030
-          COMMERCIAL_BUNDLE_URL: http://localhost:3031/graun.standalone.commercial.js
 
       - name: Start Commercial server
         run: yarn serve & npx wait-on -v -i 1000 http://localhost:3031/graun.standalone.commercial.js

--- a/.github/workflows/e2e-cypress.yml
+++ b/.github/workflows/e2e-cypress.yml
@@ -18,6 +18,12 @@ jobs:
     services:
       DCR:
         # We always run our commercial code against the latest main of DCR
+        # This does make our tests sensitive to changes in DCR
+        # (e.g. imagine someone removes the top-above-nav slot from DCR)
+        # This is something we accept in order to easily test our own code
+        #
+        # Note we use the containerised version of DCR, published from:
+        # https://github.com/guardian/dotcom-rendering/blob/6a6df272/.github/workflows/container.yml
         image: ghcr.io/guardian/dotcom-rendering:main
         ports:
           - 3030:3030


### PR DESCRIPTION
## What does this change?

This PR switches our Cypress tests to using DCR as a Github Actions _service_, pulling down and starting a [prebuilt container](https://github.com/guardian/dotcom-rendering/blob/6a6df272/.github/workflows/container.yml).

## Why?

Using a prebuilt container allows us to avoid having to download, install dependencies and build DCR in each concurrency group. This should make our E2E test actions appreciably faster.

The time it takes to prepare DCR for requests before using containers:

![Screenshot 2023-07-04 at 12 40 39](https://github.com/guardian/commercial/assets/8000415/72cdaf6e-cdea-4d38-bf0e-b57acfaa22f5)

The time it takes to prepare the DCR service for accepting requests:

![Screenshot 2023-07-04 at 12 20 36](https://github.com/guardian/commercial/assets/8000415/f93d57f9-136b-401c-9640-f28fb6220a34)

Before:

![Screenshot 2023-07-04 at 12 35 54](https://github.com/guardian/commercial/assets/8000415/1c38d3a5-b82f-4c23-a343-4bb57202a390)

After:

![Screenshot 2023-07-04 at 12 42 23](https://github.com/guardian/commercial/assets/8000415/2ceb9c92-20d4-4e36-b76b-a74dec2b31f8)

