### PR TITLE
Don't apply label height to min-height when there is no label

### DIFF
--- a/.changeset/cool-baboons-hope.md
+++ b/.changeset/cool-baboons-hope.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Fix setting of min-height when there is no lable

--- a/src/lib/dfp/on-slot-viewable.ts
+++ b/src/lib/dfp/on-slot-viewable.ts
@@ -38,10 +38,16 @@ const setAdSlotMinHeight = (advert: Advert): void => {
 
 	const isStandardAdSize = !size.isProxy();
 	if (isStandardAdSize) {
-		const adSlotHeight = size.height + AD_LABEL_HEIGHT;
-		void fastdom.mutate(() => {
-			node.style.minHeight = `${adSlotHeight}px`;
-		});
+		void fastdom
+			.measure(() => node.getAttribute('data-label') === 'true')
+			.then((hasLabel) => {
+				if (hasLabel) {
+					void fastdom.mutate(() => {
+						const adSlotHeight = size.height + AD_LABEL_HEIGHT;
+						node.style.minHeight = `${adSlotHeight}px`;
+					});
+				}
+			});
 	} else {
 		// For the situation when we load a non-standard size ad, e.g. fluid ad, after
 		// previously loading a standard size ad. Ensure that the previously added min-height is

--- a/src/lib/dfp/on-slot-viewable.ts
+++ b/src/lib/dfp/on-slot-viewable.ts
@@ -41,9 +41,10 @@ const setAdSlotMinHeight = (advert: Advert): void => {
 		void fastdom
 			.measure(() => node.getAttribute('data-label') === 'true')
 			.then((hasLabel) => {
+				const labelHeight = hasLabel ? AD_LABEL_HEIGHT : 0;
 				if (hasLabel) {
 					void fastdom.mutate(() => {
-						const adSlotHeight = size.height + AD_LABEL_HEIGHT;
+						const adSlotHeight = size.height + labelHeight;
 						node.style.minHeight = `${adSlotHeight}px`;
 					});
 				}


### PR DESCRIPTION
## What does this change?

Don't apply min height with label height when `data-label=false`

h/t to @domlander and @emma-imber for their help on this.

## Why?

This causes ads to shift when we add min-height even though `data-label=false`

Before:

https://github.com/guardian/commercial/assets/7014230/5f00eafe-954b-4252-9daf-481033d15f23

After:

https://github.com/guardian/commercial/assets/7014230/933b2023-54b5-46e3-a912-19b2cfac3392



