### PR TITLE
Fix mobile sticky close button

### DIFF
--- a/.changeset/cold-plants-pay.md
+++ b/.changeset/cold-plants-pay.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Fixes the mobile sticky close button

--- a/src/lib/dfp/render-advert-label.ts
+++ b/src/lib/dfp/render-advert-label.ts
@@ -33,20 +33,19 @@ const shouldRenderCloseButton = (adSlotNode: HTMLElement): boolean =>
 	adSlotNode.classList.contains('ad-slot--mobile-sticky');
 
 const createAdCloseDiv = (): HTMLElement => {
-	const buttonDiv: HTMLElement = document.createElement('button');
-	buttonDiv.className = 'ad-slot__close-button';
-	buttonDiv.innerHTML = crossIcon;
-	buttonDiv.onclick = () => {
-		const container: HTMLElement | null = buttonDiv.closest(
+	const buttonEl: HTMLElement = document.createElement('button');
+	buttonEl.className = 'ad-slot__close-button';
+	buttonEl.innerHTML = crossIcon;
+	buttonEl.onclick = () => {
+		const container: HTMLElement | null = buttonEl.closest(
 			'.mobilesticky-container',
 		);
 		if (container) container.remove();
 	};
 
 	const closeDiv: HTMLElement = document.createElement('div');
-	closeDiv.style.cssText =
-		'position: relative;padding: 0;text-align: left;box-sizing: border-box;display: block;width: 0;height: 0';
-	closeDiv.appendChild(buttonDiv);
+	closeDiv.style.cssText = 'position: relative;padding: 0;height: 0';
+	closeDiv.appendChild(buttonEl);
 
 	return closeDiv;
 };


### PR DESCRIPTION
## What does this change?
The close button was being pushed off to the side of the mobile sticky ad, meaning that it was very difficult to see. The styles have been updated so that the button is now back where it should be.

Also renames the button element variable in the code that creates the close button, to be clearer about the type of element it creates.

Before:
<img width="280" alt="Screenshot 2023-07-19 at 15 41 04" src="https://github.com/guardian/commercial/assets/108270776/ba9697c0-cbea-4f8c-8912-05b210be20d0">

After:
<img width="280" alt="Screenshot 2023-07-19 at 15 40 10" src="https://github.com/guardian/commercial/assets/108270776/e3e50eed-f730-40e5-ba2f-bf960d4ce1fd">

