### PR TITLE
Remove leaderboard ad size for mostpop

### DIFF
--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -318,7 +318,6 @@ const slotSizeMappings: SlotSizeMappings = {
 			adSizes.mpu,
 			adSizes.googleCard,
 			adSizes.halfPage,
-			adSizes.leaderboard,
 			adSizes.fluid,
 		],
 		desktop: [


### PR DESCRIPTION
## What does this change?
Removes the leaderboard size for mostpop ads on tablets.

## Why?
The div that the mostpop fits in on tablet view is never big enough to contain a leaderboard size. On articles on tablets, the div is usually 698px, whereas the leaderboard ad is 728px wide.

<img width="1423" alt="Screenshot 2023-09-05 at 12 10 51" src="https://github.com/guardian/commercial/assets/108270776/87cf6e9d-c71f-4432-94e2-17eb31ea09e5">

At the moment, the mostpop ad slot remains 300px wide even when a leaderboard is served into the slot which means the ad is skewed to the side:

![Screenshot 2023-09-01 at 16 58 00](https://github.com/guardian/commercial/assets/108270776/365b2928-6721-43cf-bde6-aa2aa56db5fe)

However, even when we change this to allow the slot to expand to accommodate the leaderboard, the ad will still overflow the div, because the ad is too big:
![Screenshot 2023-09-05 at 11 03 16](https://github.com/guardian/commercial/assets/108270776/9e7b5a07-6306-4ec1-98fc-a4c86db74b81)

It makes sense to remove this ad size for this slot, as it will never fit.