### PR TITLE
Remove redundant check for setting min-height when there is an ad label

### DIFF
--- a/.changeset/weak-poems-own.md
+++ b/.changeset/weak-poems-own.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Remove redundant check for setting min-height when there is an ad label

--- a/src/lib/dfp/on-slot-viewable.ts
+++ b/src/lib/dfp/on-slot-viewable.ts
@@ -42,12 +42,10 @@ const setAdSlotMinHeight = (advert: Advert): void => {
 			.measure(() => node.getAttribute('data-label') === 'true')
 			.then((hasLabel) => {
 				const labelHeight = hasLabel ? AD_LABEL_HEIGHT : 0;
-				if (hasLabel) {
-					void fastdom.mutate(() => {
-						const adSlotHeight = size.height + labelHeight;
-						node.style.minHeight = `${adSlotHeight}px`;
-					});
-				}
+				void fastdom.mutate(() => {
+					const adSlotHeight = size.height + labelHeight;
+					node.style.minHeight = `${adSlotHeight}px`;
+				});
 			});
 	} else {
 		// For the situation when we load a non-standard size ad, e.g. fluid ad, after


### PR DESCRIPTION
## What does this change?

Remove redundant check for setting min-height when there is an ad label - addresses this [comment](https://github.com/guardian/commercial/pull/987#discussion_r1284460661).