### PR TITLE
Add ix to acBidders in realTimeData

### DIFF
--- a/.changeset/fuzzy-fireants-behave.md
+++ b/.changeset/fuzzy-fireants-behave.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Add ix to acBidders in realTimeData

--- a/src/lib/header-bidding/prebid/prebid.spec.ts
+++ b/src/lib/header-bidding/prebid/prebid.spec.ts
@@ -188,6 +188,7 @@ describe('initialise', () => {
 		expect(rtcData?.name).toEqual('permutive');
 		expect(rtcData?.params.acBidders).toEqual([
 			'appnexus',
+			'ix',
 			'ozone',
 			'pubmatic',
 			'trustx',

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -304,7 +304,13 @@ const initialise = (window: Window, framework: Framework = 'tcfv2'): void => {
 				{
 					name: 'permutive',
 					params: {
-						acBidders: ['appnexus', 'ozone', 'pubmatic', 'trustx'],
+						acBidders: [
+							'appnexus',
+							'ix',
+							'ozone',
+							'pubmatic',
+							'trustx',
+						],
 						overwrites: {
 							pubmatic,
 						},


### PR DESCRIPTION
## What does this change?
Adds 'ix', the bidder name for indexSSP, to acBidders in the realTimeData config.

## Why?
This will allow them to access our Permutive audience segments so that they have audience data for targeting deals.

**Before:**

<img width="242" alt="Screenshot 2023-09-15 at 10 55 57" src="https://github.com/guardian/commercial/assets/108270776/6861620b-5941-424f-b04f-7484f22eb1b8">


**After:**

<img width="244" alt="Screenshot 2023-09-14 at 17 21 56" src="https://github.com/guardian/commercial/assets/108270776/5120b6af-7e96-4e95-b4db-edd2b34c7154">
