### PR TITLE
Remove the testing of sendBeacon from amiused

### DIFF
--- a/src/lib/utils/am-i-used.ts
+++ b/src/lib/utils/am-i-used.ts
@@ -28,7 +28,6 @@ const amIUsed = (
 	parameters?: Partial<
 		Record<string, string> & Record<RestrictedKeys, never>
 	>,
-	sampling = 0,
 ): void => {
 	// The function will return early if the sentinelLogger switch is disabled.
 	if (!window.guardian.config.switches.sentinelLogger) return;
@@ -56,32 +55,7 @@ const amIUsed = (
 			: properties,
 	};
 
-	//The code below is for testing the reliability of the sendBeacon method compared to fetch
-	//There is a possibility that sendBeacon may not be as reliable as we think: https://volument.com/blog/sendbeacon-is-broken
-
-	const shouldTestBeacon = Math.random() <= sampling;
-
-	if (shouldTestBeacon) {
-		const beaconEvent: AmIUsedLoggingEvent = {
-			...event,
-			label: 'commercial.amiused.test_send_beacon',
-		};
-
-		const fetchEvent: AmIUsedLoggingEvent = {
-			...event,
-			label: 'commercial.amiused.test_fetch',
-		};
-
-		window.navigator.sendBeacon(endpoint, JSON.stringify(beaconEvent));
-
-		void fetch(endpoint, {
-			method: 'POST',
-			body: JSON.stringify(fetchEvent),
-			keepalive: true,
-		});
-	} else {
-		window.navigator.sendBeacon(endpoint, JSON.stringify(event));
-	}
+	window.navigator.sendBeacon(endpoint, JSON.stringify(event));
 };
 
 export { amIUsed, type AmIUsedLoggingEvent };

--- a/src/standalone.commercial.ts
+++ b/src/standalone.commercial.ts
@@ -47,7 +47,6 @@ import { init as initThirdPartyTags } from 'lib/third-party-tags';
 import { init as initTrackGpcSignal } from 'lib/track-gpc-signal';
 import { init as initTrackScrollDepth } from 'lib/track-scroll-depth';
 import { isDigitalSubscriber } from 'lib/user-features';
-import { amIUsed } from 'lib/utils/am-i-used';
 import { reportError } from 'lib/utils/report-error';
 import { catchErrorsWithContext } from 'lib/utils/robust';
 
@@ -178,18 +177,6 @@ const bootCommercial = async (): Promise<void> => {
 		log(
 			'commercial',
 			`@guardian/commercial commit https://github.com/guardian/commercial/blob/${process.env.COMMIT_SHA}`,
-		);
-	}
-
-	//adding an amiused call for a very small proportion of users to test sendBeacon vs fetch
-	//this will be removed when we have enough data
-	const shouldTestBeacon = Math.random() <= 1 / 10000;
-	if (shouldTestBeacon) {
-		amIUsed(
-			'standalone.commercial.ts',
-			'bootCommercial',
-			{ userAgent: navigator.userAgent },
-			1,
 		);
 	}
 


### PR DESCRIPTION
## What does this change?
No longer call amiused from standalone, and remove the sendBeacon sampling option from amiused.

## Why?
We now have 4 weeks worth of data comparing the performance of sendBeacon and fetch, which will be enough for analysis.