### PR TITLE
Public good test to 10%

### DIFF
--- a/.changeset/large-mayflies-judge.md
+++ b/.changeset/large-mayflies-judge.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Start public good 10% test

--- a/src/lib/experiments/tests/public-good.ts
+++ b/src/lib/experiments/tests/public-good.ts
@@ -3,9 +3,9 @@ import type { ABTest } from '@guardian/ab-core';
 export const publicGoodTest: ABTest = {
 	id: 'PublicGoodTest',
 	author: '@commercial-dev',
-	start: '2023-08-01',
-	expiry: '2023-08-30',
-	audience: 0 / 100,
+	start: '2023-08-22',
+	expiry: '2023-09-15',
+	audience: 10 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: 'USA only',
 	successMeasure: 'No significant impact to UX',


### PR DESCRIPTION
## What does this change?
Set public good test to 10%

## Why
To test the UX impact of adding public good at the end of articles in the USA

