### PR TITLE
Remove unused `createAdSlot` config

### DIFF
--- a/.changeset/wicked-plums-matter.md
+++ b/.changeset/wicked-plums-matter.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Remove unused `createAdSlot` config

--- a/src/core/create-ad-slot.ts
+++ b/src/core/create-ad-slot.ts
@@ -16,8 +16,6 @@ type SlotName =
 	| 'epic'
 	| 'exclusion'
 	| 'fronts-banner'
-	| 'high-merch-lucky'
-	| 'high-merch-paid'
 	| 'high-merch'
 	| 'im'
 	| 'inline'
@@ -46,11 +44,6 @@ const adSlotConfigs: AdSlotConfigs = {
 		label: false,
 		refresh: false,
 		name: 'merchandising-high-lucky',
-	},
-	'high-merch-paid': {
-		label: false,
-		refresh: false,
-		name: 'merchandising-high',
 	},
 	carrot: {
 		label: false,

--- a/src/core/create-ad-slot.ts
+++ b/src/core/create-ad-slot.ts
@@ -19,7 +19,6 @@ type SlotName =
 	| 'im'
 	| 'inline'
 	| 'mobile-sticky'
-	| 'mostpop'
 	| 'top-above-nav';
 
 type AdSlotConfigs = Partial<Record<SlotName, AdSlotConfig>>;

--- a/src/core/create-ad-slot.ts
+++ b/src/core/create-ad-slot.ts
@@ -13,7 +13,6 @@ type SlotName =
 	| 'carrot'
 	| 'comments-expanded'
 	| 'comments'
-	| 'epic'
 	| 'exclusion'
 	| 'fronts-banner'
 	| 'high-merch'
@@ -44,11 +43,6 @@ const adSlotConfigs: AdSlotConfigs = {
 		label: false,
 		refresh: false,
 		name: 'carrot',
-	},
-	epic: {
-		label: false,
-		refresh: false,
-		name: 'epic',
 	},
 	'mobile-sticky': {
 		label: true,

--- a/src/core/create-ad-slot.ts
+++ b/src/core/create-ad-slot.ts
@@ -40,11 +40,6 @@ const adSlotConfigs: AdSlotConfigs = {
 		refresh: false,
 		name: 'merchandising-high',
 	},
-	'high-merch-lucky': {
-		label: false,
-		refresh: false,
-		name: 'merchandising-high-lucky',
-	},
 	carrot: {
 		label: false,
 		refresh: false,

--- a/src/lib/high-merch.ts
+++ b/src/lib/high-merch.ts
@@ -15,11 +15,7 @@ export const init = (): Promise<void> => {
 		const container = document.createElement('div');
 
 		container.className = 'fc-container fc-container--commercial';
-		const slot = createAdSlot(
-			window.guardian.config.page.isPaidContent
-				? 'high-merch-paid'
-				: 'high-merch',
-		);
+		const slot = createAdSlot('high-merch');
 
 		container.appendChild(slot);
 


### PR DESCRIPTION
## What does this change?

Remove unused slots from ad slot config object:
- `high-merch-lucky`: There are no places where `createAdSlot` is called with this slot name.
- `high-merch-paid`: This is the exact same object as `high-merch`, so we can just use this definition.
- `epic`: There are no places where `createAdSlot` is called with this slot name.
- `mostpop`: These slots are currently not created dynamically.

## Why?

`createAdSlot` is used to create an ad slot div for dynamically inserted ads (e.g. by Spacefinder). This function relies on some configuration, which I've cleaned up above to remove definitions we no longer use.
