### PR TITLE
Update cypress tests following reduction of text line height

### DIFF
--- a/.changeset/funny-dragons-deliver.md
+++ b/.changeset/funny-dragons-deliver.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Fix cypress tests following text line height reduction

--- a/cypress/e2e/parallel-2/article-inline-slots.cy.ts
+++ b/cypress/e2e/parallel-2/article-inline-slots.cy.ts
@@ -2,34 +2,46 @@ import { breakpoints } from '../../fixtures/breakpoints';
 import { articles, liveblogs } from '../../fixtures/pages';
 import { mockIntersectionObserver } from '../../lib/util';
 
-const pages = articles.filter((page) => 'expectedMinInlineSlotsOnPage' in page);
+const pages = articles.filter(
+	(page) =>
+		'expectedMinInlineSlotsOnDesktop' in page &&
+		'expectedMinInlineSlotsOnMobile' in page,
+);
 
 describe('Slots and iframes load on article pages', () => {
 	beforeEach(() => {
 		cy.useConsentedSession('article-consented');
 	});
 
-	pages.forEach(({ path, expectedMinInlineSlotsOnPage }) => {
-		breakpoints.forEach(({ breakpoint, width, height }) => {
-			it(`Test ${path} has at least ${expectedMinInlineSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, () => {
-				cy.viewport(width, height);
+	pages.forEach(
+		({
+			path,
+			expectedMinInlineSlotsOnDesktop,
+			expectedMinInlineSlotsOnMobile,
+		}) => {
+			breakpoints.forEach(({ breakpoint, width, height }) => {
+				const expectedMinSlotsOnPage =
+					breakpoint === 'mobile'
+						? expectedMinInlineSlotsOnMobile
+						: expectedMinInlineSlotsOnDesktop;
 
-				cy.visit(path, {
-					onBeforeLoad(win) {
-						mockIntersectionObserver(win, '.ad-slot--inline');
-					},
-				});
+				it(`Test ${path} has at least ${expectedMinSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, () => {
+					cy.viewport(width, height);
 
-				cy.get('.ad-slot--inline')
-					.should(
-						'have.length.at.least',
-						expectedMinInlineSlotsOnPage,
-					)
-					.each((slot) => {
-						cy.wrap(slot).scrollIntoView();
-						cy.wrap(slot).find('iframe').should('exist');
+					cy.visit(path, {
+						onBeforeLoad(win) {
+							mockIntersectionObserver(win, '.ad-slot--inline');
+						},
 					});
+
+					cy.get('.ad-slot--inline')
+						.should('have.length.at.least', expectedMinSlotsOnPage)
+						.each((slot) => {
+							cy.wrap(slot).scrollIntoView();
+							cy.wrap(slot).find('iframe').should('exist');
+						});
+				});
 			});
-		});
-	});
+		},
+	);
 });

--- a/cypress/e2e/parallel-3/liveblog-inline-slots.cy.ts
+++ b/cypress/e2e/parallel-3/liveblog-inline-slots.cy.ts
@@ -1,34 +1,47 @@
 import { breakpoints } from '../../fixtures/breakpoints';
-import { articles, liveblogs } from '../../fixtures/pages';
+import { liveblogs } from '../../fixtures/pages';
 import { mockIntersectionObserver } from '../../lib/util';
 
 const liveBlogPages = liveblogs.filter(
-	(page) => 'expectedMinInlineSlotsOnPage' in page,
+	(page) =>
+		'expectedMinInlineSlotsOnDesktop' in page &&
+		'expectedMinInlineSlotsOnMobile' in page,
 );
 
 describe('Slots and iframes load on liveblog pages', () => {
 	beforeEach(() => {
 		cy.useConsentedSession('liveblog-consented-2');
 	});
-	liveBlogPages.forEach(({ path, expectedMinInlineSlotsOnPage }) => {
-		breakpoints.forEach(({ breakpoint, width, height }) => {
-			it(`Test ${path} has at least ${expectedMinInlineSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, () => {
-				cy.viewport(width, height);
+	liveBlogPages.forEach(
+		({
+			path,
+			expectedMinInlineSlotsOnDesktop,
+			expectedMinInlineSlotsOnMobile,
+		}) => {
+			breakpoints.forEach(({ breakpoint, width, height }) => {
+				const expectedMinSlotsOnPage =
+					breakpoint === 'mobile'
+						? expectedMinInlineSlotsOnMobile
+						: expectedMinInlineSlotsOnDesktop;
 
-				cy.visit(path, {
-					onBeforeLoad(win) {
-						mockIntersectionObserver(
-							win,
-							'.ad-slot--liveblog-inline',
-						);
-					},
+				it(`Test ${path} has at least ${expectedMinSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, () => {
+					cy.viewport(width, height);
+
+					cy.visit(path, {
+						onBeforeLoad(win) {
+							mockIntersectionObserver(
+								win,
+								'.ad-slot--liveblog-inline',
+							);
+						},
+					});
+
+					cy.get('.ad-slot--liveblog-inline').should(
+						'have.length.at.least',
+						expectedMinSlotsOnPage,
+					);
 				});
-
-				cy.get('.ad-slot--liveblog-inline').should(
-					'have.length.at.least',
-					expectedMinInlineSlotsOnPage,
-				);
 			});
-		});
-	});
+		},
+	);
 });

--- a/cypress/e2e/parallel-3/liveblog-live-update.cy.ts
+++ b/cypress/e2e/parallel-3/liveblog-live-update.cy.ts
@@ -2,14 +2,14 @@ import { breakpoints } from '../../fixtures/breakpoints';
 import { liveblogs } from '../../fixtures/pages';
 import { mockIntersectionObserver } from '../../lib/util';
 
-const pages = [...liveblogs];
+const pages = liveblogs.filter(({ name }) => name === 'live-update');
 
 describe('Liveblog live updates', () => {
 	beforeEach(() => {
 		cy.useConsentedSession('liveblog-live-update-consented');
 	});
 
-	pages.forEach(({ path, expectedMinInlineSlotsOnPage }) => {
+	pages.forEach(({ path }) => {
 		breakpoints.forEach(({ breakpoint, width, height }) => {
 			it(`Test ads are inserted when liveblogs live update, breakpoint: ${breakpoint}`, () => {
 				cy.viewport(width, height);
@@ -25,29 +25,21 @@ describe('Liveblog live updates', () => {
 				cy.window().invoke('mockLiveUpdate', {
 					numNewBlocks: 5,
 					html: `
-							<p style="height:1000px;" class="pending block">New block</p>
-							<p style="height:1000px;" class="pending block">New block</p>
-							<p style="height:1000px;" class="pending block">New block</p>
-							<p style="height:1000px;" class="pending block">New block</p>
-							<p style="height:1000px;" class="pending block">New block</p>
-							`,
+						<p style="height:1000px;" class="pending block">New block</p>
+						<p style="height:1000px;" class="pending block">New block</p>
+						<p style="height:1000px;" class="pending block">New block</p>
+						<p style="height:1000px;" class="pending block">New block</p>
+						<p style="height:1000px;" class="pending block">New block</p>
+					`,
 					mostRecentBlockId: 'abc',
 				});
 
-				if (expectedMinInlineSlotsOnPage) {
-					cy.get('@adCount').then((adCount) => {
-						cy.get(
-							`#dfp-ad--inline${
-								breakpoint === 'mobile'
-									? expectedMinInlineSlotsOnPage + 3
-									: expectedMinInlineSlotsOnPage + 1
-							}`,
-						).should('exist');
-						cy.get('#liveblog-body .ad-slot')
-							.its('length')
-							.should('be.gt', adCount);
-					});
-				}
+				// Ensure that another ad has been added to the page after the new blocks are inserted
+				cy.get('@adCount').then((adCount) => {
+					cy.get('#liveblog-body .ad-slot')
+						.its('length')
+						.should('be.gt', adCount);
+				});
 			});
 		});
 	});

--- a/cypress/fixtures/pages/Page.ts
+++ b/cypress/fixtures/pages/Page.ts
@@ -1,5 +1,6 @@
 export type Page = {
 	path: string;
 	name?: string;
-	expectedMinInlineSlotsOnPage?: number;
+	expectedMinInlineSlotsOnMobile?: number;
+	expectedMinInlineSlotsOnDesktop?: number;
 };

--- a/cypress/fixtures/pages/articles.ts
+++ b/cypress/fixtures/pages/articles.ts
@@ -21,7 +21,8 @@ const articles: Page[] = [
 			stage,
 			'/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife',
 		),
-		expectedMinInlineSlotsOnPage: 10,
+		expectedMinInlineSlotsOnDesktop: 11,
+		expectedMinInlineSlotsOnMobile: 16,
 	},
 	{
 		path: getTestUrl(

--- a/cypress/fixtures/pages/liveblogs.ts
+++ b/cypress/fixtures/pages/liveblogs.ts
@@ -10,7 +10,16 @@ const liveblogs: Page[] = [
 			'/politics/live/2022/jan/31/uk-politics-live-omicron-nhs-workers-coronavirus-vaccines-no-10-sue-gray-report',
 			'liveblog',
 		),
-		expectedMinInlineSlotsOnPage: 4,
+		name: 'live-update',
+	},
+	{
+		path: getTestUrl(
+			stage,
+			'/business/live/2023/aug/07/halifax-house-prices-gradual-drop-annual-fall-in-july-interest-rates-mortgages-business-live',
+			'liveblog',
+		),
+		expectedMinInlineSlotsOnDesktop: 4,
+		expectedMinInlineSlotsOnMobile: 5,
 	},
 ];
 


### PR DESCRIPTION
## What does this change?

- Fixes a failing cypress test. 
- Replaces the liveblog test page with another that contains a more typical number of embeds. The previous Liveblog test page had a lot more Twitter embeds than usual.
- Split expected slot tests into mobile and desktop.

## Why?

- The reduction in line height for text content on liveblog meant that the page became shorter and commercial have less space to insert ads. On the test liveblog page, we were now only inserting 3 ads instead of 4 at some breakpoints.
- There is no need for our test liveblog page to have so many twitter embeds. It was a red herring when investigating the cause of this Cypress test failure.
- Desktop and mobile screen sizes typically render a different number of ad slots