### PR TITLE
Add merch-high ad size to fronts-banner ads

### DIFF
--- a/.changeset/gentle-suns-battle.md
+++ b/.changeset/gentle-suns-battle.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Add the merch-high ad size to fronts-banner slots

--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -292,6 +292,7 @@ const slotSizeMappings: SlotSizeMappings = {
 			adSizes.empty,
 			adSizes.billboard,
 			adSizes.fabric,
+			adSizes.merchandisingHigh,
 			adSizes.fluid,
 		],
 	},


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

- Adds the merch-high ad size (88x87) to fronts-banner ad slots

## Why?

- So we can display adverts targeting the 88x87 size in these slots

## Screenshots

<img width="1994" alt="Screenshot 2023-08-29 at 15 29 14" src="https://github.com/guardian/commercial/assets/9574885/6ef78a2d-f30a-4b97-9d00-6cb8ac8c8d44">
