### PR TITLE
Start liveblog right column ads test

### DIFF
--- a/.changeset/chilled-bobcats-sit.md
+++ b/.changeset/chilled-bobcats-sit.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Start liveblog right ads test

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To develop locally, run `yarn serve` to start a local server. This will watch fo
 
 To run the unit tests, run `yarn test`.
 
-To run the integration tests, switch to the `e2e` workspace to run `yarn cypress:open` or `yarn cypress:run` to run cypress integration tests.
+To run the Cypress integration tests, run `yarn e2e:open` or `yarn e2e:run`.
 
 ### Releasing
 

--- a/src/lib/experiments/tests/liveblog-right-column-ads.ts
+++ b/src/lib/experiments/tests/liveblog-right-column-ads.ts
@@ -3,9 +3,9 @@ import type { ABTest } from '@guardian/ab-core';
 export const liveblogRightColumnAds: ABTest = {
 	id: 'LiveblogRightColumnAds',
 	author: '@commercial-dev',
-	start: '2023-07-15',
+	start: '2023-08-01',
 	expiry: '2023-09-20',
-	audience: 0 / 100,
+	audience: 15 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: 'Desktop users with wide (1300px+) screens only',
 	successMeasure:


### PR DESCRIPTION
## What does this change?

Sets the audience to 15% for the liveblog right column ads AB test

## Why?

- This will start the AB test and allow us to create metrics.
- Setting the audience to 15% so that the participation group of each control and variant (of which there are two) will be 5%.