### PR TITLE
Use Guardian browserslist to govern browser support

### DIFF
--- a/.changeset/dirty-dancers-repeat.md
+++ b/.changeset/dirty-dancers-repeat.md
@@ -2,4 +2,4 @@
 '@guardian/commercial': minor
 ---
 
-Use @guardian/browserslist-config to govern broswer compatibility
+Use @guardian/browserslist-config to govern browser compatibility

--- a/.changeset/dirty-dancers-repeat.md
+++ b/.changeset/dirty-dancers-repeat.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Use @guardian/browserslist-config to govern broswer compatibility

--- a/babel.config.js
+++ b/babel.config.js
@@ -5,6 +5,20 @@ module.exports = {
 		'@babel/plugin-syntax-dynamic-import',
 	],
 	env: {
+		production: {
+			presets: [
+				[
+					'@babel/preset-env',
+					{
+						modules: false,
+					},
+				],
+			],
+			plugins: [
+				'@babel/plugin-transform-runtime',
+				'@babel/plugin-proposal-class-properties',
+			],
+		},
 		test: {
 			presets: [
 				[

--- a/babel.config.js
+++ b/babel.config.js
@@ -23,21 +23,7 @@ module.exports = {
 			],
 		},
 		internal: {
-			presets: [
-				[
-					'@babel/preset-env',
-					{
-						targets: {
-							browsers: [
-								'last 2 Chrome versions',
-								'last 1 Safari version',
-								'last 2 Firefox versions',
-								'last 2 Edge versions',
-							],
-						},
-					},
-				],
-			],
+			presets: [['@babel/preset-env']],
 		},
 	},
 	ignore: ['eslintrc.js'],

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-	presets: ['@babel/preset-react'],
+	presets: ['@babel/preset-react', '@babel/preset-env'],
 	plugins: [
 		'@babel/plugin-proposal-object-rest-spread',
 		'@babel/plugin-syntax-dynamic-import',
@@ -21,9 +21,6 @@ module.exports = {
 				'@babel/plugin-proposal-class-properties',
 				'dynamic-import-node',
 			],
-		},
-		internal: {
-			presets: [['@babel/preset-env']],
 		},
 	},
 	ignore: ['eslintrc.js'],

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 		"@guardian/ab-core": "5.0.0",
 		"@guardian/consent-management-platform": "13.6.1",
 		"@guardian/core-web-vitals": "5.1.0",
+		"@guardian/browserslist-config": "^5.1.0",
 		"@guardian/eslint-config-typescript": "^6.0.0",
 		"@guardian/libs": "15.6.4",
 		"@guardian/prettier": "4.0.0",
@@ -139,5 +140,8 @@
 		"@guardian/libs": "^15.6.4",
 		"@guardian/source-foundations": "^13.0.0",
 		"@guardian/support-dotcom-components": "^1.0.7"
-	}
+	},
+	"browserslist": [
+		"extends @guardian/browserslist-config"
+	]
 }

--- a/src/lib/detect/detect-breakpoint.ts
+++ b/src/lib/detect/detect-breakpoint.ts
@@ -119,11 +119,11 @@ const initMediaQueryListeners = () => {
 			const listener = (mql: MediaQueryListEvent | MediaQueryList) =>
 				mql.matches && updateBreakpoint(bp);
 
-			try {
+			//addListener is a deprecated method but Safari 13 and earlier versions do not support the new
+			//method, so we need it here as a fallback to load ads on those versions of Safari
+			if (typeof mql.addEventListener !== 'undefined') {
 				mql.addEventListener('change', listener);
-			} catch {
-				//addListener is a deprecated method but Safari 13 and earlier versions do not support the new
-				//method, so we need it here as a fallback to load ads on those versions of Safari
+			} else if (typeof mql.addListener !== 'undefined') {
 				mql.addListener(listener);
 			}
 

--- a/src/lib/detect/detect-breakpoint.ts
+++ b/src/lib/detect/detect-breakpoint.ts
@@ -119,7 +119,13 @@ const initMediaQueryListeners = () => {
 			const listener = (mql: MediaQueryListEvent | MediaQueryList) =>
 				mql.matches && updateBreakpoint(bp);
 
-			mql.addEventListener('change', listener);
+			try {
+				mql.addEventListener('change', listener);
+			} catch {
+				//addListener is a deprecated method but Safari 13 and earlier versions do not support the new
+				//method, so we need it here as a fallback to load ads on those versions of Safari
+				mql.addListener(listener);
+			}
 
 			listener(mql);
 		}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1339,6 +1339,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-5.0.0.tgz#cce32ff4cdfb6b24c013723bf352dcd61135d34d"
   integrity sha512-Td5gtK2sARl+fXj1Qe6RuFqf/zxuZjW1q2Jck09zXPIfMgU+sJoTi549zbNeC1cldCBhPWy/qPQ0r+8klfF7jg==
 
+"@guardian/browserslist-config@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-5.1.0.tgz#61cd822388dc196cea1b39c693366ed550edcd10"
+  integrity sha512-QsyaZ7OZ6jBl8lByiLWtnobcS0IvIPVzDeGz9XY+CvPy5v5Kb0RJo+fFLEZbCqRLrfK+5f2sjrwPqrwtJBe2Sw==
+
 "@guardian/consent-management-platform@13.6.1":
   version "13.6.1"
   resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.6.1.tgz#528ed9193b1bd96e9f84964a5a1a080de43e29c1"


### PR DESCRIPTION
## What does this change?
Uses the "@guardian/browserslist-config" package so that we build the bundle to be compatible with the browsers defined here: https://github.com/guardian/csnx/tree/main/libs/%40guardian/browserslist-config#included-browsers

I've also added the deprecated addListener function as a fallback for addEventListener in detect-breakpoint. In versions of Safari before 14, the MediaQueryList does not inherit the addEventListener function, and this was preventing ads from loading as the function could not be found.

This means Safari versions 11, 12, and 13 are now supported and will show ads.

## Why?
Using a standardised list is more robust than just building for the last x versions of a browser, and makes sure that we build our bundle to be compatible with the browsers that we know our readers use. This should mean our ads reach more users.

## How does this affect the bundle size?
Before adding the browserslist, the parsed bundle size according to webpack-bundle-analyzer was 626.74 kB

After adding browserslist, the parsed bundle size is now 653.8 kB

This is approximately a 4% increase in bundle size for the additional browser support.

## Screenshots
### Before
Safari 13.1 on Catalina
![Screenshot 2023-08-16 at 17 36 39](https://github.com/guardian/commercial/assets/108270776/c6cb181b-52ad-4002-896c-4275af590a67)

### After
Safari 11.1 on High Sierra
![Screenshot 2023-08-18 at 17 20 03](https://github.com/guardian/commercial/assets/108270776/5c2495a5-60a1-4841-8cf6-424f6fc7d0b8)
