### PR TITLE
Remove switch check for carrot ad

### DIFF
--- a/.changeset/stale-rings-attend.md
+++ b/.changeset/stale-rings-attend.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Remove carrot switch check

--- a/src/lib/commercial-features.ts
+++ b/src/lib/commercial-features.ts
@@ -139,7 +139,6 @@ class CommercialFeatures {
 		this.carrotTrafficDriver =
 			!this.adFree &&
 			this.articleBodyAdverts &&
-			!!window.guardian.config.switches.carrotTrafficDriver &&
 			!window.guardian.config.page.isPaidContent;
 
 		this.highMerch =


### PR DESCRIPTION

## What does this change?
We're removing this switch as part of our switch audit, so we don't need to check it any more.

## Why?
