### PR TITLE
Use `satisfies` when defining ad sizes and size mappings

### DIFF
--- a/.changeset/forty-rice-attend.md
+++ b/.changeset/forty-rice-attend.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Use satsifies operator when defining ad sizes and slot mappings config

--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -170,13 +170,13 @@ const guardianProprietaryAdSizes = {
 	merchandisingHighAdFeature: createAdSize(88, 89),
 };
 
-const adSizes: Record<SizeKeys, AdSize> = {
+const adSizes = {
 	...namedStandardAdSizes,
 	...standardAdSizes,
 	...outstreamSizes,
 	...proprietaryAdSizes,
 	...guardianProprietaryAdSizes,
-};
+} satisfies Record<SizeKeys, AdSize>;
 
 /**
  * mark: 432b3a46-90c1-4573-90d3-2400b51af8d0
@@ -193,7 +193,7 @@ const adSizes: Record<SizeKeys, AdSize> = {
  * will have no size mapping. This type of example may be used in cases where
  * we only want the slot to appear on the "tablet" size or greater.
  **/
-const slotSizeMappings: SlotSizeMappings = {
+const slotSizeMappings = {
 	inline: {
 		mobile: [
 			adSizes.outOfPage,
@@ -380,7 +380,7 @@ const slotSizeMappings: SlotSizeMappings = {
 	external: {
 		mobile: [adSizes.outOfPage, adSizes.empty, adSizes.fluid, adSizes.mpu],
 	},
-};
+} satisfies SlotSizeMappings;
 
 const getAdSize = (size: SizeKeys): AdSize => adSizes[size];
 

--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -114,7 +114,7 @@ type SlotName =
 	| 'article-end'
 	| 'external';
 
-type SizeMapping = Partial<Record<Breakpoint, AdSize[]>>;
+type SizeMapping = Partial<Record<Breakpoint, Readonly<AdSize[]>>>;
 
 type SlotSizeMappings = Record<SlotName, SizeMapping>;
 
@@ -176,7 +176,7 @@ const adSizes = {
 	...outstreamSizes,
 	...proprietaryAdSizes,
 	...guardianProprietaryAdSizes,
-} satisfies Record<SizeKeys, AdSize>;
+} as const satisfies Record<SizeKeys, AdSize>;
 
 /**
  * mark: 432b3a46-90c1-4573-90d3-2400b51af8d0
@@ -380,7 +380,7 @@ const slotSizeMappings = {
 	external: {
 		mobile: [adSizes.outOfPage, adSizes.empty, adSizes.fluid, adSizes.mpu],
 	},
-} satisfies SlotSizeMappings;
+} as const satisfies SlotSizeMappings;
 
 const getAdSize = (size: SizeKeys): AdSize => adSizes[size];
 
@@ -408,7 +408,7 @@ const getAdSize = (size: SizeKeys): AdSize => adSizes[size];
 const findAppliedSizesForBreakpoint = (
 	sizeMappings: SizeMapping,
 	breakpoint: Breakpoint,
-): AdSize[] => {
+): Readonly<AdSize[]> => {
 	if (!isBreakpoint(breakpoint)) {
 		return [];
 	}

--- a/src/lib/dfp/define-slot.spec.ts
+++ b/src/lib/dfp/define-slot.spec.ts
@@ -1,5 +1,5 @@
 import type { SizeMapping } from 'core/ad-sizes';
-import { adSizes } from 'core/ad-sizes';
+import { adSizes, createAdSize } from 'core/ad-sizes';
 import { toGoogleTagSize } from 'lib/utils/googletag-ad-size';
 import {
 	buildGoogletagSizeMapping,
@@ -151,25 +151,25 @@ describe('Define Slot', () => {
 
 		const topAboveNavSizes = {
 			tablet: [
-				[1, 1],
-				[2, 2],
-				[728, 90],
-				[88, 71],
-				[0, 0],
+				createAdSize(1, 1),
+				createAdSize(2, 2),
+				createAdSize(728, 90),
+				createAdSize(88, 71),
+				createAdSize(0, 0),
 			],
 			desktop: [
-				[1, 1],
-				[2, 2],
-				[728, 90],
-				[940, 230],
-				[900, 250],
-				[970, 250],
-				[88, 71],
-				[0, 0],
+				createAdSize(1, 1),
+				createAdSize(2, 2),
+				createAdSize(728, 90),
+				createAdSize(940, 230),
+				createAdSize(900, 250),
+				createAdSize(970, 250),
+				createAdSize(88, 71),
+				createAdSize(0, 0),
 			],
 		};
 
-		defineSlot(slotDiv, topAboveNavSizes as SizeMapping);
+		defineSlot(slotDiv, topAboveNavSizes);
 
 		expect(window.googletag.defineSlot).toHaveBeenCalledWith(
 			undefined,

--- a/src/lib/header-bidding/slot-config.ts
+++ b/src/lib/header-bidding/slot-config.ts
@@ -30,7 +30,7 @@ const getHbBreakpoint = () => {
  * (this does not include inline1)
  */
 const filterBySizeMapping =
-	(slotSizes: AdSize[] = []) =>
+	(slotSizes: Readonly<AdSize[]> = []) =>
 	({ key, sizes }: HeaderBiddingSlot): HeaderBiddingSlot => {
 		// For now, only apply filtering to inline header bidding slots
 		// In the future we may want to expand this to all slots


### PR DESCRIPTION
## What does this change?

Use the new TypeScript [`satisfies`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#the-satisfies-operator) operator when defining ad sizes and size mappings. I've combined this with `as const` in order to infer the narrowest possible types, allowing things like in Intellisense:

![Screenshot 2023-09-14 at 10 05 43](https://github.com/guardian/commercial/assets/8000415/1a5fab42-8c4a-4dbf-ab08-6e60833e312b)

Doing this required size mappings use readonly arrays of ad-sizes (and some fixing up in a place or two to satisfy this). I think this is probably a good thing!

## Why?

This allows us to infer a narrower type in each case, whilst still asserting that ad sizes and size mappings have a certain shape:

- In the case of ad sizes, this doesn't have a material effect, since the type inferred is the same as the one that is satisfied.
- In the case of size mappings, it means we can now access properties deeply.

This currently only has limited utility, but could be extended in the future (it'll allow certain types of per-property TSDoc to be surfaced, or for us to use a narrower ad size type).
