### PR TITLE
add new id's to tripleLift prebid for AUS

### DIFF
--- a/.changeset/hip-wasps-sniff.md
+++ b/.changeset/hip-wasps-sniff.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Adds tripleLift to the add list for US and Aus

--- a/src/lib/header-bidding/prebid/bid-config.spec.ts
+++ b/src/lib/header-bidding/prebid/bid-config.spec.ts
@@ -657,7 +657,7 @@ describe('triplelift adapter', () => {
 		});
 	});
 
-	test('should return correct triplelift adapter params for mbu, with requests from Aus or NZ', () => {
+	test('should return correct triplelift adapter params for MPU, with requests from Aus or NZ', () => {
 		containsLeaderboard.mockReturnValueOnce(false);
 		containsMpu.mockReturnValueOnce(true);
 		containsDmpu.mockReturnValueOnce(false);

--- a/src/lib/header-bidding/prebid/bid-config.spec.ts
+++ b/src/lib/header-bidding/prebid/bid-config.spec.ts
@@ -640,7 +640,7 @@ describe('triplelift adapter', () => {
 		});
 	});
 
-	test('should return correct triplelift adapter params, with requests from US or Canada', () => {
+	test('should return correct triplelift adapter params for MPU, with requests from US or Canada', () => {
 		containsLeaderboard.mockReturnValueOnce(false);
 		containsMpu.mockReturnValueOnce(true);
 		containsDmpu.mockReturnValueOnce(false);

--- a/src/lib/header-bidding/prebid/bid-config.spec.ts
+++ b/src/lib/header-bidding/prebid/bid-config.spec.ts
@@ -608,12 +608,12 @@ describe('triplelift adapter', () => {
 		expect(getBidders()).toEqual(['ix', 'triplelift']);
 	});
 
-	test('should return correct triplelift adapter params for leaderboard', () => {
+	test('should return correct triplelift adapter params for leaderboard, with requests from US or Canada', () => {
 		containsLeaderboard.mockReturnValueOnce(true);
 		containsMpu.mockReturnValueOnce(false);
 		containsDmpu.mockReturnValueOnce(false);
 		containsMobileSticky.mockReturnValueOnce(false);
-
+		isInUsOrCa.mockReturnValue(true);
 		const tripleLiftBids = bids(
 			'dfp-ad--top-above-nav',
 			[createAdSize(728, 90)],
@@ -624,11 +624,28 @@ describe('triplelift adapter', () => {
 		});
 	});
 
-	test('should return correct triplelift adapter params for mbu', () => {
+	test('should return correct triplelift adapter params for leaderboard, with requests from Aus or NZ', () => {
+		containsLeaderboard.mockReturnValueOnce(true);
+		containsMpu.mockReturnValueOnce(false);
+		containsDmpu.mockReturnValueOnce(false);
+		containsMobileSticky.mockReturnValueOnce(false);
+		isInAuOrNz.mockReturnValue(true);
+		const tripleLiftBids = bids(
+			'dfp-ad--top-above-nav',
+			[createAdSize(728, 90)],
+			mockPageTargeting,
+		)[1].params;
+		expect(tripleLiftBids).toEqual({
+			inventoryCode: 'theguardian_topbanner_728x90_prebid_AU',
+		});
+	});
+
+	test('should return correct triplelift adapter params, with requests from US or Canada', () => {
 		containsLeaderboard.mockReturnValueOnce(false);
 		containsMpu.mockReturnValueOnce(true);
 		containsDmpu.mockReturnValueOnce(false);
 		containsMobileSticky.mockReturnValueOnce(false);
+		isInUsOrCa.mockReturnValue(true);
 
 		const tripleLiftBids = bids(
 			'dfp-ad--inline1',
@@ -640,11 +657,29 @@ describe('triplelift adapter', () => {
 		});
 	});
 
-	test('should return correct triplelift adapter params for mobile sticky', () => {
+	test('should return correct triplelift adapter params for mbu, with requests from Aus or NZ', () => {
+		containsLeaderboard.mockReturnValueOnce(false);
+		containsMpu.mockReturnValueOnce(true);
+		containsDmpu.mockReturnValueOnce(false);
+		containsMobileSticky.mockReturnValueOnce(false);
+		isInAuOrNz.mockReturnValue(true);
+
+		const tripleLiftBids = bids(
+			'dfp-ad--inline1',
+			[createAdSize(300, 250)],
+			mockPageTargeting,
+		)[1].params;
+		expect(tripleLiftBids).toEqual({
+			inventoryCode: 'theguardian_sectionfront_300x250_prebid_AU',
+		});
+	});
+
+	test('should return correct triplelift adapter params for mobile sticky, with requests from US or Canada', () => {
 		containsLeaderboard.mockReturnValueOnce(false);
 		containsMpu.mockReturnValueOnce(false);
 		containsDmpu.mockReturnValueOnce(false);
 		containsMobileSticky.mockReturnValueOnce(true);
+		isInUsOrCa.mockReturnValue(true);
 
 		const tripleLiftBids = bids(
 			'dfp-ad--top-above-nav',
@@ -653,6 +688,23 @@ describe('triplelift adapter', () => {
 		)[1].params;
 		expect(tripleLiftBids).toEqual({
 			inventoryCode: 'theguardian_320x50_HDX',
+		});
+	});
+
+	test('should return correct triplelift adapter params for mobile sticky, with requests from Aus or NZ', () => {
+		containsLeaderboard.mockReturnValueOnce(false);
+		containsMpu.mockReturnValueOnce(false);
+		containsDmpu.mockReturnValueOnce(false);
+		containsMobileSticky.mockReturnValueOnce(true);
+		isInAuOrNz.mockReturnValue(true);
+
+		const tripleLiftBids = bids(
+			'dfp-ad--top-above-nav',
+			[createAdSize(320, 50)],
+			mockPageTargeting,
+		)[1].params;
+		expect(tripleLiftBids).toEqual({
+			inventoryCode: 'theguardian_320x50_HDX_AU',
 		});
 	});
 });

--- a/src/lib/header-bidding/prebid/bid-config.ts
+++ b/src/lib/header-bidding/prebid/bid-config.ts
@@ -161,18 +161,33 @@ const getTripleLiftInventoryCode = (
 	sizes: HeaderBiddingSize[],
 ): string => {
 	if (containsLeaderboard(sizes)) {
-		return 'theguardian_topbanner_728x90_prebid';
+		if (isInUsOrCa()) {
+			return 'theguardian_topbanner_728x90_prebid';
+		} else if (isInAuOrNz()) {
+			return 'theguardian_topbanner_728x90_prebid_AU';
+		}
 	}
 
 	if (containsMpu(sizes)) {
-		return isArticle
-			? 'theguardian_article_300x250_prebid'
-			: 'theguardian_sectionfront_300x250_prebid';
+		if (isInUsOrCa()) {
+			return isArticle
+				? 'theguardian_article_300x250_prebid'
+				: 'theguardian_sectionfront_300x250_prebid';
+		} else if (isInAuOrNz()) {
+			return isArticle
+				? 'theguardian_article_300x250_prebid_AU'
+				: 'theguardian_sectionfront_300x250_prebid_AU';
+		}
 	}
 
-	if (containsMobileSticky(sizes)) return 'theguardian_320x50_HDX';
+	if (containsMobileSticky(sizes)) {
+		if (isInUsOrCa()) {
+			return 'theguardian_320x50_HDX';
+		} else if (isInAuOrNz()) {
+			return 'theguardian_320x50_HDX_AU';
+		}
+	}
 
-	console.log(`PREBID: Failed to get TripleLift ad unit for slot ${slotId}.`);
 	return '';
 };
 
@@ -507,7 +522,7 @@ const currentBidders = (
 		[shouldIncludeSmart(), smartBidder],
 		[shouldIncludeSonobi(), sonobiBidder(pageTargeting)],
 		[shouldIncludeTrustX(), trustXBidder],
-		[shouldIncludeTripleLift(), tripleLiftBidder],
+		[shouldIncludeTripleLift(), tripleLiftBidder], // so will provide an object shouldIncludeTripleLift() return T (isInUsOrCa())
 		[shouldIncludeAppNexus(), appNexusBidder(pageTargeting)],
 		[shouldIncludeImproveDigital(), improveDigitalBidder],
 		[shouldIncludeImproveDigitalSkin(), improveDigitalSkinBidder],

--- a/src/lib/header-bidding/prebid/bid-config.ts
+++ b/src/lib/header-bidding/prebid/bid-config.ts
@@ -522,7 +522,7 @@ const currentBidders = (
 		[shouldIncludeSmart(), smartBidder],
 		[shouldIncludeSonobi(), sonobiBidder(pageTargeting)],
 		[shouldIncludeTrustX(), trustXBidder],
-		[shouldIncludeTripleLift(), tripleLiftBidder], // so will provide an object shouldIncludeTripleLift() return T (isInUsOrCa())
+		[shouldIncludeTripleLift(), tripleLiftBidder],
 		[shouldIncludeAppNexus(), appNexusBidder(pageTargeting)],
 		[shouldIncludeImproveDigital(), improveDigitalBidder],
 		[shouldIncludeImproveDigitalSkin(), improveDigitalSkinBidder],

--- a/src/lib/header-bidding/utils.ts
+++ b/src/lib/header-bidding/utils.ts
@@ -152,7 +152,8 @@ export const shouldIncludeOpenx = (): boolean => !isInUsOrCa();
 
 export const shouldIncludeTrustX = (): boolean => isInUsOrCa();
 
-export const shouldIncludeTripleLift = (): boolean => isInUsOrCa();
+export const shouldIncludeTripleLift = (): boolean =>
+	isInUsOrCa() || isInAuOrNz();
 
 export const shouldIncludeAdYouLike = (
 	slotSizes: HeaderBiddingSize[],


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?
Currently `tripleLift` is targeted specifically to USA or Canada IP's to return appropriate ID's.
Depending on the ad types detected, the function returns an appropriate inventory code.

Generating the correct inventory code that TripleLift needs to identify the specific ad placement and size during the bidding process. 
The inventory code is used to target the right ad inventory and ensure that the correct creative is shown if the bid wins the auction

An Array of `bids` is created in order to be sent to `prebid`, we need to ensure that `tripleLift` is included only in US or Canada and Australia or NZ.
However within that logic we also need to ensure the appropriate inventory code is provided for each region (`_AU` for Australia)

#### Tested Locally - using Logger and setting VPN to US and AUS respectively
in order to test this I am looking at the logger for the constructed `bids` array, that will be sent to make requests to those Ad Servers in order to then receive a proposed bid.

| Testing Bid Object from US or Canada | 
|--------------|
| <img width="1106" alt="Screenshot 2023-08-18 at 17 18 33" src="https://github.com/guardian/commercial/assets/49187886/5fee37af-b65b-4681-b202-353d1b12f091">|

| Testing Bid object includes `tripleLift` for Aus or NZ | 
|--------------|
|<img width="1119" alt="Screenshot 2023-08-18 at 17 35 27" src="https://github.com/guardian/commercial/assets/49187886/80693bb5-a43c-4c2b-b396-0b8b5c5b7cca"> |


#### Tested in CODE- using Logger and setting VPN to US and AUS respectively
in order to test this I am looking at the logger for the constructed `bids` array, that will be sent to make requests to those Ad Servers in order to then receive a proposed bid.

| Testing Bid Object from US or Canada | 
|--------------|
| <img width="1006" alt="Screenshot 2023-08-21 at 19 42 51" src="https://github.com/guardian/commercial/assets/49187886/7d0457ee-2e19-48bb-9bf8-870e1da611d5">|

| Testing Bid object includes `tripleLift` for Aus or NZ | 
|--------------|
| <img width="1039" alt="Screenshot 2023-08-21 at 19 33 43" src="https://github.com/guardian/commercial/assets/49187886/8f668fb9-1084-4a70-80cd-a9a2887d4e76">|


## Why?
This PR adds Australia or NZ to tripleLift with specific targeted ID's
