### PR TITLE
VS Code title bar colour

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,8 +9,13 @@
 		"source.fixAll": true,
 		"source.organizeImports": false
 	},
+	"workbench.colorCustomizations": {
+		"titleBar.activeBackground": "#601414",
+		"titleBar.activeForeground": "#cccccc",
+		"titleBar.inactiveBackground": "#3a0a0a",
+		"titleBar.inactiveForeground": "#999999"
+	},
 	"eslint.format.enable": true,
-	"eslint.packageManager": "yarn",
 	"eslint.workingDirectories": [
 		{ "directory": "src", "changeProcessCWD": true }
 	],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,9 +10,9 @@
 		"source.organizeImports": false
 	},
 	"workbench.colorCustomizations": {
-		"titleBar.activeBackground": "#601414",
+		"titleBar.activeBackground": "#0b3e11",
 		"titleBar.activeForeground": "#cccccc",
-		"titleBar.inactiveBackground": "#3a0a0a",
+		"titleBar.inactiveBackground": "#041d07",
 		"titleBar.inactiveForeground": "#999999"
 	},
 	"eslint.format.enable": true,


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

- Sets the title bar colour of VS Code
- Remove `eslint.packageManager`

## Why?

- DX. Distinguish between code editors
- Package manager is detected automatically now

## Screenshots

Green?
https://github.com/guardian/commercial/assets/9574885/8895e018-8221-410f-aa52-64ca312927a1

or red?
https://github.com/guardian/commercial/assets/9574885/8141f95c-72f2-4943-a20e-40823e236801