### PR TITLE
Remove `.vscode/settings.json` from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ coverage
 
 # Editor settings
 .idea
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json.recommended
+!.vscode/settings.json.required
 
 # Work-in-progress folder
 wip

--- a/.vscode/settings.json.recommended
+++ b/.vscode/settings.json.recommended
@@ -1,3 +1,6 @@
+// Recommended VS Code settings for this project.
+// Copy these to .vscode/settings.json to apply them to your editor – but don't commit it!
+// https://github.com/guardian/recommendations/blob/main/VSCode.md#do-not-commit-vscode
 {
 	"[javascript]": {
 		"editor.formatOnSave": true
@@ -15,11 +18,6 @@
 		"titleBar.inactiveBackground": "#041d07",
 		"titleBar.inactiveForeground": "#999999"
 	},
-	"eslint.format.enable": true,
-	"eslint.workingDirectories": [
-		{ "directory": "src", "changeProcessCWD": true }
-	],
-	"typescript.tsdk": "node_modules/typescript/lib",
 	"cSpell.words": [
 		"AMTGRP",
 		"Bonzai",
@@ -38,5 +36,4 @@
 		"viewability",
 		"Youtube"
 	],
-	"jest.rootPath": "core"
 }

--- a/.vscode/settings.json.required
+++ b/.vscode/settings.json.required
@@ -1,0 +1,11 @@
+{
+	"eslint.format.enable": true,
+	"eslint.workingDirectories": [
+		{
+			"directory": "src",
+			"changeProcessCWD": true
+		}
+	],
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"jest.rootPath": "core"
+}


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

- Removes `.vscode/settings.json` from the repo
- Adds `.vscode/settings.json.required` and `.vscode/settings.json.recommended`

## Why?

In the spirit of [the recommendation](https://github.com/guardian/recommendations/blob/main/VSCode.md#vscodesettingsjson). We can then keep these files up to date and individual devs can pick and choose their preferred settings.