### PR TITLE
chore(deps): bump @guardian/libs

### DIFF
--- a/.changeset/red-cooks-heal.md
+++ b/.changeset/red-cooks-heal.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+A working getMeasure implementation

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
 		"@guardian/ab-core": "^5.0.0",
 		"@guardian/consent-management-platform": "^13.6.1",
 		"@guardian/core-web-vitals": "^5.0.0",
-		"@guardian/libs": "15.6.3",
+		"@guardian/libs": "15.6.4",
 		"@guardian/source-foundations": "^12.0.0",
 		"@guardian/support-dotcom-components": "^1.0.7",
 		"@octokit/core": "^4.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1369,10 +1369,10 @@
     eslint-plugin-eslint-comments "3.2.0"
     eslint-plugin-import "2.27.5"
 
-"@guardian/libs@15.6.3":
-  version "15.6.3"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.6.3.tgz#3c748640bfe706ef8ecbd44c101567bf2b769f4a"
-  integrity sha512-WRHnZGXMn7TD2p/gXWdK+u2ZnS+CAvQ1pdBEjT3x61Ab1YhxOYEIkF5gT+l2kACuJZ7a8pWwuO6CA89JcfZfrw==
+"@guardian/libs@15.6.4":
+  version "15.6.4"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.6.4.tgz#13787065e5c58b884944c5c71d6e324c7f2e566a"
+  integrity sha512-oN+xN7FBuVKLCbbjvAMdWjgWqOtvR38acnqwAKsjUDkFsBzRWU/pueDSEGTCTTVSFcRdCKOsWnop+Vwh59P47g==
 
 "@guardian/libs@^10.0.0":
   version "10.1.1"


### PR DESCRIPTION
## What does this change?

Bump @guardian/libs and bump this package…

## Why?

The latest version of `getMeasures` actually works – this package is not a peer dependency

See https://github.com/guardian/dotcom-rendering/pull/8571