### PR TITLE
Make `@guardian` dependencies peer dependencies

### DIFF
--- a/.changeset/heavy-berries-sit.md
+++ b/.changeset/heavy-berries-sit.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': major
+---
+
+Move guardian deps to peer deps

--- a/package.json
+++ b/package.json
@@ -52,8 +52,14 @@
 		"@babel/register": "^7.11.5",
 		"@babel/runtime": "^7.11.2",
 		"@cypress/webpack-preprocessor": "^5.17.1",
+		"@guardian/ab-core": "^5.0.0",
+		"@guardian/consent-management-platform": "^13.6.1",
+		"@guardian/core-web-vitals": "^5.0.0",
 		"@guardian/eslint-config-typescript": "^6.0.0",
+		"@guardian/libs": "15.6.3",
 		"@guardian/prettier": "^4.0.0",
+		"@guardian/source-foundations": "^12.0.0",
+		"@guardian/support-dotcom-components": "^1.0.7",
 		"@percy/cli": "^1.26.0",
 		"@percy/cypress": "^3.1.2",
 		"@types/google.analytics": "^0.0.42",
@@ -102,12 +108,6 @@
 	},
 	"dependencies": {
 		"@changesets/cli": "^2.26.1",
-		"@guardian/ab-core": "^5.0.0",
-		"@guardian/consent-management-platform": "^13.6.1",
-		"@guardian/core-web-vitals": "^5.0.0",
-		"@guardian/libs": "15.6.4",
-		"@guardian/source-foundations": "^12.0.0",
-		"@guardian/support-dotcom-components": "^1.0.7",
 		"@octokit/core": "^4.0.5",
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",
@@ -131,5 +131,12 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"peerDependencies": {
+		"@guardian/consent-management-platform": "^13.6.1",
+		"@guardian/core-web-vitals": "^5.0.0",
+		"@guardian/libs": "15.6.3",
+		"@guardian/source-foundations": "^12.0.0",
+		"@guardian/support-dotcom-components": "^1.0.7"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -54,11 +54,11 @@
 		"@cypress/webpack-preprocessor": "^5.17.1",
 		"@guardian/ab-core": "5.0.0",
 		"@guardian/consent-management-platform": "13.6.1",
-		"@guardian/core-web-vitals": "5.0.0",
+		"@guardian/core-web-vitals": "5.1.0",
 		"@guardian/eslint-config-typescript": "^6.0.0",
-		"@guardian/libs": "15.6.3",
+		"@guardian/libs": "15.6.4",
 		"@guardian/prettier": "4.0.0",
-		"@guardian/source-foundations": "12.0.0",
+		"@guardian/source-foundations": "13.0.0",
 		"@guardian/support-dotcom-components": "1.0.7",
 		"@percy/cli": "^1.26.0",
 		"@percy/cypress": "^3.1.2",
@@ -135,9 +135,9 @@
 	"peerDependencies": {
 		"@guardian/ab-core": "^5.0.0",
 		"@guardian/consent-management-platform": "^13.6.1",
-		"@guardian/core-web-vitals": "^5.0.0",
-		"@guardian/libs": "^15.6.3",
-		"@guardian/source-foundations": "^12.0.0",
+		"@guardian/core-web-vitals": "^5.1.0",
+		"@guardian/libs": "^15.6.4",
+		"@guardian/source-foundations": "^13.0.0",
 		"@guardian/support-dotcom-components": "^1.0.7"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -52,14 +52,14 @@
 		"@babel/register": "^7.11.5",
 		"@babel/runtime": "^7.11.2",
 		"@cypress/webpack-preprocessor": "^5.17.1",
-		"@guardian/ab-core": "^5.0.0",
-		"@guardian/consent-management-platform": "^13.6.1",
-		"@guardian/core-web-vitals": "^5.0.0",
+		"@guardian/ab-core": "5.0.0",
+		"@guardian/consent-management-platform": "13.6.1",
+		"@guardian/core-web-vitals": "5.0.0",
 		"@guardian/eslint-config-typescript": "^6.0.0",
 		"@guardian/libs": "15.6.3",
-		"@guardian/prettier": "^4.0.0",
-		"@guardian/source-foundations": "^12.0.0",
-		"@guardian/support-dotcom-components": "^1.0.7",
+		"@guardian/prettier": "4.0.0",
+		"@guardian/source-foundations": "12.0.0",
+		"@guardian/support-dotcom-components": "1.0.7",
 		"@percy/cli": "^1.26.0",
 		"@percy/cypress": "^3.1.2",
 		"@types/google.analytics": "^0.0.42",
@@ -133,9 +133,10 @@
 		"access": "public"
 	},
 	"peerDependencies": {
+		"@guardian/ab-core": "^5.0.0",
 		"@guardian/consent-management-platform": "^13.6.1",
 		"@guardian/core-web-vitals": "^5.0.0",
-		"@guardian/libs": "15.6.3",
+		"@guardian/libs": "^15.6.3",
 		"@guardian/source-foundations": "^12.0.0",
 		"@guardian/support-dotcom-components": "^1.0.7"
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1334,17 +1334,17 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.42.0.tgz#484a1d638de2911e6f5a30c12f49c7e4a3270fb6"
   integrity sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==
 
-"@guardian/ab-core@^5.0.0":
+"@guardian/ab-core@5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-5.0.0.tgz#cce32ff4cdfb6b24c013723bf352dcd61135d34d"
   integrity sha512-Td5gtK2sARl+fXj1Qe6RuFqf/zxuZjW1q2Jck09zXPIfMgU+sJoTi549zbNeC1cldCBhPWy/qPQ0r+8klfF7jg==
 
-"@guardian/consent-management-platform@^13.6.1":
+"@guardian/consent-management-platform@13.6.1":
   version "13.6.1"
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.6.1.tgz#528ed9193b1bd96e9f84964a5a1a080de43e29c1"
   integrity sha512-5KQ4dZrqIBKuJCSJ/TTWXZ4F0WXY9ecpMnfOfvNIU9tXF1LAeT+LNv7hfV8eC5qMJskj2yvZZUi7hlwWD+Nq/A==
 
-"@guardian/core-web-vitals@^5.0.0":
+"@guardian/core-web-vitals@5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/core-web-vitals/-/core-web-vitals-5.0.0.tgz#ab74da6001427f3414a84d15f57bac1a888a140a"
   integrity sha512-Mq3v8Y/YJGs7p/8NWmYHFKdVqRThjDJSfpoo1zSb6DgpQ1Ko8RjvOa2Q9P9ABWfKJCaDp0kcGK3dk0AjDSi/Qw==
@@ -1379,19 +1379,19 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-10.1.1.tgz#7048c365a68dda068f707d46c78979f430221963"
   integrity sha512-OdWReBHRWhdbErVmS15hihVzlkdU8DkKrjDsUIN0P8QZiF4twuzcU3qsPwto2UfibAwPkWqKkNwH1k8b6xNclA==
 
-"@guardian/prettier@^4.0.0":
+"@guardian/prettier@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-4.0.0.tgz#1ad1d7d079194937bfd0107789dde7b0fb84fa11"
   integrity sha512-JvvnDnI04NcmpuD2mF5ZXTWI7tand1pj1s33fh4JxHNAV00QXwTWZBI2/QWS3ck7KjpYjpRaz8CDUcMz35hReg==
 
-"@guardian/source-foundations@^12.0.0":
+"@guardian/source-foundations@12.0.0":
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-12.0.0.tgz#3f75d5dd26dae0d3fe13fd93aabe1e837cf0ddbb"
   integrity sha512-sq+htAsvPlaZBjfSZ8ISZZdAnFQwuZ7xeCrI/C369HA+MDl3pQ1dFWz3YmqCP/vkXS8Wr3qVlxXNqWGwKKrYrw==
   dependencies:
     mini-svg-data-uri "1.4.4"
 
-"@guardian/support-dotcom-components@^1.0.7":
+"@guardian/support-dotcom-components@1.0.7":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@guardian/support-dotcom-components/-/support-dotcom-components-1.0.7.tgz#b3aadcca5f6ee35b2c541121144be237d72bd3e0"
   integrity sha512-MhaO+rC+ujXMcaMd1TL5D0t0eEuHWGh3OrFkM8BhPwhMkjela/dCOPeVPvGJDJ0a37o4PeMszqy+dSuiR4BvvQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,10 +1344,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.6.1.tgz#528ed9193b1bd96e9f84964a5a1a080de43e29c1"
   integrity sha512-5KQ4dZrqIBKuJCSJ/TTWXZ4F0WXY9ecpMnfOfvNIU9tXF1LAeT+LNv7hfV8eC5qMJskj2yvZZUi7hlwWD+Nq/A==
 
-"@guardian/core-web-vitals@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/core-web-vitals/-/core-web-vitals-5.0.0.tgz#ab74da6001427f3414a84d15f57bac1a888a140a"
-  integrity sha512-Mq3v8Y/YJGs7p/8NWmYHFKdVqRThjDJSfpoo1zSb6DgpQ1Ko8RjvOa2Q9P9ABWfKJCaDp0kcGK3dk0AjDSi/Qw==
+"@guardian/core-web-vitals@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/core-web-vitals/-/core-web-vitals-5.1.0.tgz#1a7224ff69e773e30698fa16bdd5be608a554ebf"
+  integrity sha512-/6L5Ri+/bXBAZ6na8zQ30I1+eHXBHyGFNiLAGvw1bryOnbq2PjCLkmyHQq0EisWCXBWMvdB7p2HdS1DmFLM3Jg==
 
 "@guardian/eslint-config-typescript@^6.0.0":
   version "6.0.0"
@@ -1384,10 +1384,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-4.0.0.tgz#1ad1d7d079194937bfd0107789dde7b0fb84fa11"
   integrity sha512-JvvnDnI04NcmpuD2mF5ZXTWI7tand1pj1s33fh4JxHNAV00QXwTWZBI2/QWS3ck7KjpYjpRaz8CDUcMz35hReg==
 
-"@guardian/source-foundations@12.0.0":
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-12.0.0.tgz#3f75d5dd26dae0d3fe13fd93aabe1e837cf0ddbb"
-  integrity sha512-sq+htAsvPlaZBjfSZ8ISZZdAnFQwuZ7xeCrI/C369HA+MDl3pQ1dFWz3YmqCP/vkXS8Wr3qVlxXNqWGwKKrYrw==
+"@guardian/source-foundations@13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/source-foundations/-/source-foundations-13.0.0.tgz#3e8f4e67dcd5fe706001fd04df582f69210b132f"
+  integrity sha512-1+z20ySfwm0K2GiQXh2JlWIjOKBwHxISRdAgAKivOdT1QUCh5VdU+2xCVE07juMI4lBBfIzXe/qZXAI7II6tQQ==
   dependencies:
     mini-svg-data-uri "1.4.4"
 


### PR DESCRIPTION
## What does this change?

Move all `@guardian` dependencies to peer dependencies so that clients of commercial (primarily DCR) with strict checks on peer dependency alignment do not have to raise versions in lockstep.

Yarn and npm < v7 do not install peer dependencies so we have to add them to dev dependencies for local development and bundling.

The commercial repo publishes two things:
1) the commercial bundle which requires deps at bundle time
2) utility functions for consumption by consuming applications

aiui release bundling still works with @guardian deps as peers deps because we install all dependencies (i.e. not using install --production) and then this get cached and restored by all the workflow jobs.