### PR TITLE
Load user features in DCR for reject all readers

### DIFF
--- a/src/standalone.commercial.ts
+++ b/src/standalone.commercial.ts
@@ -254,7 +254,9 @@ const chooseAdvertisingTag = async () => {
 		void import(
 			/* webpackChunkName: "consentless" */
 			'./commercial.consentless'
-		).then(({ bootConsentless }) => bootConsentless(consentState));
+		).then(({ bootConsentless }) =>
+			bootConsentless(consentState, isDotcomRendering),
+		);
 	} else {
 		bootCommercialWhenReady();
 	}


### PR DESCRIPTION
## What does this change?
Loads user features for reject all readers on pages rendered by DCR.

## Why?
We need user features to set cookies for subscribers to make sure that they don't see adverts or paid for messaging. In the future, we should aim to move this functionality out of the commercial bundle as it affects multiple teams.