### PR TITLE
Add publisher ID for improve digital

### DIFF
--- a/.changeset/calm-windows-refuse.md
+++ b/.changeset/calm-windows-refuse.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Add publisherId for the improve digital bidder

--- a/src/lib/header-bidding/prebid-types.ts
+++ b/src/lib/header-bidding/prebid-types.ts
@@ -67,6 +67,7 @@ export type PrebidTripleLiftParams = {
 };
 
 export type PrebidImproveParams = {
+	publisherId?: number;
 	placementId: number;
 	size: {
 		w?: number;

--- a/src/lib/header-bidding/prebid/bid-config.ts
+++ b/src/lib/header-bidding/prebid/bid-config.ts
@@ -380,6 +380,7 @@ const improveDigitalBidder: PrebidBidder = {
 		slotId: string,
 		sizes: HeaderBiddingSize[],
 	): PrebidImproveParams => ({
+		publisherId: 995,
 		placementId: getImprovePlacementId(sizes, isInFrontsBannerVariant),
 		size: getImproveSizeParam(slotId, isDesktopAndArticle),
 	}),


### PR DESCRIPTION
## What does this change?
Add the publisher ID to the improveDigitalBidder. I've kept it as an optional parameter for now as we don't need to send it for the improve pageskin bidder.

![Screenshot 2023-09-11 at 16 46 52](https://github.com/guardian/commercial/assets/108270776/e4ea4d9a-d760-490b-bef6-74c01565c952)

## Why?
To address an incoming request from Improve Digital