### PR TITLE
Sentry sampling for Okta test participants

### DIFF
--- a/.changeset/hot-weeks-sell.md
+++ b/.changeset/hot-weeks-sell.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Stop sending all Sentry reports for Okta test participants

--- a/src/lib/raven.ts
+++ b/src/lib/raven.ts
@@ -64,10 +64,6 @@ const sentryOptions: RavenOptions = {
 	shouldSendCallback(data: { tags: { ignored?: unknown } }) {
 		const isIgnored = !!data.tags.ignored;
 
-		const isInOktaExperiment =
-			!!window.guardian.config.switches.okta &&
-			window.guardian.config.tests?.oktaVariant === 'variant';
-
 		// Sample at a very small rate.
 		const isInSample = Math.random() < 0.008;
 
@@ -77,7 +73,7 @@ const sentryOptions: RavenOptions = {
 
 		return (
 			!!enableSentryReporting &&
-			(isInSample || isInOktaExperiment) &&
+			isInSample &&
 			!isIgnored &&
 			!adblockBeingUsed
 		);


### PR DESCRIPTION
## What does this change?
Stop bypassing the Sentry sampling rate for Okta test participants.

## Why?
When we migrated to Okta we wanted to see all Sentry errors from Okta test participants to keep an eye out for any new errors. Now that the test is going to 10%, we want to reintroduce sampling so that we don't flood Sentry with error messages.