### PR TITLE
Visual tests should only be manually triggered

### DIFF
--- a/.github/workflows/e2e-visual.yml
+++ b/.github/workflows/e2e-visual.yml
@@ -1,14 +1,6 @@
 name: E2E Visual
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    paths:
-      - src/**
-      - cypress/!(e2e)/**
-      - cypress.config.ts
-      - .github/workflows/e2e-visual.yml
+  workflow_dispatch:
 
 concurrency:
   group: 'commercial-e2e-visual-${{ github.head_ref }}'


### PR DESCRIPTION
## What does this change?

This PR changes the Percy visual testing Github Action to only be triggered manually from the Github UI.

## Why?

This action is not currently required for a build to pass, and often errors. This prevents the workflow from running when its not required.
