### PR TITLE
Add kargo as a prebid bidder in the US if in 0% AB test

### DIFF
--- a/.changeset/young-houses-eat.md
+++ b/.changeset/young-houses-eat.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Add kargo as a prebid bidder in the US

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",
 		"ophan-tracker-js": "^1.4.0",
-		"prebid.js": "guardian/prebid.js",
+		"prebid.js": "guardian/prebid.js#1d6bbdc",
 		"process": "^0.11.10",
 		"raven-js": "^3.27.2",
 		"tslib": "^2.5.3",

--- a/src/lib/experiments/ab-tests.ts
+++ b/src/lib/experiments/ab-tests.ts
@@ -6,6 +6,7 @@ import { elementsManager } from './tests/elements-manager';
 import { integrateIma } from './tests/integrate-ima';
 import { limitInlineMerch } from './tests/limit-inline-merch';
 import { liveblogRightColumnAds } from './tests/liveblog-right-column-ads';
+import { prebidKargo } from './tests/prebid-kargo';
 import { publicGoodTest } from './tests/public-good';
 import { signInGateCopyTestJan2023 } from './tests/sign-in-gate-copy-test-variant';
 import { signInGateMainControl } from './tests/sign-in-gate-main-control';
@@ -25,4 +26,5 @@ export const concurrentTests: readonly ABTest[] = [
 	limitInlineMerch,
 	liveblogRightColumnAds,
 	publicGoodTest,
+	prebidKargo,
 ];

--- a/src/lib/experiments/tests/prebid-kargo.ts
+++ b/src/lib/experiments/tests/prebid-kargo.ts
@@ -1,0 +1,28 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const prebidKargo: ABTest = {
+	id: 'PrebidKargo',
+	author: '@commercial-dev',
+	start: '2023-08-10',
+	expiry: '2023-09-29',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: 'USA only',
+	successMeasure: '',
+	description: 'Test Kargo as a prebid bidder for US traffic',
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+	canRun: () => true,
+};

--- a/src/lib/header-bidding/prebid-types.ts
+++ b/src/lib/header-bidding/prebid-types.ts
@@ -111,6 +111,10 @@ export type PrebidSmartParams = {
 	formatId: number;
 };
 
+export type PrebidKargoParams = {
+	placementId: string;
+};
+
 export type BidderCode =
 	| 'adyoulike'
 	| 'and'
@@ -125,7 +129,8 @@ export type BidderCode =
 	| 'sonobi'
 	| 'triplelift'
 	| 'trustx'
-	| 'xhb';
+	| 'xhb'
+	| 'kargo';
 
 export type PrebidParams =
 	| PrebidAdYouLikeParams
@@ -140,7 +145,8 @@ export type PrebidParams =
 	| PrebidSonobiParams
 	| PrebidTripleLiftParams
 	| PrebidTrustXParams
-	| PrebidXaxisParams;
+	| PrebidXaxisParams
+	| PrebidKargoParams;
 
 export type PrebidBidder = {
 	name: BidderCode;

--- a/src/lib/header-bidding/prebid-types.ts
+++ b/src/lib/header-bidding/prebid-types.ts
@@ -122,6 +122,7 @@ export type BidderCode =
 	| 'criteo'
 	| 'improvedigital'
 	| 'ix'
+	| 'kargo'
 	| 'oxd'
 	| 'ozone'
 	| 'pubmatic'
@@ -129,8 +130,7 @@ export type BidderCode =
 	| 'sonobi'
 	| 'triplelift'
 	| 'trustx'
-	| 'xhb'
-	| 'kargo';
+	| 'xhb';
 
 export type PrebidParams =
 	| PrebidAdYouLikeParams
@@ -138,6 +138,7 @@ export type PrebidParams =
 	| PrebidCriteoParams
 	| PrebidImproveParams
 	| PrebidIndexExchangeParams
+	| PrebidKargoParams
 	| PrebidOpenXParams
 	| PrebidOzoneParams
 	| PrebidPubmaticParams
@@ -145,8 +146,7 @@ export type PrebidParams =
 	| PrebidSonobiParams
 	| PrebidTripleLiftParams
 	| PrebidTrustXParams
-	| PrebidXaxisParams
-	| PrebidKargoParams;
+	| PrebidXaxisParams;
 
 export type PrebidBidder = {
 	name: BidderCode;

--- a/src/lib/header-bidding/prebid/bid-config.ts
+++ b/src/lib/header-bidding/prebid/bid-config.ts
@@ -493,7 +493,7 @@ const biddersBeingTested = (allBidders: PrebidBidder[]): PrebidBidder[] =>
 
 const biddersSwitchedOn = (allBidders: PrebidBidder[]): PrebidBidder[] => {
 	const isSwitchedOn = (bidder: PrebidBidder): boolean =>
-		window.guardian.config.switches[bidder.switchName] ?? true;
+		window.guardian.config.switches[bidder.switchName] ?? false;
 
 	return allBidders.filter((bidder) => isSwitchedOn(bidder));
 };

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -141,6 +141,7 @@ type BidderSettings = {
 	improvedigital?: Partial<BidderSetting>;
 	ozone?: Partial<BidderSetting>;
 	criteo?: Partial<BidderSetting>;
+	kargo?: Partial<BidderSetting>;
 };
 
 class PrebidAdUnit {
@@ -424,6 +425,12 @@ const initialise = (window: Window, framework: Framework = 'tcfv2'): void => {
 
 		pbjsConfig.improvedigital = {
 			usePrebidSizes: true,
+		};
+	}
+
+	if (window.guardian.config.switches.prebidKargo) {
+		window.pbjs.bidderSettings.kargo = {
+			storageAllowed: true,
 		};
 	}
 

--- a/src/lib/header-bidding/utils.ts
+++ b/src/lib/header-bidding/utils.ts
@@ -87,9 +87,6 @@ export const containsLeaderboard = (sizes: HeaderBiddingSize[]): boolean =>
 export const containsBillboard = (sizes: HeaderBiddingSize[]): boolean =>
 	contains(sizes, createAdSize(970, 250));
 
-export const containsSkyscraper = (sizes: HeaderBiddingSize[]): boolean =>
-	contains(sizes, createAdSize(160, 600));
-
 export const containsBillboardNotLeaderboard = (
 	sizes: HeaderBiddingSize[],
 ): boolean => containsBillboard(sizes) && !containsLeaderboard(sizes);

--- a/src/lib/header-bidding/utils.ts
+++ b/src/lib/header-bidding/utils.ts
@@ -5,11 +5,14 @@ import {
 	getCurrentTweakpoint,
 	matchesBreakpoints,
 } from 'lib/detect/detect-breakpoint';
+import { isInVariantSynchronous } from 'lib/experiments/ab';
+import { prebidKargo } from 'lib/experiments/tests/prebid-kargo';
 import {
 	isInAuOrNz,
 	isInCanada,
 	isInRow,
 	isInUk,
+	isInUsa,
 	isInUsOrCa,
 } from 'lib/utils/geo-utils';
 import { pbTestNameMap } from 'lib/utils/url';
@@ -83,6 +86,9 @@ export const containsLeaderboard = (sizes: HeaderBiddingSize[]): boolean =>
 
 export const containsBillboard = (sizes: HeaderBiddingSize[]): boolean =>
 	contains(sizes, createAdSize(970, 250));
+
+export const containsSkyscraper = (sizes: HeaderBiddingSize[]): boolean =>
+	contains(sizes, createAdSize(160, 600));
 
 export const containsBillboardNotLeaderboard = (
 	sizes: HeaderBiddingSize[],
@@ -184,6 +190,9 @@ export const shouldIncludeCriteo = (): boolean => !isInAuOrNz();
  * Determine whether to include Smart as a prebid bidder
  */
 export const shouldIncludeSmart = (): boolean => isInUk() || isInRow();
+
+export const shouldIncludeKargo = (): boolean =>
+	isInUsa() && isInVariantSynchronous(prebidKargo, 'variant');
 
 export const shouldIncludeMobileSticky = once(
 	(): boolean =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6944,9 +6944,9 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-prebid.js@guardian/prebid.js:
+prebid.js@guardian/prebid.js#1d6bbdc:
   version "7.26.0"
-  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/2e3b96dc57dfe14ed8c418674ee7a0a150ece7cb"
+  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/1d6bbdc64411fbe719489eb06bce72b66ac6a4f3"
   dependencies:
     "@babel/core" "^7.16.7"
     "@babel/plugin-transform-runtime" "^7.18.9"


### PR DESCRIPTION
## What does this change?
Adds `kargo` as a bidder in the USA, 

Frontend PR where switch and test was added: https://github.com/guardian/frontend/pull/26475

Enabling kargo bid adapter in our prebid.js fork https://github.com/guardian/Prebid.js/pull/134
which has been updated in this PR

The relevant line-items have been generated in this PR https://github.com/guardian/commercial-tools/pull/165 where you can see the price bucketing and line items priority (same as prebid main)

The placement IDs are as follows:
Platform | Type | Sizes | Placement ID
-- | -- | -- | --
Mobile | Middle In-Article | 300x250 | _y9LINEsbfh
Mobile | Adhesion | 320x50 | _odszPLn2hK
Desktop | Middle In-Article | 300x250 | _qDBbBXYtzA
Desktop | Right Rail | 300x250, 300x600, 160x600 | _zOpeEAyfiz
Desktop | Above The Fold | 728x90 | _y6zKwuoPpX
Desktop | Adhesion | 970x250 | _yflg9S7c2x



## Why?
We would like to add `kargo` as a prebid bidder in the USA behind a 0% test