### PR TITLE
Update Prebid.js to 7.54.5

### DIFF
--- a/.changeset/thirty-ravens-give.md
+++ b/.changeset/thirty-ravens-give.md
@@ -2,4 +2,4 @@
 '@guardian/commercial': patch
 ---
 
-Testing Prebid update
+Update Prebid version

--- a/.changeset/thirty-ravens-give.md
+++ b/.changeset/thirty-ravens-give.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Testing Prebid update

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",
 		"ophan-tracker-js": "^1.4.0",
-		"prebid.js": "guardian/prebid.js#ei/upgrade-prebid",
+		"prebid.js": "guardian/prebid.js#356f371",
 		"process": "^0.11.10",
 		"raven-js": "^3.27.2",
 		"tslib": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",
 		"ophan-tracker-js": "^1.4.0",
-		"prebid.js": "guardian/prebid.js#b8263f2",
+		"prebid.js": "guardian/prebid.js#ei/upgrade-prebid",
 		"process": "^0.11.10",
 		"raven-js": "^3.27.2",
 		"tslib": "^2.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7464,9 +7464,9 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-prebid.js@guardian/prebid.js#b8263f2:
-  version "7.54.4"
-  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/b8263f2e041833b0ec0d05d14de6c3f1bdd466ff"
+prebid.js@guardian/prebid.js#ei/upgrade-prebid:
+  version "7.54.5"
+  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/33139299e50aac564ed65eeb31608006ec001375"
   dependencies:
     "@babel/core" "^7.16.7"
     "@babel/plugin-transform-runtime" "^7.18.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7464,9 +7464,9 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-prebid.js@guardian/prebid.js#ei/upgrade-prebid:
+prebid.js@guardian/prebid.js#356f371:
   version "7.54.5"
-  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/33139299e50aac564ed65eeb31608006ec001375"
+  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/356f3714fda0459b6740e90ff265055fe6d4f813"
   dependencies:
     "@babel/core" "^7.16.7"
     "@babel/plugin-transform-runtime" "^7.18.9"


### PR DESCRIPTION
# What does this change?
Upgrade Prebid to 7.54.5, to use the version from this PR: https://github.com/guardian/Prebid.js/pull/135
