### PR TITLE
Fix unchecked indexed access errors in `spacefinder.ts`

### DIFF
--- a/.changeset/bright-panthers-sip.md
+++ b/.changeset/bright-panthers-sip.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Fix noUncheckedIndexedAccess errors in spacefinder.ts

--- a/src/lib/spacefinder/spacefinder.ts
+++ b/src/lib/spacefinder/spacefinder.ts
@@ -144,7 +144,7 @@ const onInteractivesLoaded = memoize(async (rules: SpacefinderRules) => {
 	const notLoaded = query('.element-interactive', rules.body).filter(
 		(interactive) => {
 			const iframes = Array.from(interactive.children).filter(isIframe);
-			return !(iframes.length && isIframeLoaded(iframes[0]));
+			return !(iframes[0] && isIframeLoaded(iframes[0]));
 		},
 	);
 
@@ -158,9 +158,9 @@ const onInteractivesLoaded = memoize(async (rules: SpacefinderRules) => {
 				// Listen for when iframes are added as children to interactives
 				new MutationObserver((records, instance) => {
 					if (
-						!records.length ||
-						!records[0].addedNodes.length ||
-						!isIframe(records[0].addedNodes[0])
+						// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- enable noUncheckedIndexedAccess in tsconfig
+						!records[0]?.addedNodes[0] ||
+						!isIframe(records[0]?.addedNodes[0])
 					) {
 						return;
 					}
@@ -183,8 +183,8 @@ const onInteractivesLoaded = memoize(async (rules: SpacefinderRules) => {
 
 const partitionCandidates = <T>(
 	list: T[],
-	filterElement: (element: T, lastFilteredElement: T) => boolean,
-) => {
+	filterElement: (element: T, lastFilteredElement: T | undefined) => boolean,
+): [T[], T[]] => {
 	const filtered: T[] = [];
 	const exclusions: T[] = [];
 
@@ -289,9 +289,7 @@ const enforceRules = (
 					testCandidates(
 						rule,
 						candidate,
-						measurements.opponents
-							? measurements.opponents[selector]
-							: [],
+						measurements.opponents?.[selector] ?? [],
 					),
 			);
 			spacefinderExclusions[selector] = exclusions;


### PR DESCRIPTION
## What does this change?

Fix errors related to [noUncheckedIndexedAccess](https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess) in the `spacefinder.ts` file.

## Why?

Much better type safety when access collections by their index.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/commercial/assets/8000415/713a4824-582e-45d5-99bc-d76a68843861
[after]: https://github.com/guardian/commercial/assets/8000415/58867bcd-62fb-4a4a-8b41-842f5b7cada7

