### PR TITLE
Fix bug when adding additional sizes to empty size mapping.

### DIFF
--- a/.changeset/short-scissors-fix.md
+++ b/.changeset/short-scissors-fix.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Fix bug when adding additional sizes to empty size mapping

--- a/src/core/ad-sizes.test.ts
+++ b/src/core/ad-sizes.test.ts
@@ -1,4 +1,10 @@
-import { _, adSizes, getAdSize } from './ad-sizes';
+import {
+	_,
+	adSizes,
+	findAppliedSizesForBreakpoint,
+	getAdSize,
+} from './ad-sizes';
+import type { SizeMapping } from './ad-sizes';
 
 const { createAdSize } = _;
 
@@ -52,6 +58,62 @@ describe('ad size splicing', () => {
 	it('should be able to splice the array returned from the array method on AdSize', () => {
 		expect(adSizes.skyscraper.toArray().splice(0, 1)[0]).toEqual(160);
 		expect(adSizes.skyscraper.toArray().splice(1, 1)[0]).toEqual(600);
+	});
+});
+
+describe('findAppliedSizesForBreakpoint', () => {
+	const exampleSizeMappingOne: SizeMapping = {
+		mobile: [adSizes.outstreamMobile, adSizes.mpu],
+		desktop: [adSizes.billboard],
+	};
+	const exampleSizeMappingTwo: SizeMapping = {
+		tablet: [adSizes.billboard],
+	};
+
+	describe('sizes defined for specified breakpoint', () => {
+		it('should return correct sizes for mobile', () => {
+			expect(
+				findAppliedSizesForBreakpoint(exampleSizeMappingOne, 'mobile'),
+			).toEqual([adSizes.outstreamMobile, adSizes.mpu]);
+		});
+		it('should return correct sizes for phablet', () => {
+			expect(
+				findAppliedSizesForBreakpoint(exampleSizeMappingOne, 'desktop'),
+			).toEqual([adSizes.billboard]);
+		});
+		it('should return correct sizes for tablet', () => {
+			expect(
+				findAppliedSizesForBreakpoint(exampleSizeMappingTwo, 'tablet'),
+			).toEqual([adSizes.billboard]);
+		});
+	});
+
+	describe('no sizes defined for specified breakpoint', () => {
+		it('should return correct sizes for phablet', () => {
+			expect(
+				findAppliedSizesForBreakpoint(exampleSizeMappingOne, 'phablet'),
+			).toEqual([adSizes.outstreamMobile, adSizes.mpu]);
+		});
+		it('should return correct sizes for tablet', () => {
+			expect(
+				findAppliedSizesForBreakpoint(exampleSizeMappingOne, 'tablet'),
+			).toEqual([adSizes.outstreamMobile, adSizes.mpu]);
+		});
+		it('should return correct sizes for tablet', () => {
+			expect(
+				findAppliedSizesForBreakpoint(exampleSizeMappingTwo, 'mobile'),
+			).toEqual([]);
+		});
+		it('should return correct sizes for tablet', () => {
+			expect(
+				findAppliedSizesForBreakpoint(exampleSizeMappingTwo, 'phablet'),
+			).toEqual([]);
+		});
+		it('should return correct sizes for tablet', () => {
+			expect(
+				findAppliedSizesForBreakpoint(exampleSizeMappingTwo, 'desktop'),
+			).toEqual([adSizes.billboard]);
+		});
 	});
 });
 

--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -397,7 +397,9 @@ const findAppliedSizesForBreakpoint = (
 		return [];
 	}
 
-	let breakpointIndex = breakpoints.findIndex((b) => b === breakpoint);
+	let breakpointIndex: 0 | 1 | 2 | 3 = breakpoints.findIndex(
+		(b) => b === breakpoint,
+	) as 0 | 1 | 2 | 3;
 
 	while (breakpointIndex >= 0) {
 		const breakpointToTry = breakpoints[breakpointIndex];

--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -1,3 +1,4 @@
+import { breakpoints, isBreakpoint } from './lib/breakpoint';
 import type { Breakpoint } from './lib/breakpoint';
 
 type AdSizeString = 'fluid' | `${number},${number}`;
@@ -178,6 +179,16 @@ const adSizes: Record<SizeKeys, AdSize> = {
  * mark: 432b3a46-90c1-4573-90d3-2400b51af8d0
  * Some of these may or may not need to be synced for with the sizes in ./create-ad-slot.ts
  * these were originally from DCR, create-ad-slot.ts ones were in frontend.
+ *
+ * Note:
+ * If a breakpoint is not defined in a size mapping for a slot, that breakpoint will use the sizes
+ * of the next breakpoint down that has a size mapping. For example, if only "mobile" and "phablet" sizes
+ * are defined for a slot, all breakpoints larger than "phablet" will use the mapping for "phablet".
+ *
+ * In another example, if a slot has only "tablet" as a size mapping defined,
+ * then "desktop" will use the size mapping for "tablet". "mobile" and "phablet"
+ * will have no size mapping. This type of example may be used in cases where
+ * we only want the slot to appear on the "tablet" size or greater.
  **/
 const slotSizeMappings: SlotSizeMappings = {
 	inline: {
@@ -371,6 +382,36 @@ const slotSizeMappings: SlotSizeMappings = {
 
 const getAdSize = (size: SizeKeys): AdSize => adSizes[size];
 
+/**
+ * Finds the ad sizes that will be used for a breakpoint given a size mapping
+ *
+ * If ad sizes are defined in the size mapping for the specified breakpoint, we use that.
+ * If no sizes are defined for the breakpoint, use the next smallest breakpoint with defined ad sizes.
+ * If no smaller breakpoints have defined ad sizes, return an empty array
+ */
+const findAppliedSizesForBreakpoint = (
+	sizeMappings: SizeMapping,
+	breakpoint: Breakpoint,
+): AdSize[] => {
+	if (!isBreakpoint(breakpoint)) {
+		return [];
+	}
+
+	let breakpointIndex = breakpoints.findIndex((b) => b === breakpoint);
+
+	while (breakpointIndex >= 0) {
+		const breakpointToTry = breakpoints[breakpointIndex];
+		const sizeMapping = sizeMappings[breakpointToTry];
+		if (sizeMapping?.length) {
+			return sizeMapping;
+		}
+		breakpointIndex--;
+	}
+
+	// There are no size mappings defined for any size smaller than the breakpoint
+	return [];
+};
+
 // Export for testing
 export const _ = { createAdSize };
 
@@ -390,4 +431,5 @@ export {
 	getAdSize,
 	slotSizeMappings,
 	createAdSize,
+	findAppliedSizesForBreakpoint,
 };

--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -391,6 +391,20 @@ const getAdSize = (size: SizeKeys): AdSize => adSizes[size];
  * If ad sizes are defined in the size mapping for the specified breakpoint, we use that.
  * If no sizes are defined for the breakpoint, use the next smallest breakpoint with defined ad sizes.
  * If no smaller breakpoints have defined ad sizes, return an empty array
+ *
+ * Example:
+ * For the following slotSizeMappings:
+ *     inline: {
+ *         phablet: [adSizes.mpu],
+ *         desktop: [adSizes.billboard]
+ *     }
+ * the applied sizes for each breakpoint for the "inline" slot will be:
+ *     mobile: []
+ *     phablet: [adSizes.mpu]
+ *     tablet: [adSizes.mpu]
+ *     desktop: [adSizes.billboard]
+ *
+ * See ad-sizes.test.ts for more examples
  */
 const findAppliedSizesForBreakpoint = (
 	sizeMappings: SizeMapping,

--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -1,7 +1,10 @@
 import { breakpoints, isBreakpoint } from './lib/breakpoint';
 import type { Breakpoint } from './lib/breakpoint';
+import type { Indices } from './types';
 
 type AdSizeString = 'fluid' | `${number},${number}`;
+
+type BreakpointIndices = Indices<typeof breakpoints>;
 
 /**
  * Store ad sizes in a way that is compatible with google-tag but also accessible via
@@ -397,12 +400,12 @@ const findAppliedSizesForBreakpoint = (
 		return [];
 	}
 
-	let breakpointIndex: 0 | 1 | 2 | 3 = breakpoints.findIndex(
+	let breakpointIndex: BreakpointIndices = breakpoints.findIndex(
 		(b) => b === breakpoint,
-	) as 0 | 1 | 2 | 3;
+	) as BreakpointIndices;
 
 	while (breakpointIndex >= 0) {
-		const breakpointToTry = breakpoints[breakpointIndex];
+		const breakpointToTry: Breakpoint = breakpoints[breakpointIndex];
 		const sizeMapping = sizeMappings[breakpointToTry];
 		if (sizeMapping?.length) {
 			return sizeMapping;

--- a/src/core/create-ad-slot.ts
+++ b/src/core/create-ad-slot.ts
@@ -1,3 +1,4 @@
+import { findAppliedSizesForBreakpoint } from './ad-sizes';
 import type { SizeMapping } from './ad-sizes';
 import { isBreakpoint } from './lib/breakpoint';
 
@@ -108,7 +109,6 @@ const createClasses = (
  *
  * 1. Check that the options size mappings use known device names
  * 2. If so concat the size mappings
- *
  */
 const concatSizeMappings = (
 	defaultSizeMappings: SizeMapping,
@@ -118,11 +118,15 @@ const concatSizeMappings = (
 		(sizeMappings, [breakpoint, optionSizes]) => {
 			// Only perform concatenation if breakpoint is of the correct type
 			if (isBreakpoint(breakpoint)) {
+				const sizes = findAppliedSizesForBreakpoint(
+					sizeMappings,
+					breakpoint,
+				);
+
 				// Concatenate the option sizes onto any existing sizes present for a given breakpoint
-				sizeMappings[breakpoint] = (
-					sizeMappings[breakpoint] ?? []
-				).concat(optionSizes);
+				sizeMappings[breakpoint] = sizes.concat(optionSizes);
 			}
+
 			return sizeMappings;
 		},
 		{ ...defaultSizeMappings },
@@ -139,10 +143,9 @@ const wrapSlotInContainer = (
 	options: ContainerOptions = {},
 ) => {
 	const container = document.createElement('div');
-
 	container.className = `${adSlotContainerClass} ${options.className ?? ''}`;
-
 	container.appendChild(adSlot);
+
 	return container;
 };
 

--- a/src/core/create-ad-slot.ts
+++ b/src/core/create-ad-slot.ts
@@ -1,3 +1,4 @@
+import { log } from '@guardian/libs';
 import { findAppliedSizesForBreakpoint } from './ad-sizes';
 import type { SizeMapping } from './ad-sizes';
 import { isBreakpoint } from './lib/breakpoint';
@@ -74,9 +75,11 @@ const createAdSlotElement = (
 		// introduce dfp-ad--top-above-nav then there isn't already one.
 		const node = document.getElementById(id);
 		if (node?.parentNode) {
-			const pnode = node.parentNode;
-			console.log(`warning: cleaning up dom node id: dfp-ad--${name}`);
-			pnode.removeChild(node);
+			log(
+				'commercial',
+				`warning: cleaning up dom node id: dfp-ad--${name}`,
+			);
+			node.parentNode.removeChild(node);
 		}
 	}
 

--- a/src/core/lib/breakpoint.ts
+++ b/src/core/lib/breakpoint.ts
@@ -1,7 +1,12 @@
-type Breakpoint = 'mobile' | 'desktop' | 'phablet' | 'tablet';
+/**
+ * Breakpoints ordered from smallest to largest
+ */
+const breakpoints = ['mobile', 'phablet', 'tablet', 'desktop'] as const;
+
+type Breakpoint = (typeof breakpoints)[number];
 
 const isBreakpoint = (s: string): s is Breakpoint =>
-	s === 'mobile' || s === 'phablet' || s === 'tablet' || s === 'desktop';
+	breakpoints.includes(s as Breakpoint);
 
 export type { Breakpoint };
-export { isBreakpoint };
+export { breakpoints, isBreakpoint };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -119,3 +119,15 @@ export type True = 't';
 export type False = 'f';
 
 export type NotApplicable = 'na';
+
+/**
+ * Generates a type which represents possible indices of this array
+ *
+ * Example usage:
+ * const list = ['foo', 'bar', 'baz'] as const;
+ * type Test = Indices<typeof list>
+ */
+export type Indices<T extends readonly unknown[]> = Exclude<
+	Partial<T>['length'],
+	T['length']
+>;


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

- Fixes a bug where additional sizes could be added to a breakpoint which has no existing size definition. When adding additional sizes, instead of appending the additional sizes to the existing ad sizes from the next smallest breakpoint with ad sizes, it would overwrite these sizes.

## Why?

- Inline slots on liveblog pages at phablet & tablet viewport sizes were only using the additional sizes and not the sizes defined for mobile viewport with the additional sizes.

## Screenshots

| Before | After |
| - | - |
| ![Before] | ![After] |

[Before]: https://github.com/guardian/commercial/assets/9574885/283a6bdb-bcd4-43a1-9cb1-45304743a8f5
[After]: https://github.com/guardian/commercial/assets/9574885/ca2bfb84-0f80-442e-8bee-55fec6c1818c

