### PR TITLE
Ensure liveblog-right ads are inserted via custom event

### DIFF
--- a/.changeset/slimy-plums-taste.md
+++ b/.changeset/slimy-plums-taste.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Fix bug in creating liveblog-right adverts

--- a/src/lib/dfp/fill-advert-slots.ts
+++ b/src/lib/dfp/fill-advert-slots.ts
@@ -85,7 +85,7 @@ const fillAdvertSlots = async (): Promise<void> => {
 			(adSlot) => !(isDCRMobile && adSlot.id === 'dfp-ad--top-above-nav'),
 		)
 		// We cannot guarantee that liveblog-right slots will be on the page when this code runs.
-		// liveblog-right slots are inserted by liveblog-right-adverts.ts, where they will be
+		// liveblog-right slots are inserted by liveblog-right-column-adverts.ts, where they will be
 		// inserted when a custom event is received.
 		.filter((adSlot) => !adSlot.id.includes('liveblog-right'))
 		.map((adSlot) => {

--- a/src/lib/dfp/fill-advert-slots.ts
+++ b/src/lib/dfp/fill-advert-slots.ts
@@ -84,6 +84,10 @@ const fillAdvertSlots = async (): Promise<void> => {
 		.filter(
 			(adSlot) => !(isDCRMobile && adSlot.id === 'dfp-ad--top-above-nav'),
 		)
+		// We cannot guarantee that liveblog-right slots will be on the page when this code runs.
+		// liveblog-right slots are inserted by liveblog-right-adverts.ts, where they will be
+		// inserted when a custom event is received.
+		.filter((adSlot) => !adSlot.id.includes('liveblog-right'))
 		.map((adSlot) => {
 			const additionalSizes = decideAdditionalSizes(adSlot);
 			return createAdvert(adSlot, additionalSizes);

--- a/src/lib/spacefinder/liveblog-right-adverts.ts
+++ b/src/lib/spacefinder/liveblog-right-adverts.ts
@@ -57,7 +57,8 @@ const fillAdvertSlots = async (numAdsToInsert: number, fromIndex: number) => {
 
 // When a liveblog-right ad slot is inserted into the page, create an ad in this new slot
 export const initLiveblogRightAdverts = (): Promise<void> => {
-	if (isInVariantSynchronous(liveblogRightColumnAds, 'multiple-adverts')) {
+	// The top right slot is inserted by fill-advert-slots.ts if not in the variant
+	if (!isInVariantSynchronous(liveblogRightColumnAds, 'multiple-adverts')) {
 		return Promise.resolve();
 	}
 

--- a/src/lib/spacefinder/liveblog-right-column-adverts.ts
+++ b/src/lib/spacefinder/liveblog-right-column-adverts.ts
@@ -73,12 +73,15 @@ const createLiveblogRightAdverts = () => {
 	});
 };
 
-const restrictRightAdContainerHeight = () => {
-	void fastdom.measure(() => {
+const restrictRightAdContainerHeight = (): void => {
+	fastdom.measure(() => {
 		const rightAdContainer =
 			document.querySelector<HTMLElement>('#top-right-ad-slot');
+
 		if (rightAdContainer !== null) {
-			rightAdContainer.style.maxHeight = '1059px';
+			fastdom.mutate(() => {
+				rightAdContainer.style.maxHeight = '1059px';
+			});
 		}
 	});
 };

--- a/src/lib/spacefinder/liveblog-right-column-adverts.ts
+++ b/src/lib/spacefinder/liveblog-right-column-adverts.ts
@@ -1,4 +1,5 @@
 import { isNonNullable } from '@guardian/libs';
+import fastdom from 'fastdom';
 import type { Advert } from 'lib/dfp/Advert';
 import { fillDynamicAdSlot } from 'lib/dfp/fill-dynamic-advert-slot';
 import { isInVariantSynchronous } from 'lib/experiments/ab';
@@ -23,20 +24,18 @@ const isCustomEvent = (event: Event): event is CustomEvent => {
 
 // TODO: There's lots of overlap with fill-advert-slots.ts in this function. If multiple right
 // ad slots on liveblogs is what we go forward with, then refactor this to use common functions
-const fillAdvertSlots = async (numAdsToInsert: number, fromIndex: number) => {
-	// Create an array with the indexes of adverts that need to be created
-	// This is to exclude adverts that have already been loaded
-	const newAdvertIndexes = [...Array(numAdsToInsert).keys()].map(
-		(i) => i + fromIndex,
-	);
-
+const fillAdvertSlots = async (newAdvertIndexes?: number[]) => {
 	const adSlots = [
 		...document.querySelectorAll<HTMLElement>('.ad-slot--liveblog-right'),
 	]
-		.filter(({ id }) =>
+		.filter(({ id }) => {
 			// exclude ad slots that have already been filled
-			newAdvertIndexes.includes(Number(id[id.length - 1])),
-		)
+			if (newAdvertIndexes?.length) {
+				return newAdvertIndexes.includes(Number(id[id.length - 1]));
+			}
+
+			return true;
+		})
 		.filter((advert) => isNonNullable(advert));
 
 	if (!adSlots.length) return;
@@ -55,12 +54,8 @@ const fillAdvertSlots = async (numAdsToInsert: number, fromIndex: number) => {
 	}
 };
 
-// When a liveblog-right ad slot is inserted into the page, create an ad in this new slot
-export const initLiveblogRightAdverts = (): Promise<void> => {
-	// The top right slot is inserted by fill-advert-slots.ts if not in the variant
-	if (!isInVariantSynchronous(liveblogRightColumnAds, 'multiple-adverts')) {
-		return Promise.resolve();
-	}
+const createLiveblogRightAdverts = () => {
+	void fillAdvertSlots();
 
 	document.addEventListener('liveblog-right-ads-inserted', (event: Event) => {
 		if (!isCustomEvent(event)) throw new Error('not a custom event');
@@ -68,8 +63,45 @@ export const initLiveblogRightAdverts = (): Promise<void> => {
 		const { numAdsToInsert, fromIndex } = (<AdsInsertedCustomEvent>event)
 			.detail;
 
-		void fillAdvertSlots(numAdsToInsert, fromIndex);
+		// Create an array with the indexes of adverts that need to be created
+		// This is to exclude adverts that have already been loaded
+		const newAdvertIndexes = [...Array(numAdsToInsert).keys()].map(
+			(i) => i + fromIndex,
+		);
+
+		void fillAdvertSlots(newAdvertIndexes);
 	});
+};
+
+const restrictRightAdContainerHeight = () => {
+	void fastdom.measure(() => {
+		const rightAdContainer =
+			document.querySelector<HTMLElement>('#top-right-ad-slot');
+		if (rightAdContainer !== null) {
+			rightAdContainer.style.maxHeight = '1059px';
+		}
+	});
+};
+
+// When a liveblog-right ad slot is inserted into the page, create an ad in this new slot
+export const initLiveblogRightColumnAdverts = async (): Promise<void> => {
+	const isInMultipleAdsVariant = isInVariantSynchronous(
+		liveblogRightColumnAds,
+		'multiple-adverts',
+	);
+	const isInMinStickinessVariant = isInVariantSynchronous(
+		liveblogRightColumnAds,
+		'minimum-stickiness',
+	);
+
+	// Don't insert extra ads if not in the multiple-adverts variant of the liveblogRightColumnAds AB test.
+	if (isInMultipleAdsVariant) {
+		void createLiveblogRightAdverts();
+	}
+
+	if (isInMultipleAdsVariant || isInMinStickinessVariant) {
+		void restrictRightAdContainerHeight();
+	}
 
 	return Promise.resolve();
 };

--- a/src/standalone.commercial.ts
+++ b/src/standalone.commercial.ts
@@ -41,7 +41,7 @@ import { init as initArticleBodyAdverts } from 'lib/spacefinder/article-body-adv
 import { initCommentAdverts } from 'lib/spacefinder/comment-adverts';
 import { initCommentsExpandedAdverts } from 'lib/spacefinder/comments-expanded-advert';
 import { init as initLiveblogAdverts } from 'lib/spacefinder/liveblog-adverts';
-import { initLiveblogRightAdverts } from 'lib/spacefinder/liveblog-right-adverts';
+import { initLiveblogRightColumnAdverts } from 'lib/spacefinder/liveblog-right-column-adverts';
 import { initTeadsCookieless } from 'lib/teads-cookieless';
 import { init as initThirdPartyTags } from 'lib/third-party-tags';
 import { init as initTrackGpcSignal } from 'lib/track-gpc-signal';
@@ -107,7 +107,7 @@ if (!commercialFeatures.adFree) {
 		['cm-redplanet', initRedplanet],
 		['cm-commentAdverts', initCommentAdverts],
 		['cm-commentsExpandedAdverts', initCommentsExpandedAdverts],
-		['cm-liveblogRightAdverts', initLiveblogRightAdverts],
+		['cm-liveblogRightAdverts', initLiveblogRightColumnAdverts],
 		['rr-adblock-ask', initAdblockAsk],
 	);
 }


### PR DESCRIPTION
## What does this change?

- This fixes a bug in the liveblog right column adverts AB test. The liveblog-right ads were being created by `fill-advert-slots.ts`. However, we cannot be certain that all the `liveblog-right` ad slots will be on the page when this code is run. Therefore there's an extra call to `fillAdvertSlots()` before the eventListener is registered, in case the slots are already on the page.
- Moved the logic to restrict the height of the `right` ad slot from the DCR to Commercial repo.

## Why?

- We want the `liveblog-right` adverts to be created when we know the slots are ready.
- So that we can update the styles, since the `right` ad slot is rendered on the server