### PR TITLE
Switch off liveblog right column ads AB test

### DIFF
--- a/.changeset/healthy-dolphins-grin.md
+++ b/.changeset/healthy-dolphins-grin.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Turn off liveblog right column ads ab test

--- a/src/lib/experiments/tests/liveblog-right-column-ads.ts
+++ b/src/lib/experiments/tests/liveblog-right-column-ads.ts
@@ -5,7 +5,7 @@ export const liveblogRightColumnAds: ABTest = {
 	author: '@commercial-dev',
 	start: '2023-08-01',
 	expiry: '2023-09-20',
-	audience: 15 / 100,
+	audience: 0 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: 'Desktop users with wide (1300px+) screens only',
 	successMeasure:


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

Turns off the liveblog-right-column-ads AB test.

## Why?

We have reached the required number of impressions to obtain a result for the test.