### PR TITLE
Update @types/googletag to v3.0.3

### DIFF
--- a/.changeset/grumpy-needles-study.md
+++ b/.changeset/grumpy-needles-study.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Update @types/googletag to v3.0.3

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"@percy/cli": "^1.26.0",
 		"@percy/cypress": "^3.1.2",
 		"@types/google.analytics": "^0.0.42",
-		"@types/googletag": "~1.1.3",
+		"@types/googletag": "~3.0.3",
 		"@types/jest": "^29.4.0",
 		"@types/lodash-es": "^4.17.6",
 		"@types/node": "18.15.0",

--- a/src/lib/dfp/on-slot-render.ts
+++ b/src/lib/dfp/on-slot-render.ts
@@ -59,7 +59,7 @@ export const onSlotRender = (
 		 * if advert.hasPrebidSize is false we use size
 		 * from the GAM event when adjusting the slot size.
 		 * */
-		if (!advert.hasPrebidSize) {
+		if (!advert.hasPrebidSize && event.size) {
 			advert.size = sizeEventToAdSize(event.size);
 		}
 

--- a/src/lib/dfp/prepare-googletag.spec.ts
+++ b/src/lib/dfp/prepare-googletag.spec.ts
@@ -292,9 +292,10 @@ describe('DFP', () => {
 		document.head.appendChild($style);
 
 		pubAds = {
-			listeners: listeners,
 			// @ts-expect-error - it is a mock
+			listeners: listeners,
 			addEventListener: jest.fn((eventType, listener) => {
+				// @ts-expect-error - it is a mock
 				listeners[eventType] = listener;
 				return pubAds;
 			}),
@@ -607,13 +608,17 @@ describe('DFP', () => {
 			mockOnConsent(ausNotRejected);
 			mockGetConsentFor(true);
 			await prepareGoogletag();
-			expect(pubAds.setRequestNonPersonalizedAds).toHaveBeenCalledWith(0);
+			expect(pubAds.setPrivacySettings).toHaveBeenCalledWith({
+				nonPersonalizedAds: false,
+			});
 		});
 		it('when AUS consent is NOT given', async () => {
 			mockOnConsent(ausRejected);
 			mockGetConsentFor(false);
 			await prepareGoogletag();
-			expect(pubAds.setRequestNonPersonalizedAds).toHaveBeenCalledWith(1);
+			expect(pubAds.setPrivacySettings).toHaveBeenCalledWith({
+				nonPersonalizedAds: true,
+			});
 		});
 	});
 	describe('restrictDataProcessing flag in CCPA', () => {

--- a/src/lib/dfp/prepare-googletag.ts
+++ b/src/lib/dfp/prepare-googletag.ts
@@ -110,7 +110,6 @@ export const init = (): Promise<void> => {
 				canRun = getConsentFor('googletag', consentState);
 			} else if (consentState.aus) {
 				// AUS mode
-				// canRun stays true, set NPA flag
 				const nonPersonalizedAds = !getConsentFor(
 					'googletag',
 					consentState,

--- a/src/lib/dfp/prepare-googletag.ts
+++ b/src/lib/dfp/prepare-googletag.ts
@@ -111,11 +111,14 @@ export const init = (): Promise<void> => {
 			} else if (consentState.aus) {
 				// AUS mode
 				// canRun stays true, set NPA flag
-				const npaFlag = !getConsentFor('googletag', consentState);
+				const nonPersonalizedAds = !getConsentFor(
+					'googletag',
+					consentState,
+				);
 				window.googletag.cmd.push(() => {
-					window.googletag
-						.pubads()
-						.setRequestNonPersonalizedAds(npaFlag ? 1 : 0);
+					window.googletag.pubads().setPrivacySettings({
+						nonPersonalizedAds,
+					});
 				});
 			}
 

--- a/src/lib/dfp/prepare-permutive.ts
+++ b/src/lib/dfp/prepare-permutive.ts
@@ -219,10 +219,9 @@ export const initPermutive = (): Promise<void> => {
 		{},
 	);
 	/* eslint-enable */
-	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- this is a stub
-	(window.googletag = window.googletag || {}),
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- this is a stub
-		(window.googletag.cmd = window.googletag.cmd || []),
+	(window.googletag = window.googletag || {}), // eslint-disable-line @typescript-eslint/no-unnecessary-condition -- this is a stub
+		// @ts-expect-error -- this is a stub
+		(window.googletag.cmd = window.googletag.cmd || []), // eslint-disable-line @typescript-eslint/no-unnecessary-condition -- this is a stub
 		window.googletag.cmd.push(() => {
 			if (
 				window.googletag.pubads().getTargeting('permutive').length === 0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2087,10 +2087,10 @@
   resolved "https://registry.yarnpkg.com/@types/google.analytics/-/google.analytics-0.0.42.tgz#efe6ef9251a22ec8208dbb09f221a48a1863d720"
   integrity sha512-w0ZFj3SHznQXSq99kFCuO8tkN6w4T14znjrF2alLCSDnHOXEnpzneyNwxLvekcsDBInr8b5mXmzYh03GArqEyw==
 
-"@types/googletag@~1.1.3":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@types/googletag/-/googletag-1.1.4.tgz#7717c529347a1acd39aebd0f8de08dc9d365ff29"
-  integrity sha512-2hUHxgj2xr9JXvAiLL6bZAbc41ZPSLQXIjqhJ3Yuvt2oZEtpXvwdJQDQOJYL3mNwynrsTS4E+m1tZW5mbGSyag==
+"@types/googletag@~3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/googletag/-/googletag-3.0.3.tgz#c49d541a522bf26bcd2a8f7a0a524d3204e0d56e"
+  integrity sha512-5WNCmZOFtNsvAmS25vxKj/oSKgSVnmcdRau3g2bo37t8m7GqQUWHpsLOJDhmQX68WMbOvnTSGZIHS1CbBn8pHA==
 
 "@types/graceful-fs@^4.1.3":
   version "4.1.6"


### PR DESCRIPTION
## What does this change?
Update @types/googletag v3.0.3

## Why?
Some of the types have been updated, and `googletag.setNonPersonalizedAds` was deprecated, requiring some code change, so giving this dependency update it's own PR

The deprecation is in the types PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61241, but missing from the release notes https://developers.google.com/publisher-tag/release-notes which was a little confusing.


