### PR TITLE
Upgrade Prebid.js to v7.54.4

### DIFF
--- a/.changeset/flat-beers-learn.md
+++ b/.changeset/flat-beers-learn.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Upgrade Prebid.js@7.54.4

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",
 		"ophan-tracker-js": "^1.4.0",
-		"prebid.js": "guardian/prebid.js#upgrade-v7.54.4",
+		"prebid.js": "guardian/prebid.js#b8263f2",
 		"process": "^0.11.10",
 		"raven-js": "^3.27.2",
 		"tslib": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",
 		"ophan-tracker-js": "^1.4.0",
-		"prebid.js": "guardian/prebid.js#1d6bbdc",
+		"prebid.js": "guardian/prebid.js#upgrade-v7.54.4",
 		"process": "^0.11.10",
 		"raven-js": "^3.27.2",
 		"tslib": "^2.5.3",

--- a/src/lib/header-bidding/prebid/prebid.spec.ts
+++ b/src/lib/header-bidding/prebid/prebid.spec.ts
@@ -43,35 +43,6 @@ describe('initialise', () => {
 	test('should generate correct Prebid config when all switches on', () => {
 		prebid.initialise(window, 'tcfv2');
 		expect(window.pbjs?.getConfig()).toEqual({
-			_auctionOptions: {},
-			_bidderSequence: 'random',
-			_bidderTimeout: 1500,
-			_customPriceBucket: {
-				buckets: [
-					{
-						max: 10,
-						increment: 0.01,
-					},
-					{
-						max: 15,
-						increment: 0.1,
-					},
-					{
-						max: 100,
-						increment: 1,
-					},
-				],
-			},
-			_debug: false,
-			_deviceAccess: true,
-			_disableAjaxTimeout: false,
-			_maxNestedIframes: 10,
-			_mediaTypePriceGranularity: {},
-			_priceGranularity: 'custom',
-			_publisherDomain: null,
-			_sendAllBids: true,
-			_timeoutBuffer: 400,
-			_useBidCache: false,
 			auctionOptions: {},
 			bidderSequence: 'random',
 			bidderTimeout: 1500,
@@ -105,7 +76,7 @@ describe('initialise', () => {
 			maxNestedIframes: 10,
 			mediaTypePriceGranularity: {},
 			priceGranularity: 'custom',
-			publisherDomain: null,
+			publisherDomain: undefined,
 			s2sConfig: {
 				adapter: 'prebidServer',
 				adapterOptions: {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -1369,17 +1369,12 @@
     eslint-plugin-eslint-comments "3.2.0"
     eslint-plugin-import "2.27.5"
 
-"@guardian/libs@15.6.4":
+"@guardian/libs@15.6.4", "@guardian/libs@^15.6.4":
   version "15.6.4"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.6.4.tgz#13787065e5c58b884944c5c71d6e324c7f2e566a"
   integrity sha512-oN+xN7FBuVKLCbbjvAMdWjgWqOtvR38acnqwAKsjUDkFsBzRWU/pueDSEGTCTTVSFcRdCKOsWnop+Vwh59P47g==
 
-"@guardian/libs@^10.0.0":
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-10.1.1.tgz#7048c365a68dda068f707d46c78979f430221963"
-  integrity sha512-OdWReBHRWhdbErVmS15hihVzlkdU8DkKrjDsUIN0P8QZiF4twuzcU3qsPwto2UfibAwPkWqKkNwH1k8b6xNclA==
-
-"@guardian/prettier@4.0.0":
+"@guardian/prettier@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-4.0.0.tgz#1ad1d7d079194937bfd0107789dde7b0fb84fa11"
   integrity sha512-JvvnDnI04NcmpuD2mF5ZXTWI7tand1pj1s33fh4JxHNAV00QXwTWZBI2/QWS3ck7KjpYjpRaz8CDUcMz35hReg==
@@ -6155,11 +6150,17 @@ listr2@^5.0.7:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
-live-connect-js@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/live-connect-js/-/live-connect-js-2.4.0.tgz#c98b1c1fa94f81e0b67202a456de2bd915e41e6c"
-  integrity sha512-MSBLKfnXoxH+pqwji/Mf8yZu3VZMq4tnNfwMw7NTWN5a+TBM6f0RWgwui1YMA3nHmMhX/nzxxsso0SkyKcF0fA==
+live-connect-common@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/live-connect-common/-/live-connect-common-1.0.0.tgz#9cb558cd665c0418271770854538243420cd1354"
+  integrity sha512-LBZsvykcGeVRYI1eqqXrrNZsoBdL2a8cpyrYPIiGAF/CpixbyRbvqGslaFw511lH294QB16J3fYYg21aYuaM2Q==
+
+live-connect-js@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/live-connect-js/-/live-connect-js-5.0.1.tgz#152372cf757e8af8eb4829f32979669b26cd9052"
+  integrity sha512-X/fFbKGG8MahpqIuxndApAc9udj1g5NIxL95zKPzvqoipPYoeqvh7SCDly1hPvbqsfFj/DIbOfdWbttXzCSryw==
   dependencies:
+    live-connect-common "^1.0.0"
     tiny-hashes "1.0.1"
 
 load-json-file@^4.0.0:
@@ -6944,15 +6945,15 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-prebid.js@guardian/prebid.js#1d6bbdc:
-  version "7.26.0"
-  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/1d6bbdc64411fbe719489eb06bce72b66ac6a4f3"
+prebid.js@guardian/prebid.js#upgrade-v7.54.4:
+  version "7.54.4"
+  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/34a36a116b123ecfbbc56dd11c81e1e9748b7254"
   dependencies:
     "@babel/core" "^7.16.7"
     "@babel/plugin-transform-runtime" "^7.18.9"
     "@babel/preset-env" "^7.16.8"
     "@babel/runtime" "^7.18.9"
-    "@guardian/libs" "^10.0.0"
+    "@guardian/libs" "^15.6.4"
     core-js "^3.13.0"
     core-js-pure "^3.13.0"
     criteo-direct-rsa-validate "^1.1.0"
@@ -6962,7 +6963,7 @@ prebid.js@guardian/prebid.js#1d6bbdc:
     express "^4.15.4"
     fun-hooks "^0.9.9"
     just-clone "^1.0.2"
-    live-connect-js "2.4.0"
+    live-connect-js "^5.0.0"
   optionalDependencies:
     fsevents "^2.3.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1374,7 +1374,7 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.6.4.tgz#13787065e5c58b884944c5c71d6e324c7f2e566a"
   integrity sha512-oN+xN7FBuVKLCbbjvAMdWjgWqOtvR38acnqwAKsjUDkFsBzRWU/pueDSEGTCTTVSFcRdCKOsWnop+Vwh59P47g==
 
-"@guardian/prettier@^4.0.0":
+"@guardian/prettier@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-4.0.0.tgz#1ad1d7d079194937bfd0107789dde7b0fb84fa11"
   integrity sha512-JvvnDnI04NcmpuD2mF5ZXTWI7tand1pj1s33fh4JxHNAV00QXwTWZBI2/QWS3ck7KjpYjpRaz8CDUcMz35hReg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6945,9 +6945,9 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-prebid.js@guardian/prebid.js#upgrade-v7.54.4:
+prebid.js@guardian/prebid.js#b8263f2:
   version "7.54.4"
-  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/34a36a116b123ecfbbc56dd11c81e1e9748b7254"
+  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/b8263f2e041833b0ec0d05d14de6c3f1bdd466ff"
   dependencies:
     "@babel/core" "^7.16.7"
     "@babel/plugin-transform-runtime" "^7.18.9"


### PR DESCRIPTION
## What does this change?

Upgrade Prebid.js to v7.54.4 as per https://github.com/guardian/Prebid.js/pull/132

Note:

The prebid config object has changed to not include any private fields (`_*`) when calling:

`window.pbjs.getConfig()`

I think this is okay as all the fields have public equivalents and it does not seem to affect the functioning of prebid.

Have tested on CODE


