### PR TITLE
External ads

### DIFF
--- a/.changeset/wet-cougars-yell.md
+++ b/.changeset/wet-cougars-yell.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+External ads

--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -107,7 +107,8 @@ type SlotName =
 	| 'right'
 	| 'survey'
 	| 'top-above-nav'
-	| 'article-end';
+	| 'article-end'
+	| 'external';
 
 type SizeMapping = Partial<Record<Breakpoint, AdSize[]>>;
 
@@ -362,6 +363,9 @@ const slotSizeMappings: SlotSizeMappings = {
 	},
 	exclusion: {
 		mobile: [adSizes.empty],
+	},
+	external: {
+		mobile: [adSizes.outOfPage, adSizes.empty, adSizes.fluid],
 	},
 };
 

--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -365,7 +365,7 @@ const slotSizeMappings: SlotSizeMappings = {
 		mobile: [adSizes.empty],
 	},
 	external: {
-		mobile: [adSizes.outOfPage, adSizes.empty, adSizes.fluid],
+		mobile: [adSizes.outOfPage, adSizes.empty, adSizes.fluid, adSizes.mpu],
 	},
 };
 

--- a/src/lib/dfp/Advert.ts
+++ b/src/lib/dfp/Advert.ts
@@ -67,6 +67,8 @@ const getSlotSizeMapping = (name: string): SizeMapping => {
 		slotName = 'fronts-banner';
 	} else if (name.includes('liveblog-right')) {
 		slotName = 'liveblog-right';
+	} else if (name.includes('external-')) {
+		slotName = 'external';
 	} else {
 		slotName = name;
 	}

--- a/src/lib/dfp/Advert.ts
+++ b/src/lib/dfp/Advert.ts
@@ -67,7 +67,7 @@ const getSlotSizeMapping = (name: string): SizeMapping => {
 		slotName = 'fronts-banner';
 	} else if (name.includes('liveblog-right')) {
 		slotName = 'liveblog-right';
-	} else if (name.includes('external-')) {
+	} else if (name.includes('external')) {
 		slotName = 'external';
 	} else {
 		slotName = name;

--- a/src/lib/dfp/fill-external-slots.ts
+++ b/src/lib/dfp/fill-external-slots.ts
@@ -16,7 +16,7 @@
 
 import { fillDynamicAdSlot } from './fill-dynamic-advert-slot';
 
-const EXTERNAL_SLOT_PREFIX = 'dfp-ad--external-';
+const EXTERNAL_SLOT_PREFIX = 'dfp-ad--external';
 
 type ExternalSlotCustomEventDetail = {
 	slotId: string;

--- a/src/lib/dfp/fill-external-slots.ts
+++ b/src/lib/dfp/fill-external-slots.ts
@@ -1,0 +1,60 @@
+/**
+ * External slots are a special type of dynamic slot.
+ *
+ * They are not fixed (aka SSR) or dynamic (aka injected by spacefinder).
+ * They are placed on the page by a non-standard route for example in a thrasher or some
+ * other async process that adds the slot at an unknown time but still expects the
+ * commercial runtime to fulfill the slot.
+ *
+ * The extra logic in addition to dynamic slots covers when:
+ * - the commercial runtime loads before the slot so we wait for a custom event
+ * - the commercial runtime loads after the slot so we fill the slot immediately
+ *
+ * External slots will not work from within a restricted iframe such as a
+ * cross-origin or safeframe iframe.
+ */
+
+import { fillDynamicAdSlot } from './fill-dynamic-advert-slot';
+
+const EXTERNAL_SLOT_PREFIX = 'dfp-ad--external-';
+
+type ExternalSlotCustomEventDetail = {
+	slotId: string;
+};
+
+type ExternalSlotCustomEvent = {
+	detail: ExternalSlotCustomEventDetail;
+};
+
+const isCustomEvent = (event: Event): event is CustomEvent => {
+	return 'detail' in event;
+};
+
+const fillExternalSlots = () => {
+	const externalSlots = document.querySelectorAll<HTMLElement>(
+		`[id^=${EXTERNAL_SLOT_PREFIX}]`,
+	);
+	return [...externalSlots].map((slot) => fillDynamicAdSlot(slot, false));
+};
+
+const createSlotFillListener = () => {
+	document.addEventListener('gu.commercial.slot.fill', (event: Event) => {
+		if (isCustomEvent(event)) {
+			const { slotId } = (<ExternalSlotCustomEvent>event).detail;
+			const slot = document.getElementById(slotId);
+			if (slot) {
+				void fillDynamicAdSlot(slot, false);
+			}
+		}
+	});
+};
+
+const init = () => {
+	return new Promise<void>((resolve) => {
+		fillExternalSlots();
+		createSlotFillListener();
+		resolve();
+	});
+};
+
+export { init };

--- a/src/lib/remove-slots.ts
+++ b/src/lib/remove-slots.ts
@@ -1,3 +1,4 @@
+import { log } from '@guardian/libs';
 import { once } from 'lodash-es';
 import { isInVariantSynchronous } from 'lib/experiments/ab';
 import { elementsManager } from 'lib/experiments/tests/elements-manager';
@@ -5,7 +6,6 @@ import { dfpEnv } from './dfp/dfp-env';
 import fastdom from './fastdom-promise';
 
 // Remove ad slots
-// Remove toggled ad labels that sit outside of the ad slot
 const selectors: string[] = [dfpEnv.adSlotSelector, '.top-banner-ad-container'];
 
 const selectNodes = () =>
@@ -23,7 +23,12 @@ const isDisabled = (node: Element) =>
 const filterDisabledNodes = (nodes: Element[]) => nodes.filter(isDisabled);
 
 const removeNodes = (nodes: Element[]): Promise<void> =>
-	fastdom.mutate(() => nodes.forEach((node) => node.remove()));
+	fastdom.mutate(() =>
+		nodes.forEach((node) => {
+			log('commercial', `Removing ad slot ${node.id}`);
+			node.remove();
+		}),
+	);
 
 const removeSlots = (): Promise<void> => {
 	// Don't collapse slots when in the Elements Manager AB test variant.

--- a/src/standalone.commercial.ts
+++ b/src/standalone.commercial.ts
@@ -24,6 +24,7 @@ import { initAdblockAsk } from 'lib/adblock-ask';
 import { commercialFeatures } from 'lib/commercial-features';
 import { init as initComscore } from 'lib/comscore';
 import { adSlotIdPrefix } from 'lib/dfp/dfp-env-globals';
+import { init as initExternalAdverts } from 'lib/dfp/fill-external-slots';
 import { init as prepareA9 } from 'lib/dfp/prepare-a9';
 import { init as prepareGoogletag } from 'lib/dfp/prepare-googletag';
 import { initPermutive } from 'lib/dfp/prepare-permutive';
@@ -103,12 +104,13 @@ if (!commercialFeatures.adFree) {
 		['cm-articleAsideAdverts', initArticleAsideAdverts],
 		['cm-articleBodyAdverts', initArticleBodyAdverts],
 		['cm-liveblogAdverts', initLiveblogAdverts],
-		['cm-thirdPartyTags', initThirdPartyTags],
-		['cm-redplanet', initRedplanet],
 		['cm-commentAdverts', initCommentAdverts],
 		['cm-commentsExpandedAdverts', initCommentsExpandedAdverts],
 		['cm-liveblogRightAdverts', initLiveblogRightColumnAdverts],
+		['cm-externalAdverts', initExternalAdverts],
 		['rr-adblock-ask', initAdblockAsk],
+		['cm-thirdPartyTags', initThirdPartyTags],
+		['cm-redplanet', initRedplanet],
 	);
 }
 


### PR DESCRIPTION
## What does this change?

Enable ads to be placed on the page via an external route e.g. thrashers

I'm not completely convinced about the naming but going with 'external' for now

Mostly a generic implementation of #947, specifically [liveblog-right-adverts.ts](https://github.com/guardian/commercial/blob/53e203c77b8a7c9f36300a4dfba81c5b404baa43/src/lib/spacefinder/liveblog-right-adverts.ts) - thanks @domlander !

The extra logic in addition to dynamic slots covers when:
- the commercial runtime loads after the slot so we query any external slots and fill them
- the commercial runtime loads before the slot so we listen for custom events and fill them e.g.
    ```js
    document.dispatchEvent(
        new CustomEvent('gu.commercial.slot.fill', {
            detail: { slotId: 'dfp-ad--external1' },
        }),
    );
    ```




