### PR TITLE
Record Cypress videos in CI

### DIFF
--- a/.github/workflows/e2e-cypress.yml
+++ b/.github/workflows/e2e-cypress.yml
@@ -58,7 +58,7 @@ jobs:
         working-directory: ./commercial
 
       - uses: actions/upload-artifact@v2
-        if: always()
+        if: failure()
         with:
           name: cypress-videos
           path: commercial/cypress/videos

--- a/.github/workflows/e2e-cypress.yml
+++ b/.github/workflows/e2e-cypress.yml
@@ -57,6 +57,9 @@ jobs:
         run: yarn cypress run --spec cypress/e2e/parallel-${{ matrix.group }}/*
         working-directory: ./commercial
 
+      # Only capture videos and screenshots on failure
+      # In order to minimize unused artifacts
+
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -9,7 +9,9 @@ export default defineConfig({
 		runMode: 2,
 		openMode: 0,
 	},
-	video: false,
+	// Record videos in CI
+	// In the GHA we'll only record failures, to minimize storage
+	video: !!process.env.CI,
 	e2e: {
 		setupNodeEvents(on, config) {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-var-requires -- cypress api

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
 		openMode: 0,
 	},
 	// Record videos in CI
-	// In the GHA we'll only record failures, to minimize storage
+	// This environment var is always set to "true" in CI (i.e. Github Actions)
 	video: !!process.env.CI,
 	e2e: {
 		setupNodeEvents(on, config) {


### PR DESCRIPTION
## What does this change?

- Record Cypress videos when running in CI, detected via the [`CI`](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) environment variable.
- Only upload the captured videos as artifacts when the E2E test suite fails.

## Why?

This should make it slightly easier to debug any issues with failing tests running in CI.

I've opted to switch to only upload artifacts on failure to minimise the amount of videos stored that we'll likely never watch.