### PR TITLE
YouTube targeting uses `Consentstate.canTarget`

### DIFF
--- a/.changeset/eighty-lizards-refuse.md
+++ b/.changeset/eighty-lizards-refuse.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+YouTube targeting uses Consentstate.canTarget

--- a/src/core/targeting/youtube.ts
+++ b/src/core/targeting/youtube.ts
@@ -46,19 +46,20 @@ const buildAdsConfig = (
 		} satisfies AdsConfigCCPAorAus;
 	}
 
-	if (cmpConsent.tcfv2) {
+	if (cmpConsent.framework === 'tcfv2') {
 		const tcfData = cmpConsent.tcfv2;
-		const canTarget = Object.values(tcfData.consents).every(Boolean);
-		const mergedAdTagParameters = {
-			...defaultAdsConfig.adTagParameters,
-			cmpGdpr: tcfData.gdprApplies ? 1 : 0,
-			cmpGvcd: tcfData.addtlConsent,
-			cmpVcd: tcfData.tcString,
-		};
-		return {
-			adTagParameters: mergedAdTagParameters,
-			nonPersonalizedAd: !canTarget,
-		} satisfies AdsConfigTCFV2;
+		if (tcfData) {
+			const mergedAdTagParameters = {
+				...defaultAdsConfig.adTagParameters,
+				cmpGdpr: tcfData.gdprApplies ? 1 : 0,
+				cmpGvcd: tcfData.addtlConsent,
+				cmpVcd: tcfData.tcString,
+			};
+			return {
+				adTagParameters: mergedAdTagParameters,
+				nonPersonalizedAd: !cmpConsent.canTarget,
+			} satisfies AdsConfigTCFV2;
+		}
 	}
 
 	// Shouldn't happen but handle if no matching framework

--- a/src/core/targeting/youtube.ts
+++ b/src/core/targeting/youtube.ts
@@ -39,20 +39,11 @@ const buildAdsConfig = (
 		},
 	};
 
-	if (cmpConsent.ccpa) {
-		const canTarget = !cmpConsent.ccpa.doNotSell;
+	if (cmpConsent.framework === 'ccpa' || cmpConsent.framework === 'aus') {
 		return {
 			...defaultAdsConfig,
-			restrictedDataProcessor: !canTarget,
-		} as AdsConfigCCPAorAus;
-	}
-
-	if (cmpConsent.aus) {
-		const canTarget = cmpConsent.aus.personalisedAdvertising;
-		return {
-			...defaultAdsConfig,
-			restrictedDataProcessor: !canTarget,
-		} as AdsConfigCCPAorAus;
+			restrictedDataProcessor: !cmpConsent.canTarget,
+		} satisfies AdsConfigCCPAorAus;
 	}
 
 	if (cmpConsent.tcfv2) {
@@ -67,7 +58,7 @@ const buildAdsConfig = (
 		return {
 			adTagParameters: mergedAdTagParameters,
 			nonPersonalizedAd: !canTarget,
-		} as AdsConfigTCFV2;
+		} satisfies AdsConfigTCFV2;
 	}
 
 	// Shouldn't happen but handle if no matching framework


### PR DESCRIPTION
## What does this change?

YouTube targeting uses `Consentstate.canTarget`

Since [this PR](https://github.com/guardian/consent-management-platform/pull/597) we now determine `canTarget` as part of the CMP process [here](https://github.com/guardian/consent-management-platform/blob/e768b95da95ded9c6320247cf5ddebb9beeb19a4/src/onConsentChange.ts#L50).

