### PR TITLE
Fix consent subscriber expire test

### DIFF
--- a/cypress/e2e/parallel-1/consent.cy.ts
+++ b/cypress/e2e/parallel-1/consent.cy.ts
@@ -183,11 +183,15 @@ describe('tcfv2 consent', () => {
 		// to intercept response
 		fakeLogin(false);
 
-		cy.wait(4000);
+		cy.reload();
+
+		cy.wait('@userData', { timeout: 30000 });
+
+		cy.wait(5000);
 
 		cy.reload();
 
-		cy.reload();
+		cy.wait(5000);
 
 		adsShouldShow();
 	});

--- a/cypress/lib/util.ts
+++ b/cypress/lib/util.ts
@@ -78,10 +78,14 @@ export const fakeLogin = (subscriber = true) => {
 	cy.setCookie(
 		'GU_U',
 		'WyIzMjc5Nzk0IiwiIiwiSmFrZTkiLCIiLDE2NjA4MzM3NTEyMjcsMCwxMjEyNjgzMTQ3MDAwLHRydWVd.MC0CFQCIbpFtd0J5IqK946U1vagzLgCBkwIUUN3UOkNfNN8jwNE3scKfrcvoRSg',
+		{ timeout: 30000 },
 	);
+
+	cy.wait(5000);
 
 	cy.intercept(
 		'https://members-data-api.theguardian.com/user-attributes/me',
+		{ times: 1 },
 		response,
 	).as('userData');
 };


### PR DESCRIPTION
## What does this change?

Fixes a flakey test.

We have two issues:

- repeated calls to the `fakeLogin` intercept were not isolated from each other. This is fixed by using `times: 1`
- cookies are set async in Cypress so we need to wait for them to be set and also for the commercial runtime to delete the ad-free cookie on page load

I've stuck waits in for now as a rough placeholder. We should wait for cookies to be set in a more idiomatic fashion.


