### PR TITLE
Allow overriding the data model in E2E tests

### DIFF
--- a/.github/workflows/e2e-cypress.yml
+++ b/.github/workflows/e2e-cypress.yml
@@ -34,17 +34,17 @@ jobs:
         run: yarn install --frozen-lockfile
         working-directory: ./commercial
 
-        # We always run our commercial code against the latest main of DCR
-        # This does make our tests sensitive to changes in DCR
-        # (e.g. imagine someone removes the top-above-nav slot from DCR)
-        # This is something we accept in order to easily test our own code
-        #
-        # Note we use the containerised version of DCR, published from:
-        # https://github.com/guardian/dotcom-rendering/blob/6a6df272/.github/workflows/container.yml
-        #
-        # The argument `--network host` is crucial here, as it means the container shares the networking stack of the host
-        # This makes the commercial dev server available from inside the container
-        # Note that GHA provides a service container feature, but it does not support this argument
+      # We always run our commercial code against the latest main of DCR
+      # This does make our tests sensitive to changes in DCR
+      # (e.g. imagine someone removes the top-above-nav slot from DCR)
+      # This is something we accept in order to easily test our own code
+      #
+      # Note we use the containerised version of DCR, published from:
+      # https://github.com/guardian/dotcom-rendering/blob/6a6df272/.github/workflows/container.yml
+      #
+      # The argument `--network host` is crucial here, as it means the container shares the networking stack of the host
+      # This makes the commercial dev server available from inside the container
+      # Note that GHA provides a service container feature, but it does not support this argument
       - name: Start DCR in a container
         run: |
           /usr/bin/docker run -d \

--- a/.github/workflows/e2e-cypress.yml
+++ b/.github/workflows/e2e-cypress.yml
@@ -18,21 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         group: [1, 2, 3, 4, 5]
-    services:
-      DCR:
-        # We always run our commercial code against the latest main of DCR
-        # This does make our tests sensitive to changes in DCR
-        # (e.g. imagine someone removes the top-above-nav slot from DCR)
-        # This is something we accept in order to easily test our own code
-        #
-        # Note we use the containerised version of DCR, published from:
-        # https://github.com/guardian/dotcom-rendering/blob/6a6df272/.github/workflows/container.yml
-        image: ghcr.io/guardian/dotcom-rendering:main
-        ports:
-          - 3030:3030
-        env:
-          PORT: 3030
-          COMMERCIAL_BUNDLE_URL: http://localhost:3031/graun.standalone.commercial.js
     steps:
       # Commercial
       - name: Checkout
@@ -48,6 +33,26 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
         working-directory: ./commercial
+
+        # We always run our commercial code against the latest main of DCR
+        # This does make our tests sensitive to changes in DCR
+        # (e.g. imagine someone removes the top-above-nav slot from DCR)
+        # This is something we accept in order to easily test our own code
+        #
+        # Note we use the containerised version of DCR, published from:
+        # https://github.com/guardian/dotcom-rendering/blob/6a6df272/.github/workflows/container.yml
+        #
+        # The argument `--network host` is crucial here, as it means the container shares the networking stack of the host
+        # This makes the commercial dev server available from inside the container
+        # Note that GHA provides a service container feature, but it does not support this argument
+      - name: Start DCR in a container
+        run: |
+          /usr/bin/docker run -d \
+            --network host \
+            -p 3030:3030 \
+            -e "PORT=3030" \
+            -e "COMMERCIAL_BUNDLE_URL=http://localhost:3031/graun.standalone.commercial.js" \
+            ghcr.io/guardian/dotcom-rendering:main
 
       - name: Start Commercial server
         run: yarn serve & npx wait-on -v -i 1000 http://localhost:3031/graun.standalone.commercial.js

--- a/cypress/e2e/parallel-2/googletag-switch.cy.ts
+++ b/cypress/e2e/parallel-2/googletag-switch.cy.ts
@@ -1,11 +1,18 @@
+import { getStage, getTestUrl } from '../../lib/util';
+
 describe('shouldLoadGoogletagSwitch', () => {
 	beforeEach(() => {
 		cy.useConsentedSession('should-load-googletag-switch');
 	});
 
 	it('ad slot should be filled when switch is true', () => {
-		const path =
-			'http://localhost:3030/Front/http://localhost:3031/renderFixture/overwriteShouldLoadGoogletagTrue/uk';
+		const path = getTestUrl(
+			getStage(),
+			'uk',
+			'front',
+			undefined,
+			'overwriteShouldLoadGoogletagTrue',
+		);
 		cy.visit(path);
 
 		// Check that the top-above-nav ad slot is on the page
@@ -18,20 +25,20 @@ describe('shouldLoadGoogletagSwitch', () => {
 		cy.findAdSlotIframeBySlotId('dfp-ad--top-above-nav').should('exist');
 	});
 
-	it('ad slot should be filled when switch is true', () => {
-		const path =
-			'http://localhost:3030/Front/http://localhost:3031/renderFixture/overwriteShouldLoadGoogletagFalse/uk';
+	it('ad slot should be filled when switch is false', () => {
+		const path = getTestUrl(
+			getStage(),
+			'uk',
+			'front',
+			undefined,
+			'overwriteShouldLoadGoogletagFalse',
+		);
 		cy.visit(path);
 
-		// Check that the top-above-nav ad slot is on the page
-		cy.get('#dfp-ad--top-above-nav').should('exist');
+		// eslint-disable-next-line cypress/no-unnecessary-waiting -- Wait for top-above-nav to be removed
+		cy.wait(5_000);
 
-		// creative isn't loaded unless slot is in view
-		cy.get('#dfp-ad--top-above-nav').scrollIntoView();
-
-		// Check that an iframe is placed inside the ad slot
-		cy.findAdSlotIframeBySlotId('dfp-ad--top-above-nav').should(
-			'not.exist',
-		);
+		// Check that the top-above-nav ad slot is not on the page
+		cy.get('#dfp-ad--top-above-nav').should('not.exist');
 	});
 });

--- a/cypress/e2e/parallel-2/googletag-switch.cy.ts
+++ b/cypress/e2e/parallel-2/googletag-switch.cy.ts
@@ -6,11 +6,12 @@ describe('shouldLoadGoogletagSwitch', () => {
 	});
 
 	it('ad slot should be filled when switch is true', () => {
+		// Construct a path that uses a fixture where the `shouldLoadGoogletag` switch is set to true
 		const path = getTestUrl(
 			getStage(),
 			'uk',
 			'front',
-			undefined,
+			undefined, // use the default ad test
 			'overwriteShouldLoadGoogletagTrue',
 		);
 		cy.visit(path);
@@ -26,16 +27,17 @@ describe('shouldLoadGoogletagSwitch', () => {
 	});
 
 	it('ad slot should be filled when switch is false', () => {
+		// Construct a path that uses a fixture where the `shouldLoadGoogletag` switch is set to false
 		const path = getTestUrl(
 			getStage(),
 			'uk',
 			'front',
-			undefined,
+			undefined, // use the default ad test
 			'overwriteShouldLoadGoogletagFalse',
 		);
 		cy.visit(path);
 
-		// eslint-disable-next-line cypress/no-unnecessary-waiting -- Wait for top-above-nav to be removed
+		// eslint-disable-next-line cypress/no-unnecessary-waiting -- Wait for top-above-nav to be removed by commercial code
 		cy.wait(5_000);
 
 		// Check that the top-above-nav ad slot is not on the page

--- a/cypress/e2e/parallel-2/googletag-switch.cy.ts
+++ b/cypress/e2e/parallel-2/googletag-switch.cy.ts
@@ -1,0 +1,37 @@
+describe('shouldLoadGoogletagSwitch', () => {
+	beforeEach(() => {
+		cy.useConsentedSession('should-load-googletag-switch');
+	});
+
+	it('ad slot should be filled when switch is true', () => {
+		const path =
+			'http://localhost:3030/Front/http://localhost:3031/renderFixture/overwriteShouldLoadGoogletagTrue/uk';
+		cy.visit(path);
+
+		// Check that the top-above-nav ad slot is on the page
+		cy.get('#dfp-ad--top-above-nav').should('exist');
+
+		// creative isn't loaded unless slot is in view
+		cy.get('#dfp-ad--top-above-nav').scrollIntoView();
+
+		// Check that an iframe is placed inside the ad slot
+		cy.findAdSlotIframeBySlotId('dfp-ad--top-above-nav').should('exist');
+	});
+
+	it('ad slot should be filled when switch is true', () => {
+		const path =
+			'http://localhost:3030/Front/http://localhost:3031/renderFixture/overwriteShouldLoadGoogletagFalse/uk';
+		cy.visit(path);
+
+		// Check that the top-above-nav ad slot is on the page
+		cy.get('#dfp-ad--top-above-nav').should('exist');
+
+		// creative isn't loaded unless slot is in view
+		cy.get('#dfp-ad--top-above-nav').scrollIntoView();
+
+		// Check that an iframe is placed inside the ad slot
+		cy.findAdSlotIframeBySlotId('dfp-ad--top-above-nav').should(
+			'not.exist',
+		);
+	});
+});

--- a/cypress/lib/util.ts
+++ b/cypress/lib/util.ts
@@ -6,21 +6,23 @@ const hostnames = {
 	code: 'https://code.dev-theguardian.com',
 	prod: 'https://www.theguardian.com',
 	dev: 'http://localhost:3030',
-};
+} as const;
 
 const getPath = (
 	stage: Stage,
 	type: 'article' | 'liveblog' | 'front' = 'article',
 	path: string,
+	fixtureId?: string,
 ) => {
 	if (stage === 'dev') {
-		if (type === 'liveblog' || type === 'article') {
-			return `Article/https://www.theguardian.com${path}`;
+		const dcrContentType =
+			type === 'liveblog' || type === 'article' ? 'Article' : 'Front';
+		if (fixtureId) {
+			return `${dcrContentType}/http://localhost:3031/renderFixture/${fixtureId}/${path}`;
 		} else {
-			return `Front/https://www.theguardian.com${path}`;
+			return `${dcrContentType}/https://www.theguardian.com${path}`;
 		}
 	}
-
 	return path;
 };
 
@@ -29,23 +31,18 @@ const normalizeStage = (stage: string): Stage =>
 
 /**
  * Generate a full URL for a given relative path and the desired stage
- *
- * @param {'dev' | 'code' | 'prod'} stage
- * @param {string} path
- * @param {{ isDcr?: boolean }} options
- * @returns {string} The full path
  */
 export const getTestUrl = (
 	stage: Stage,
 	path: string,
 	type: 'article' | 'liveblog' | 'front' = 'article',
 	adtest = 'fixed-puppies-ci',
-) => {
-	let url = new URL('https://www.theguardian.com');
-
-	url.href = hostnames[stage] ?? hostnames.dev;
-
-	url.pathname = getPath(stage, type, path);
+	fixtureId?: string,
+): string => {
+	const url = new URL(
+		getPath(stage, type, path, fixtureId),
+		hostnames[stage],
+	);
 
 	if (type === 'liveblog') {
 		url.searchParams.append('live', '1');

--- a/scripts/fixtures/fixtures-server.js
+++ b/scripts/fixtures/fixtures-server.js
@@ -1,0 +1,68 @@
+const { fixtures } = require('./fixtures');
+const { merge } = require('lodash');
+
+/**
+ * For a given relative path in production,
+ * retrieve the JSON required to render on DCR
+ *
+ * @param {string} path
+ * @returns {string}
+ */
+const getProdDataUrl = (path) =>
+	`https://theguardian.com/${path}.json?dcr=true`;
+
+/**
+ * @param {string} path
+ * @returns {Promise<Record<string, unknown>>}
+ */
+const fetchDcrDataModel = async (path) => {
+	const url = getProdDataUrl(path);
+	try {
+		const res = await fetch(url);
+		if (!res.ok) {
+			return undefined;
+		}
+		const json = await res.json();
+		return json;
+	} catch (err) {
+		console.error(err);
+		return undefined;
+	}
+};
+
+/**
+ * @param {import('webpack-dev-server')} devServer
+ */
+const setupFixturesServer = (devServer) => {
+	if (!devServer) {
+		throw new Error('webpack-dev-server is not defined');
+	}
+	devServer.app.get('/renderFixture/:fixtureId/*.json', async (req, res) => {
+		const path = req.params[0];
+		const fixtureId = req.params.fixtureId;
+		const fixture = fixtures[fixtureId];
+
+		if (!fixture) {
+			console.error(`Fixture with id ${fixtureId} not found`);
+			return res.status(404).send();
+		}
+
+		// Fetch the JSON for the given path from PROD Frontend
+		const dataModel = await fetchDcrDataModel(path);
+
+		if (!dataModel) {
+			console.error('Something went wrong retrieving DCR data from PROD');
+			return res.status(503).send();
+		}
+
+		// Merge the fixture into the data model
+		// Note that this will be a deep merge
+		merge(dataModel, fixture);
+
+		return res.json(dataModel);
+	});
+};
+
+module.exports = {
+	setupFixturesServer,
+};

--- a/scripts/fixtures/fixtures-server.js
+++ b/scripts/fixtures/fixtures-server.js
@@ -31,12 +31,28 @@ const fetchDcrDataModel = async (path) => {
 };
 
 /**
+ * Add an additional endpoint that proxies Frontend,
+ * merging into the resulting JSON any overrides provided
+ * as a fixture.
+ *
+ * These fixtures are stored in fixtures.json in an object keyed
+ * by the fixture ID, and are merged into the JSON returned for the
+ * rest of the path. For example, to override the data for the /uk
+ * path with fixture id 'foo' you could call:
+ *
+ * 	`http://localhost:PORT/renderFixture/foo/uk.json`
+ *
+ * These can then be used by an E2E test in order to fix certain
+ * behavior about the system-under-test e.g. override a switch state
+ * to always be true.
+ *
  * @param {import('webpack-dev-server')} devServer
  */
 const setupFixturesServer = (devServer) => {
 	if (!devServer) {
 		throw new Error('webpack-dev-server is not defined');
 	}
+
 	devServer.app.get('/renderFixture/:fixtureId/*.json', async (req, res) => {
 		const path = req.params[0];
 		const fixtureId = req.params.fixtureId;

--- a/scripts/fixtures/fixtures.js
+++ b/scripts/fixtures/fixtures.js
@@ -1,0 +1,24 @@
+const overwriteShouldLoadGoogletagTrue = {
+	config: {
+		switches: {
+			shouldLoadGoogletag: true,
+		},
+	},
+};
+
+const overwriteShouldLoadGoogletagFalse = {
+	config: {
+		switches: {
+			shouldLoadGoogletag: false,
+		},
+	},
+};
+
+const fixtures = {
+	overwriteShouldLoadGoogletagTrue,
+	overwriteShouldLoadGoogletagFalse,
+};
+
+module.exports = {
+	fixtures,
+};

--- a/scripts/fixtures/fixtures.js
+++ b/scripts/fixtures/fixtures.js
@@ -14,6 +14,14 @@ const overwriteShouldLoadGoogletagFalse = {
 	},
 };
 
+/**
+ * The fixtures represent a set of objects that is deeply merged into the JSON
+ * data that is used by DCR. It can be used to override properties for the
+ * purposes of testing e.g. to set a switch state to be true regardless of
+ * the state in PROD.
+ *
+ * Each of the fixtures is available via an endpoint (see fixtures-server.js)
+ */
 const fixtures = {
 	overwriteShouldLoadGoogletagTrue,
 	overwriteShouldLoadGoogletagFalse,

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -8,7 +8,6 @@ const overrideBundlePath = `http://localhost:${port}/`;
 const shouldOverrideBundle = !!process.env.OVERRIDE_BUNDLE;
 
 module.exports = webpackMerge.smart(config, {
-	/** @type {import('webpack-dev-server').Configuration} */
 	devtool: 'inline-source-map',
 	mode: 'development',
 	output: {
@@ -38,6 +37,7 @@ module.exports = webpackMerge.smart(config, {
 			process: 'process/browser',
 		},
 	},
+	/** @type {import('webpack-dev-server').Configuration} */
 	devServer: {
 		port,
 		compress: true,

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -2,6 +2,9 @@ const webpack = require('webpack');
 const webpackMerge = require('webpack-merge');
 const config = require('./webpack.config.js');
 const path = require('path');
+const {
+	setupFixturesServer,
+} = require('./scripts/fixtures/fixtures-server.js');
 
 const port = 3031;
 const overrideBundlePath = `http://localhost:${port}/`;
@@ -31,7 +34,6 @@ module.exports = webpackMerge.smart(config, {
 					process: 'process/browser',
 				}),
 		  ],
-
 	resolve: {
 		alias: {
 			process: 'process/browser',
@@ -43,5 +45,6 @@ module.exports = webpackMerge.smart(config, {
 		compress: true,
 		hot: false,
 		liveReload: true,
+		onAfterSetupMiddleware: setupFixturesServer,
 	},
 });


### PR DESCRIPTION
## Motivation

It'd be useful to be able to run end-to-end / integration tests where we fix the data model we send to DCR.

1. When the `shouldLoadGoogletag` switch is switched on, ads load on the page.
2. When the `shouldLoadGoogletag` switch is switched off, ads do not load on the page.

Therefore, we want to ignore the production value for the `shouldLoadGoogletag` switch and override it with a value we have fixed for the test.

The test that implements that as part of this PR is located in [googletag-switch.ts](https://github.com/guardian/commercial/blob/39fd2ab93ff3feae54ee2e4c1db745c38f9e33d3/cypress/e2e/parallel-2/googletag-switch.cy.ts) as part of this PR.

## The approach

In order to achieve the above, this PR adds a _fixtures server_ to our existing webpack dev server setup. This has an endpoint that accepts GET requests of the form:

```
http://localhost:3031/renderFixture/:fixtureId/*.json
```

Note:
- The `*` captures the path that will be used to fetch the page data from production - so `/renderFixture/:fixutreId/uk.json` will get the data from https://www.theguardian.com/uk.json?dcr.
- The `fixtureId` is used to lookup an object with that key in [`fixtures.js`](https://github.com/guardian/commercial/blob/39fd2ab93ff3feae54ee2e4c1db745c38f9e33d3/scripts/fixtures/fixtures.js). This is then deeply merged into the page data from production, producing JSON that can be used to render content by DCR.



This allows us to render a page for testing that matches production data, but with a small amount of changes required to produce a desirable condition for our test (such as a switch being switched on, or a server-side participation for example). 

So, to render the UK front, overriding properties from fixture with id `foo`, we'd use the URL:

```
http://localhost:3030/Front/http://localhost:3031/renderFixture/foo/uk.json
```

This URL can be used from within a Cypress test using the `getTestUrl` utility, where you have to supply the fixture id that corresponds to a fixture in `fixtures.js`.

## Caveats

- I had to edit our CI to no longer use a Github [container service](https://docs.github.com/en/actions/using-containerized-services/about-service-containers) and use a direct `docker run ...` command. This was necessary in order to pass in the `--network host` argument ([more on this here](https://docs.docker.com/network/drivers/host/)), which allows the container to share the networking stack of the host runner. This is important to allow DCR (localhost:3030) to reach the dev server outside of the container (localhost:3031).

- Fixtures are defined in `fixtures.js` so they're available to the webpack dev server. This is quite far from the actual spec files that send them - it'd be nice if these were more tightly coupled, and perhaps TS was aware of the set of permitted fixture ids.

On the second point, I think we can try and improve the dev-ex here once we've decided to migrate our tests to a different framework. 