### PR TITLE
Remove `hbImpl`

### DIFF
--- a/.changeset/tough-flowers-listen.md
+++ b/.changeset/tough-flowers-listen.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Remove `hbImpl`.

--- a/src/lib/dfp/dfp-env.ts
+++ b/src/lib/dfp/dfp-env.ts
@@ -6,7 +6,6 @@ const getUrlVars = _getUrlVars as (arg?: string) => Record<string, string>;
 interface DfpEnv {
 	renderStartTime: number;
 	adSlotSelector: string;
-	hbImpl: Record<string, boolean>;
 	lazyLoadEnabled: boolean;
 	lazyLoadObserve: boolean;
 	creativeIDs: string[];
@@ -17,8 +16,6 @@ interface DfpEnv {
 	shouldLazyLoad: () => boolean;
 }
 
-const { switches } = window.guardian.config;
-
 const dfpEnv: DfpEnv = {
 	/* renderStartTime: integer. Point in time when DFP kicks in */
 	renderStartTime: -1,
@@ -26,12 +23,6 @@ const dfpEnv: DfpEnv = {
 	/* adSlotSelector: string. A CSS selector to query ad slots in the DOM */
 	adSlotSelector: '.js-ad-slot',
 
-	/* hbImpl: Returns an object {'prebid': boolean, 'a9': boolean} to indicate which header bidding implementations are switched on */
-	hbImpl: {
-		// TODO: fix the Switch type upstream
-		prebid: switches.prebidHeaderBidding ?? false,
-		a9: switches.a9HeaderBidding ?? false,
-	},
 	/* lazyLoadEnabled: boolean. Set to true when adverts are lazy-loaded */
 	lazyLoadEnabled: false,
 
@@ -69,3 +60,4 @@ window.guardian.commercial = window.guardian.commercial ?? {};
 window.guardian.commercial.dfpEnv = dfpEnv;
 
 export { dfpEnv };
+export type { DfpEnv };

--- a/src/lib/dfp/prepare-a9.spec.ts
+++ b/src/lib/dfp/prepare-a9.spec.ts
@@ -59,7 +59,6 @@ describe('init', () => {
 
 	it('should initialise A9 when A9 switch is ON and advertising is on and ad-free is off', async () => {
 		window.guardian.config.switches = {
-			prebidHeaderBidding: false,
 			a9HeaderBidding: true,
 		};
 		commercialFeatures.dfpAdvertising = true;
@@ -72,7 +71,6 @@ describe('init', () => {
 
 	it('should NOT initialise A9 when in Canada', async () => {
 		window.guardian.config.switches = {
-			prebidHeaderBidding: false,
 			a9HeaderBidding: true,
 		};
 		commercialFeatures.dfpAdvertising = true;
@@ -86,7 +84,6 @@ describe('init', () => {
 
 	it('should initialise A9 when both prebid and a9 switches are ON and advertising is on and ad-free is off', async () => {
 		window.guardian.config.switches = {
-			prebidHeaderBidding: true,
 			a9HeaderBidding: true,
 		};
 		commercialFeatures.dfpAdvertising = true;
@@ -103,7 +100,6 @@ describe('init', () => {
 
 	it('should not initialise A9 when no external demand', async () => {
 		window.guardian.config.switches = {
-			prebidHeaderBidding: false,
 			a9HeaderBidding: false,
 		};
 		await setupA9();
@@ -112,7 +108,6 @@ describe('init', () => {
 
 	it('should not initialise a9 when advertising is switched off', async () => {
 		window.guardian.config.switches = {
-			prebidHeaderBidding: false,
 			a9HeaderBidding: true,
 		};
 		commercialFeatures.dfpAdvertising = false;
@@ -123,7 +118,6 @@ describe('init', () => {
 
 	it('should not initialise a9 when ad-free is on', async () => {
 		window.guardian.config.switches = {
-			prebidHeaderBidding: false,
 			a9HeaderBidding: true,
 		};
 		commercialFeatures.dfpAdvertising = true;
@@ -134,7 +128,6 @@ describe('init', () => {
 
 	it('should not initialise a9 when the page has a pageskin', async () => {
 		window.guardian.config.switches = {
-			prebidHeaderBidding: false,
 			a9HeaderBidding: true,
 		};
 		commercialFeatures.dfpAdvertising = true;
@@ -146,7 +139,6 @@ describe('init', () => {
 
 	it('should initialise a9 when the page has no pageskin', async () => {
 		window.guardian.config.switches = {
-			prebidHeaderBidding: false,
 			a9HeaderBidding: true,
 		};
 		commercialFeatures.dfpAdvertising = true;
@@ -158,7 +150,6 @@ describe('init', () => {
 
 	it('should not initialise a9 on the secure contact pages', async () => {
 		window.guardian.config.switches = {
-			prebidHeaderBidding: false,
 			a9HeaderBidding: true,
 		};
 		commercialFeatures.dfpAdvertising = true;

--- a/src/lib/dfp/prepare-a9.spec.ts
+++ b/src/lib/dfp/prepare-a9.spec.ts
@@ -1,7 +1,6 @@
 import { commercialFeatures } from 'lib/commercial-features';
 import { isInCanada } from 'lib/utils/geo-utils';
 import { a9 } from '../header-bidding/a9/a9';
-import { dfpEnv } from './dfp-env';
 import { _ } from './prepare-a9';
 
 const { setupA9 } = _;
@@ -51,6 +50,7 @@ describe('init', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
 		fakeUserAgent();
+		window.guardian.config.switches = {};
 	});
 
 	afterAll(() => {
@@ -58,7 +58,10 @@ describe('init', () => {
 	});
 
 	it('should initialise A9 when A9 switch is ON and advertising is on and ad-free is off', async () => {
-		dfpEnv.hbImpl = { a9: true, prebid: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: false,
+			a9HeaderBidding: true,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 
@@ -68,7 +71,10 @@ describe('init', () => {
 	});
 
 	it('should NOT initialise A9 when in Canada', async () => {
-		dfpEnv.hbImpl = { a9: true, prebid: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: false,
+			a9HeaderBidding: true,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		(isInCanada as jest.Mock).mockReturnValueOnce(true);
@@ -79,7 +85,10 @@ describe('init', () => {
 	});
 
 	it('should initialise A9 when both prebid and a9 switches are ON and advertising is on and ad-free is off', async () => {
-		dfpEnv.hbImpl = { a9: true, prebid: true };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+			a9HeaderBidding: true,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		await setupA9();
@@ -93,13 +102,19 @@ describe('init', () => {
 	});
 
 	it('should not initialise A9 when no external demand', async () => {
-		dfpEnv.hbImpl = { a9: false, prebid: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: false,
+			a9HeaderBidding: false,
+		};
 		await setupA9();
 		expect(a9.initialise).not.toBeCalled();
 	});
 
 	it('should not initialise a9 when advertising is switched off', async () => {
-		dfpEnv.hbImpl = { a9: true, prebid: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: false,
+			a9HeaderBidding: true,
+		};
 		commercialFeatures.dfpAdvertising = false;
 		commercialFeatures.adFree = false;
 		await setupA9();
@@ -107,7 +122,10 @@ describe('init', () => {
 	});
 
 	it('should not initialise a9 when ad-free is on', async () => {
-		dfpEnv.hbImpl = { a9: true, prebid: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: false,
+			a9HeaderBidding: true,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = true;
 		await setupA9();
@@ -115,7 +133,10 @@ describe('init', () => {
 	});
 
 	it('should not initialise a9 when the page has a pageskin', async () => {
-		dfpEnv.hbImpl = { a9: true, prebid: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: false,
+			a9HeaderBidding: true,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		window.guardian.config.page.hasPageSkin = true;
@@ -124,7 +145,10 @@ describe('init', () => {
 	});
 
 	it('should initialise a9 when the page has no pageskin', async () => {
-		dfpEnv.hbImpl = { a9: true, prebid: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: false,
+			a9HeaderBidding: true,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		window.guardian.config.page.hasPageSkin = false;
@@ -133,7 +157,10 @@ describe('init', () => {
 	});
 
 	it('should not initialise a9 on the secure contact pages', async () => {
-		dfpEnv.hbImpl = { a9: true, prebid: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: false,
+			a9HeaderBidding: true,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		commercialFeatures.isSecureContact = true;

--- a/src/lib/dfp/prepare-a9.ts
+++ b/src/lib/dfp/prepare-a9.ts
@@ -10,13 +10,12 @@ import { isGoogleProxy } from 'lib/detect/detect-google-proxy';
 import { isInCanada } from 'lib/utils/geo-utils';
 import { a9 } from '../header-bidding/a9/a9';
 import { shouldIncludeOnlyA9 } from '../header-bidding/utils';
-import { dfpEnv } from './dfp-env';
 
 const shouldLoadA9 = () =>
 	// There are two articles that InfoSec would like to avoid loading scripts on
 	!commercialFeatures.isSecureContact &&
 	!isGoogleProxy() &&
-	dfpEnv.hbImpl.a9 &&
+	window.guardian.config.switches.a9HeaderBidding &&
 	commercialFeatures.dfpAdvertising &&
 	!commercialFeatures.adFree &&
 	!window.guardian.config.page.hasPageSkin &&

--- a/src/lib/dfp/prepare-googletag.spec.ts
+++ b/src/lib/dfp/prepare-googletag.spec.ts
@@ -191,7 +191,10 @@ const reset = () => {
 	dfpEnv.adverts = [];
 	dfpEnv.advertsToRefresh = [];
 	dfpEnv.advertsToLoad = [];
-	dfpEnv.hbImpl = { prebid: false, a9: false };
+	window.guardian.config.switches = {
+		prebidHeaderBidding: false,
+		a9HeaderBidding: false,
+	};
 };
 
 const tcfv2WithConsent: ConsentState = {

--- a/src/lib/dfp/prepare-prebid.spec.ts
+++ b/src/lib/dfp/prepare-prebid.spec.ts
@@ -8,7 +8,6 @@ import { log } from '@guardian/libs';
 import { commercialFeatures } from 'lib/commercial-features';
 import { isInCanada } from 'lib/utils/geo-utils';
 import { prebid } from '../header-bidding/prebid/prebid';
-import { dfpEnv } from './dfp-env';
 import { _ } from './prepare-prebid';
 
 const { setupPrebid } = _;
@@ -133,12 +132,15 @@ describe('init', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
 		fakeUserAgent();
+		window.guardian.config.switches = {};
 	});
 
 	it('should initialise Prebid when Prebid switch is ON and advertising is on and ad-free is off', async () => {
 		expect.hasAssertions();
-
-		dfpEnv.hbImpl = { prebid: true, a9: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+			a9HeaderBidding: false,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		mockOnConsent(tcfv2WithConsent);
@@ -150,8 +152,10 @@ describe('init', () => {
 
 	it('should not initialise Prebid when useragent is Google Web Preview', async () => {
 		expect.hasAssertions();
-
-		dfpEnv.hbImpl = { prebid: true, a9: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+			a9HeaderBidding: false,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		fakeUserAgent('Google Web Preview');
@@ -167,7 +171,10 @@ describe('init', () => {
 
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
-		dfpEnv.hbImpl = { prebid: false, a9: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: false,
+			a9HeaderBidding: false,
+		};
 		mockOnConsent(tcfv2WithConsent);
 		mockGetConsentFor(true);
 
@@ -178,7 +185,10 @@ describe('init', () => {
 	it('should initialise Prebid when NOT in Canada', async () => {
 		expect.hasAssertions();
 
-		dfpEnv.hbImpl = { prebid: true, a9: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+			a9HeaderBidding: false,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		mockOnConsent(tcfv2WithConsent);
@@ -192,7 +202,10 @@ describe('init', () => {
 	it('should NOT initialise Prebid when in Canada', async () => {
 		expect.hasAssertions();
 
-		dfpEnv.hbImpl = { prebid: true, a9: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+			a9HeaderBidding: false,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		mockOnConsent(tcfv2WithConsent);
@@ -206,7 +219,10 @@ describe('init', () => {
 	it('should not initialise Prebid when advertising is switched off', async () => {
 		expect.hasAssertions();
 
-		dfpEnv.hbImpl = { prebid: true, a9: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+			a9HeaderBidding: false,
+		};
 		commercialFeatures.dfpAdvertising = false;
 		commercialFeatures.adFree = false;
 		mockOnConsent(tcfv2WithConsent);
@@ -219,7 +235,10 @@ describe('init', () => {
 	it('should not initialise Prebid when ad-free is on', async () => {
 		expect.hasAssertions();
 
-		dfpEnv.hbImpl = { prebid: true, a9: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+			a9HeaderBidding: false,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = true;
 		mockOnConsent(tcfv2WithConsent);
@@ -232,7 +251,10 @@ describe('init', () => {
 	it('should not initialise Prebid when the page has a pageskin', async () => {
 		expect.hasAssertions();
 
-		dfpEnv.hbImpl = { prebid: true, a9: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+			a9HeaderBidding: false,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		window.guardian.config.page.hasPageSkin = true;
@@ -244,7 +266,10 @@ describe('init', () => {
 	});
 
 	it('should initialise Prebid when the page has no pageskin', async () => {
-		dfpEnv.hbImpl = { prebid: true, a9: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+			a9HeaderBidding: false,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		window.guardian.config.page.hasPageSkin = false;
@@ -258,7 +283,10 @@ describe('init', () => {
 	it('should initialise Prebid if TCFv2 consent with correct Sourcepoint Id is true ', async () => {
 		expect.hasAssertions();
 
-		dfpEnv.hbImpl = { prebid: true, a9: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+			a9HeaderBidding: false,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		mockOnConsent(tcfv2WithConsent);
@@ -270,7 +298,10 @@ describe('init', () => {
 	it('should not initialise Prebid if TCFv2 consent with correct Sourcepoint Id is false', async () => {
 		expect.assertions(2);
 
-		dfpEnv.hbImpl = { prebid: true, a9: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+			a9HeaderBidding: false,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		mockOnConsent(tcfv2WithoutConsent);
@@ -289,7 +320,10 @@ describe('init', () => {
 	it('should initialise Prebid in CCPA if doNotSell is false', async () => {
 		expect.hasAssertions();
 
-		dfpEnv.hbImpl = { prebid: true, a9: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+			a9HeaderBidding: false,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		mockOnConsent(ccpaWithConsent);
@@ -301,7 +335,10 @@ describe('init', () => {
 	it('should not initialise Prebid in CCPA if doNotSell is true', async () => {
 		expect.assertions(2);
 
-		dfpEnv.hbImpl = { prebid: true, a9: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+			a9HeaderBidding: false,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		mockOnConsent(ccpaWithoutConsent);
@@ -320,7 +357,10 @@ describe('init', () => {
 	it('should initialise Prebid in AUS if Advertising is not rejected', async () => {
 		expect.hasAssertions();
 
-		dfpEnv.hbImpl = { prebid: true, a9: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+			a9HeaderBidding: false,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		mockOnConsent(ausWithConsent);
@@ -332,7 +372,10 @@ describe('init', () => {
 	it('should not initialise Prebid in AUS if Advertising is rejected', async () => {
 		expect.assertions(2);
 
-		dfpEnv.hbImpl = { prebid: true, a9: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+			a9HeaderBidding: false,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		mockOnConsent(ausWithoutConsent);
@@ -351,7 +394,10 @@ describe('init', () => {
 	it('should not initialise Prebid if the framework is invalid', async () => {
 		expect.assertions(2);
 
-		dfpEnv.hbImpl = { prebid: true, a9: false };
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+			a9HeaderBidding: false,
+		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
 		mockOnConsent(invalidWithoutConsent);

--- a/src/lib/dfp/prepare-prebid.spec.ts
+++ b/src/lib/dfp/prepare-prebid.spec.ts
@@ -139,7 +139,6 @@ describe('init', () => {
 		expect.hasAssertions();
 		window.guardian.config.switches = {
 			prebidHeaderBidding: true,
-			a9HeaderBidding: false,
 		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
@@ -154,7 +153,6 @@ describe('init', () => {
 		expect.hasAssertions();
 		window.guardian.config.switches = {
 			prebidHeaderBidding: true,
-			a9HeaderBidding: false,
 		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
@@ -173,7 +171,6 @@ describe('init', () => {
 		commercialFeatures.adFree = false;
 		window.guardian.config.switches = {
 			prebidHeaderBidding: false,
-			a9HeaderBidding: false,
 		};
 		mockOnConsent(tcfv2WithConsent);
 		mockGetConsentFor(true);
@@ -187,7 +184,6 @@ describe('init', () => {
 
 		window.guardian.config.switches = {
 			prebidHeaderBidding: true,
-			a9HeaderBidding: false,
 		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
@@ -204,7 +200,6 @@ describe('init', () => {
 
 		window.guardian.config.switches = {
 			prebidHeaderBidding: true,
-			a9HeaderBidding: false,
 		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
@@ -221,7 +216,6 @@ describe('init', () => {
 
 		window.guardian.config.switches = {
 			prebidHeaderBidding: true,
-			a9HeaderBidding: false,
 		};
 		commercialFeatures.dfpAdvertising = false;
 		commercialFeatures.adFree = false;
@@ -237,7 +231,6 @@ describe('init', () => {
 
 		window.guardian.config.switches = {
 			prebidHeaderBidding: true,
-			a9HeaderBidding: false,
 		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = true;
@@ -253,7 +246,6 @@ describe('init', () => {
 
 		window.guardian.config.switches = {
 			prebidHeaderBidding: true,
-			a9HeaderBidding: false,
 		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
@@ -268,7 +260,6 @@ describe('init', () => {
 	it('should initialise Prebid when the page has no pageskin', async () => {
 		window.guardian.config.switches = {
 			prebidHeaderBidding: true,
-			a9HeaderBidding: false,
 		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
@@ -285,7 +276,6 @@ describe('init', () => {
 
 		window.guardian.config.switches = {
 			prebidHeaderBidding: true,
-			a9HeaderBidding: false,
 		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
@@ -300,7 +290,6 @@ describe('init', () => {
 
 		window.guardian.config.switches = {
 			prebidHeaderBidding: true,
-			a9HeaderBidding: false,
 		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
@@ -322,7 +311,6 @@ describe('init', () => {
 
 		window.guardian.config.switches = {
 			prebidHeaderBidding: true,
-			a9HeaderBidding: false,
 		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
@@ -337,7 +325,6 @@ describe('init', () => {
 
 		window.guardian.config.switches = {
 			prebidHeaderBidding: true,
-			a9HeaderBidding: false,
 		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
@@ -359,7 +346,6 @@ describe('init', () => {
 
 		window.guardian.config.switches = {
 			prebidHeaderBidding: true,
-			a9HeaderBidding: false,
 		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
@@ -374,7 +360,6 @@ describe('init', () => {
 
 		window.guardian.config.switches = {
 			prebidHeaderBidding: true,
-			a9HeaderBidding: false,
 		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;
@@ -396,7 +381,6 @@ describe('init', () => {
 
 		window.guardian.config.switches = {
 			prebidHeaderBidding: true,
-			a9HeaderBidding: false,
 		};
 		commercialFeatures.dfpAdvertising = true;
 		commercialFeatures.adFree = false;

--- a/src/lib/dfp/prepare-prebid.ts
+++ b/src/lib/dfp/prepare-prebid.ts
@@ -10,11 +10,10 @@ import { isGoogleProxy } from 'lib/detect/detect-google-proxy';
 import { isInCanada } from 'lib/utils/geo-utils';
 import { prebid } from '../header-bidding/prebid/prebid';
 import { shouldIncludeOnlyA9 } from '../header-bidding/utils';
-import { dfpEnv } from './dfp-env';
 
 const shouldLoadPrebid = () =>
 	!isGoogleProxy() &&
-	dfpEnv.hbImpl.prebid &&
+	window.guardian.config.switches.prebidHeaderBidding &&
 	commercialFeatures.dfpAdvertising &&
 	!commercialFeatures.adFree &&
 	!window.guardian.config.page.hasPageSkin &&

--- a/src/lib/header-bidding/a9/a9.ts
+++ b/src/lib/header-bidding/a9/a9.ts
@@ -1,6 +1,5 @@
 import { flatten } from 'lodash-es';
 import type { Advert } from 'lib/dfp/Advert';
-import { dfpEnv } from 'lib/dfp/dfp-env';
 import { noop } from 'lib/utils/noop';
 import type { A9AdUnitInterface } from 'types/global';
 import type { HeaderBiddingSlot, SlotFlatMap } from '../prebid-types';
@@ -49,7 +48,7 @@ const requestBids = async (
 		return requestQueue;
 	}
 
-	if (!dfpEnv.hbImpl.a9) {
+	if (!window.guardian.config.switches.a9HeaderBidding) {
 		return requestQueue;
 	}
 

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -10,7 +10,6 @@ import { EventTimer } from 'core/event-timer';
 import type { PageTargeting } from 'core/targeting/build-page-targeting';
 import { getPageTargeting } from 'lib/build-page-targeting';
 import type { Advert } from 'lib/dfp/Advert';
-import { dfpEnv } from 'lib/dfp/dfp-env';
 import { getAdvertById } from 'lib/dfp/get-advert-by-id';
 import type {
 	BidderCode,
@@ -485,7 +484,7 @@ const requestBids = async (
 		return requestQueue;
 	}
 
-	if (!dfpEnv.hbImpl.prebid) {
+	if (!window.guardian.config.switches.prebidHeaderBidding) {
 		return requestQueue;
 	}
 

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -1,5 +1,4 @@
 import type { VendorName } from '@guardian/consent-management-platform/dist/types';
-import type { Advert } from 'lib/dfp/Advert';
 import type { EventTimer } from '../core/event-timer';
 import type { PageTargeting } from '../core/targeting/build-page-targeting';
 import type {
@@ -7,21 +6,8 @@ import type {
 	GoogleTrackConversionObject,
 	NetworkInformation,
 } from '../core/types';
+import type { DfpEnv } from '../lib/dfp/dfp-env';
 import type { IasPETSlot } from './ias';
-
-interface DfpEnv {
-	renderStartTime: number;
-	adSlotSelector: string;
-	hbImpl: Record<string, boolean>;
-	lazyLoadEnabled: boolean;
-	lazyLoadObserve: boolean;
-	creativeIDs: string[];
-	advertIds: Record<string, number>;
-	advertsToLoad: Advert[];
-	advertsToRefresh: Advert[];
-	adverts: Advert[];
-	shouldLazyLoad: () => boolean;
-}
 
 type ServerSideABTest = `${string}${'Variant' | 'Control'}`;
 


### PR DESCRIPTION
## What does this change?

This PR removes the `hbImpl` object, and replaces its use with the value of the underlying switches.

## Why?

Remove an unecesary indirection, where it'd be simpler to just use the switch values directly.
