### PR TITLE
Run E2E tests on push to `main`

### DIFF
--- a/.github/workflows/e2e-cypress.yml
+++ b/.github/workflows/e2e-cypress.yml
@@ -1,5 +1,8 @@
 name: E2E Cypress
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
   pull_request:
 


### PR DESCRIPTION
## What does this change?

Run our E2E tests on pushes to the `main` branch.

## Why?

To verify that the main branch is healthy when we merge our pull requests.
