### PR TITLE
Add cypress test for pageskins

### DIFF
--- a/cypress/e2e/parallel-4/pageskin.cy.ts
+++ b/cypress/e2e/parallel-4/pageskin.cy.ts
@@ -24,10 +24,13 @@ describe('pageskin on uk front', () => {
 			cy.intercept(gamUrl, (req) => {
 				req.continue((res) => {
 					expect(res.headers).to.have.property('google-lineitem-id');
-					expect(
-						(res.headers['google-lineitem-id'] as string).split(',')
-							.length,
-					).to.be.greaterThan(1);
+
+					// In Single Request Mode, the google-lineitem-id header will contain multiple line item ids
+					const lineItemIds = (
+						res.headers['google-lineitem-id'] as string
+					).split(',');
+
+					expect(lineItemIds).to.be.greaterThan(1);
 				});
 			}).as('gamCall');
 
@@ -52,10 +55,11 @@ describe('pageskin on uk front', () => {
 			cy.intercept(gamUrl, (req) => {
 				req.continue((res) => {
 					expect(res.headers).to.have.property('google-lineitem-id');
-					expect(
-						(res.headers['google-lineitem-id'] as string).split(',')
-							.length,
-					).to.equal(1);
+					// In Non Single Request Mode, the google-lineitem-id header will contain a single line item id
+					const lineItemIds = (
+						res.headers['google-lineitem-id'] as string
+					).split(',');
+					expect(lineItemIds).to.have.lengthOf(1);
 				});
 			}).as('gamCall');
 

--- a/cypress/e2e/parallel-4/pageskin.cy.ts
+++ b/cypress/e2e/parallel-4/pageskin.cy.ts
@@ -12,7 +12,7 @@ const small = breakpoints.filter(
 	({ breakpoint }) => breakpoint === 'mobile' || breakpoint === 'tablet',
 );
 
-describe('merchandising slot on pages', () => {
+describe('pageskin on uk front', () => {
 	beforeEach(() => {
 		cy.useConsentedSession('pageskin-consented');
 	});

--- a/cypress/e2e/parallel-4/pageskin.cy.ts
+++ b/cypress/e2e/parallel-4/pageskin.cy.ts
@@ -30,7 +30,7 @@ describe('pageskin on uk front', () => {
 						res.headers['google-lineitem-id'] as string
 					).split(',');
 
-					expect(lineItemIds).to.be.greaterThan(1);
+					expect(lineItemIds.length).to.be.greaterThan(1);
 				});
 			}).as('gamCall');
 
@@ -55,11 +55,12 @@ describe('pageskin on uk front', () => {
 			cy.intercept(gamUrl, (req) => {
 				req.continue((res) => {
 					expect(res.headers).to.have.property('google-lineitem-id');
+
 					// In Non Single Request Mode, the google-lineitem-id header will contain a single line item id
 					const lineItemIds = (
 						res.headers['google-lineitem-id'] as string
 					).split(',');
-					expect(lineItemIds).to.have.lengthOf(1);
+					expect(lineItemIds.length).to.equal(1);
 				});
 			}).as('gamCall');
 

--- a/cypress/e2e/parallel-4/pageskin.cy.ts
+++ b/cypress/e2e/parallel-4/pageskin.cy.ts
@@ -1,0 +1,75 @@
+import { breakpoints } from '../../fixtures/breakpoints';
+import { frontWithPageSkin } from '../../fixtures/pages';
+import { mockIntersectionObserver } from '../../lib/util';
+
+const gamUrl = 'https://securepubads.g.doubleclick.net/gampad/ads?**';
+
+const large = breakpoints.filter(
+	({ breakpoint }) => breakpoint === 'desktop' || breakpoint === 'wide',
+);
+
+const small = breakpoints.filter(
+	({ breakpoint }) => breakpoint === 'mobile' || breakpoint === 'tablet',
+);
+
+describe('merchandising slot on pages', () => {
+	beforeEach(() => {
+		cy.useConsentedSession('pageskin-consented');
+	});
+
+	large.forEach((breakpoint) => {
+		it(`Test ${frontWithPageSkin.path} on ${breakpoint.breakpoint} should display the pageskin background and use single request mode`, () => {
+			cy.viewport(breakpoint.width, breakpoint.height);
+
+			cy.intercept(gamUrl, (req) => {
+				req.continue((res) => {
+					expect(res.headers).to.have.property('google-lineitem-id');
+					expect(
+						(res.headers['google-lineitem-id'] as string).split(',')
+							.length,
+					).to.be.greaterThan(1);
+				});
+			}).as('gamCall');
+
+			cy.visit(frontWithPageSkin.path, {
+				onBeforeLoad(win) {
+					mockIntersectionObserver(win, '#dfp-ad--top-above-nav');
+				},
+			});
+
+			cy.wait('@gamCall');
+
+			cy.get('body')
+				.should('have.class', 'has-page-skin')
+				.should('have.css', 'background-image');
+		});
+	});
+
+	small.forEach((breakpoint) => {
+		it(`Test ${frontWithPageSkin.path} on ${breakpoint.breakpoint} should not display the pageskin and not use single request mode`, () => {
+			cy.viewport(breakpoint.width, breakpoint.height);
+
+			cy.intercept(gamUrl, (req) => {
+				req.continue((res) => {
+					expect(res.headers).to.have.property('google-lineitem-id');
+					expect(
+						(res.headers['google-lineitem-id'] as string).split(',')
+							.length,
+					).to.equal(1);
+				});
+			}).as('gamCall');
+
+			cy.visit(frontWithPageSkin.path, {
+				onBeforeLoad(win) {
+					mockIntersectionObserver(win, '#dfp-ad--top-above-nav');
+				},
+			});
+
+			cy.wait('@gamCall');
+
+			cy.get('body')
+				.should('have.class', 'has-page-skin')
+				.should('have.css', 'background-image');
+		});
+	});
+});

--- a/cypress/fixtures/pages/articles.ts
+++ b/cypress/fixtures/pages/articles.ts
@@ -8,21 +8,18 @@ const articles: Page[] = [
 		path: getTestUrl(
 			stage,
 			'/politics/2022/feb/10/keir-starmer-says-stop-the-war-coalition-gives-help-to-authoritarians-like-putin',
-			{ isDcr: true },
 		),
 	},
 	{
 		path: getTestUrl(
 			stage,
 			'/sport/2022/feb/10/team-gb-winter-olympic-struggles-go-on-with-problems-for-skeleton-crew',
-			{ isDcr: true },
 		),
 	},
 	{
 		path: getTestUrl(
 			stage,
 			'/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife',
-			{ isDcr: true },
 		),
 		expectedMinInlineSlotsOnPage: 10,
 	},
@@ -30,7 +27,6 @@ const articles: Page[] = [
 		path: getTestUrl(
 			stage,
 			'/society/2020/aug/13/disabled-wont-receive-critical-care-covid-terrifying',
-			{ isDcr: true },
 		),
 		name: 'sensitive-content',
 	},
@@ -38,7 +34,7 @@ const articles: Page[] = [
 		path: getTestUrl(
 			stage,
 			'/politics/2022/feb/10/keir-starmer-says-stop-the-war-coalition-gives-help-to-authoritarians-like-putin',
-			{ isDcr: true },
+			'article',
 			'comdev',
 		),
 	},

--- a/cypress/fixtures/pages/fronts.ts
+++ b/cypress/fixtures/pages/fronts.ts
@@ -9,17 +9,22 @@ const stage = getStage();
 
 const fronts: Front[] = [
 	{
-		path: getTestUrl(stage, '/uk'),
+		path: getTestUrl(stage, '/uk', 'front', 'puppies-pageskin'),
 		section: 'uk',
 	},
 	{
-		path: getTestUrl(stage, '/commentisfree'),
+		path: getTestUrl(stage, '/commentisfree', 'front', 'puppies-pageskin'),
 		section: 'commentisfree',
 	},
 	{
-		path: getTestUrl(stage, '/sport'),
+		path: getTestUrl(stage, '/sport', 'front', 'puppies-pageskin'),
 		section: 'sport',
 	},
 ];
 
-export { fronts };
+const frontWithPageSkin: Front = {
+	path: getTestUrl(stage, '/uk', 'front', 'puppies-pageskin'),
+	section: 'uk',
+};
+
+export { fronts, frontWithPageSkin };

--- a/cypress/fixtures/pages/index.ts
+++ b/cypress/fixtures/pages/index.ts
@@ -1,7 +1,7 @@
-import { fronts } from './fronts';
+import { fronts, frontWithPageSkin } from './fronts';
 import { articles } from './articles';
 import { liveblogs } from './liveblogs';
 
 const allPages = [...articles, ...liveblogs];
 
-export { articles, liveblogs, allPages };
+export { articles, liveblogs, fronts, frontWithPageSkin, allPages };

--- a/cypress/fixtures/pages/liveblogs.ts
+++ b/cypress/fixtures/pages/liveblogs.ts
@@ -8,7 +8,6 @@ const liveblogs: Page[] = [
 		path: getTestUrl(
 			stage,
 			'/politics/live/2022/jan/31/uk-politics-live-omicron-nhs-workers-coronavirus-vaccines-no-10-sue-gray-report?live=true',
-			{ isDcr: true },
 		),
 		expectedMinInlineSlotsOnPage: 4,
 	},

--- a/cypress/fixtures/pages/liveblogs.ts
+++ b/cypress/fixtures/pages/liveblogs.ts
@@ -7,7 +7,8 @@ const liveblogs: Page[] = [
 	{
 		path: getTestUrl(
 			stage,
-			'/politics/live/2022/jan/31/uk-politics-live-omicron-nhs-workers-coronavirus-vaccines-no-10-sue-gray-report?live=true',
+			'/politics/live/2022/jan/31/uk-politics-live-omicron-nhs-workers-coronavirus-vaccines-no-10-sue-gray-report',
+			'liveblog',
 		),
 		expectedMinInlineSlotsOnPage: 4,
 	},

--- a/cypress/lib/util.ts
+++ b/cypress/lib/util.ts
@@ -16,7 +16,7 @@ const hostnames = {
 export const getTestUrl = (
 	stage: 'code' | 'prod' | 'dev',
 	path: string,
-	type: 'article' | 'front' = 'article',
+	type: 'article' | 'liveblog' | 'front' = 'article',
 	adtest = 'fixed-puppies-ci',
 ) => {
 	let url = new URL('https://www.theguardian.com');
@@ -24,6 +24,10 @@ export const getTestUrl = (
 	url.hostname = hostnames[stage] ?? hostnames.dev;
 	url.protocol = stage === 'prod' || stage === 'code' ? 'https' : 'http';
 	url.pathname = stage === 'dev' ? `/${type}/${path}` : path;
+
+	if (type === 'liveblog') {
+		url.searchParams.append('live', '1');
+	}
 
 	if (adtest) {
 		url.searchParams.append('adtest', adtest);

--- a/cypress/lib/util.ts
+++ b/cypress/lib/util.ts
@@ -1,9 +1,25 @@
 import type { UserFeaturesResponse } from '../../src/types/membership';
 
 const hostnames = {
-	code: 'code.dev-theguardian.com',
-	prod: 'www.theguardian.com',
-	dev: 'localhost:3030',
+	code: 'https://code.dev-theguardian.com',
+	prod: 'https://www.theguardian.com',
+	dev: 'http://localhost:3030',
+};
+
+const getPath = (
+	stage: 'code' | 'prod' | 'dev',
+	type: 'article' | 'liveblog' | 'front' = 'article',
+	path: string,
+) => {
+	if (stage === 'dev') {
+		if (type === 'liveblog' || type === 'article') {
+			return `Article/https://www.theguardian.com${path}`;
+		} else {
+			return `Front/https://www.theguardian.com${path}`;
+		}
+	}
+
+	return path;
 };
 /**
  * Generate a full URL for a given relative path and the desired stage
@@ -21,9 +37,9 @@ export const getTestUrl = (
 ) => {
 	let url = new URL('https://www.theguardian.com');
 
-	url.hostname = hostnames[stage] ?? hostnames.dev;
-	url.protocol = stage === 'prod' || stage === 'code' ? 'https' : 'http';
-	url.pathname = stage === 'dev' ? `/${type}/${path}` : path;
+	url.href = hostnames[stage];
+
+	url.pathname = getPath(stage, type, path);
 
 	if (type === 'liveblog') {
 		url.searchParams.append('live', '1');

--- a/cypress/lib/util.ts
+++ b/cypress/lib/util.ts
@@ -1,5 +1,7 @@
 import type { UserFeaturesResponse } from '../../src/types/membership';
 
+type Stage = 'code' | 'prod' | 'dev';
+
 const hostnames = {
 	code: 'https://code.dev-theguardian.com',
 	prod: 'https://www.theguardian.com',
@@ -7,7 +9,7 @@ const hostnames = {
 };
 
 const getPath = (
-	stage: 'code' | 'prod' | 'dev',
+	stage: Stage,
 	type: 'article' | 'liveblog' | 'front' = 'article',
 	path: string,
 ) => {
@@ -21,6 +23,10 @@ const getPath = (
 
 	return path;
 };
+
+const normalizeStage = (stage: string): Stage =>
+	['code', 'prod', 'dev'].includes(stage) ? (stage as Stage) : 'dev';
+
 /**
  * Generate a full URL for a given relative path and the desired stage
  *
@@ -30,14 +36,14 @@ const getPath = (
  * @returns {string} The full path
  */
 export const getTestUrl = (
-	stage: 'code' | 'prod' | 'dev',
+	stage: Stage,
 	path: string,
 	type: 'article' | 'liveblog' | 'front' = 'article',
 	adtest = 'fixed-puppies-ci',
 ) => {
 	let url = new URL('https://www.theguardian.com');
 
-	url.href = hostnames[stage];
+	url.href = hostnames[stage] ?? hostnames.dev;
 
 	url.pathname = getPath(stage, type, path);
 
@@ -59,9 +65,9 @@ export const getTestUrl = (
  * Pass different stage in via environment variable
  * e.g. `yarn cypress run --env stage=code`
  */
-export const getStage = () => {
+export const getStage = (): Stage => {
 	const stage = Cypress.env('stage');
-	return stage?.toLowerCase();
+	return normalizeStage(stage?.toLowerCase());
 };
 
 export const fakeLogin = (subscriber = true) => {


### PR DESCRIPTION
## What does this change?
Add a test for pageskins, testing if the pageskin image is applied on desktop and that Single Request Mode is used, also check the opposite on tablet/mobile.

Refactored `getTestUrl` slightly, to remove DCR option, we're always on DCR now and in the future.

## Why?
We wan't to be confident that the logic is working correctly, especially single request mode, it's not easy to notice if it's not behaving as we'd like.

Bonus: [Puppies Test Pageskin](https://www.theguardian.com/uk?adtest=puppies-pageskin)