### PR TITLE
Fix some noUncheckedIndexedAccess rule errors

### DIFF
--- a/src/lib/consentless/render-advert-label.spec.ts
+++ b/src/lib/consentless/render-advert-label.spec.ts
@@ -6,7 +6,7 @@ jest.mock('lib/commercial-features', () => ({
 
 const adSelector = '.js-ad-slot';
 
-const adverts: Record<string, string> = {
+const adverts = {
 	withLabel: `
         <div class="js-ad-slot"></div>`,
 	labelDisabled: `
@@ -15,7 +15,7 @@ const adverts: Record<string, string> = {
         <div class="js-ad-slot ad-slot--frame"></div>`,
 	uh: `
         <div class="js-ad-slot u-h"></div>`,
-};
+} satisfies Record<string, string>;
 
 const createAd = (html: string) => {
 	document.body.innerHTML = html;

--- a/src/lib/dfp/render-advert-label.spec.ts
+++ b/src/lib/dfp/render-advert-label.spec.ts
@@ -6,7 +6,7 @@ jest.mock('lib/commercial-features', () => ({
 
 const adSelector = '.js-ad-slot';
 
-const adverts: Record<string, string> = {
+const adverts = {
 	withLabel: `
         <div class="js-ad-slot"></div>`,
 	labelDisabled: `
@@ -27,7 +27,7 @@ const adverts: Record<string, string> = {
         <div class="js-ad-slot" data-label="true"></div>`,
 	dataLabelFalse: `
         <div class="js-ad-slot" data-label="false"></div>`,
-};
+} satisfies Record<string, string>;
 
 const createAd = (html: string) => {
 	document.body.innerHTML = html;

--- a/src/lib/dfp/render-advert.ts
+++ b/src/lib/dfp/render-advert.ts
@@ -131,7 +131,7 @@ const addContentClass = (adSlotNode: HTMLElement) => {
 
 	if (adSlotContent.length) {
 		void fastdom.mutate(() => {
-			adSlotContent[0].classList.add('ad-slot__content');
+			adSlotContent[0]?.classList.add('ad-slot__content');
 		});
 	}
 };

--- a/src/lib/header-bidding/prebid/bid-config.spec.ts
+++ b/src/lib/header-bidding/prebid/bid-config.spec.ts
@@ -380,11 +380,11 @@ describe('indexExchangeBidders', () => {
 			createAdSize(300, 600),
 		];
 		const bidders: PrebidBidder[] = indexExchangeBidders(slotSizes, false);
-		expect(bidders[0].bidParams('type', [createAdSize(1, 2)])).toEqual({
+		expect(bidders[0]?.bidParams('type', [createAdSize(1, 2)])).toEqual({
 			siteId: '123456',
 			size: [300, 250],
 		});
-		expect(bidders[1].bidParams('type', [createAdSize(1, 2)])).toEqual({
+		expect(bidders[1]?.bidParams('type', [createAdSize(1, 2)])).toEqual({
 			siteId: '123456',
 			size: [300, 600],
 		});
@@ -618,7 +618,7 @@ describe('triplelift adapter', () => {
 			'dfp-ad--top-above-nav',
 			[createAdSize(728, 90)],
 			mockPageTargeting,
-		)[1].params;
+		)[1]?.params;
 		expect(tripleLiftBids).toEqual({
 			inventoryCode: 'theguardian_topbanner_728x90_prebid',
 		});
@@ -634,7 +634,7 @@ describe('triplelift adapter', () => {
 			'dfp-ad--top-above-nav',
 			[createAdSize(728, 90)],
 			mockPageTargeting,
-		)[1].params;
+		)[1]?.params;
 		expect(tripleLiftBids).toEqual({
 			inventoryCode: 'theguardian_topbanner_728x90_prebid_AU',
 		});
@@ -651,7 +651,7 @@ describe('triplelift adapter', () => {
 			'dfp-ad--inline1',
 			[createAdSize(300, 250)],
 			mockPageTargeting,
-		)[1].params;
+		)[1]?.params;
 		expect(tripleLiftBids).toEqual({
 			inventoryCode: 'theguardian_sectionfront_300x250_prebid',
 		});
@@ -668,7 +668,7 @@ describe('triplelift adapter', () => {
 			'dfp-ad--inline1',
 			[createAdSize(300, 250)],
 			mockPageTargeting,
-		)[1].params;
+		)[1]?.params;
 		expect(tripleLiftBids).toEqual({
 			inventoryCode: 'theguardian_sectionfront_300x250_prebid_AU',
 		});
@@ -685,7 +685,7 @@ describe('triplelift adapter', () => {
 			'dfp-ad--top-above-nav',
 			[createAdSize(320, 50)],
 			mockPageTargeting,
-		)[1].params;
+		)[1]?.params;
 		expect(tripleLiftBids).toEqual({
 			inventoryCode: 'theguardian_320x50_HDX',
 		});
@@ -702,7 +702,7 @@ describe('triplelift adapter', () => {
 			'dfp-ad--top-above-nav',
 			[createAdSize(320, 50)],
 			mockPageTargeting,
-		)[1].params;
+		)[1]?.params;
 		expect(tripleLiftBids).toEqual({
 			inventoryCode: 'theguardian_320x50_HDX_AU',
 		});

--- a/src/lib/header-bidding/slot-config.spec.ts
+++ b/src/lib/header-bidding/slot-config.spec.ts
@@ -134,7 +134,7 @@ describe('getPrebidAdSlots', () => {
 
 		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline1'));
 		expect(hbSlots).toHaveLength(1);
-		expect(hbSlots[0].sizes).toEqual([
+		expect(hbSlots[0]?.sizes).toEqual([
 			[300, 250],
 			[620, 350],
 		]);
@@ -146,7 +146,7 @@ describe('getPrebidAdSlots', () => {
 
 		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline1'));
 		expect(hbSlots).toHaveLength(1);
-		expect(hbSlots[0].sizes).toEqual([
+		expect(hbSlots[0]?.sizes).toEqual([
 			[300, 197],
 			[300, 250],
 			[320, 480],
@@ -159,7 +159,7 @@ describe('getPrebidAdSlots', () => {
 
 		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline2'));
 		expect(hbSlots).toHaveLength(1);
-		expect(hbSlots[0].sizes).toEqual([
+		expect(hbSlots[0]?.sizes).toEqual([
 			[160, 600],
 			[300, 600],
 			[300, 250],
@@ -172,7 +172,7 @@ describe('getPrebidAdSlots', () => {
 
 		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline2'));
 		expect(hbSlots).toHaveLength(1);
-		expect(hbSlots[0].sizes).toEqual([
+		expect(hbSlots[0]?.sizes).toEqual([
 			[300, 250],
 			[320, 480],
 		]);
@@ -194,7 +194,7 @@ describe('getPrebidAdSlots', () => {
 
 		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline4'));
 		expect(hbSlots).toHaveLength(1);
-		expect(hbSlots[0].sizes).toEqual([[300, 250]]);
+		expect(hbSlots[0]?.sizes).toEqual([[300, 250]]);
 	});
 
 	test('should return the correct inline slot at breakpoint D with additional size mappings', () => {
@@ -207,7 +207,7 @@ describe('getPrebidAdSlots', () => {
 			}),
 		);
 		expect(hbSlots).toHaveLength(1);
-		expect(hbSlots[0].sizes).toEqual([
+		expect(hbSlots[0]?.sizes).toEqual([
 			[160, 600],
 			[300, 600],
 			[300, 250],


### PR DESCRIPTION
## What does this change?
Fixes a few of the more simple errors that result from switching on the noUncheckedIndexedAccess rule for the bundle code.

## Why?
Reduces the number of errors left to tackle:
Before:
<img width="211" alt="Screenshot 2023-09-15 at 15 27 47" src="https://github.com/guardian/commercial/assets/108270776/d7baf064-bb2f-4d5f-b737-18a3699e3984">
After:
<img width="212" alt="Screenshot 2023-09-15 at 16 51 47" src="https://github.com/guardian/commercial/assets/108270776/379eff49-8811-43e6-8279-968155a9e9ba">

