### PR TITLE
fix noUncheckedIndexAccess errors in `ab*.ts` files

### DIFF
--- a/.changeset/twelve-actors-march.md
+++ b/.changeset/twelve-actors-march.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+fix noUncheckedIndexAccess errors in `ab*.ts` files

--- a/src/lib/experiments/__mocks__/ab-tests.ts
+++ b/src/lib/experiments/__mocks__/ab-tests.ts
@@ -8,7 +8,7 @@ export const concurrentTests = [
 		genVariant('control', false),
 		genVariant('variant', true),
 	]),
-];
+] as const;
 export const epicTests = [genAbTest('EpicTest'), genAbTest('EpicTest2')];
 export const engagementBannerTests = [
 	genAbTest('BannerTest'),

--- a/src/lib/experiments/ab-core.ts
+++ b/src/lib/experiments/ab-core.ts
@@ -44,7 +44,7 @@ const testCanBeRun = (test: ABTest): boolean => {
 //
 // The test population is just a subset of MVT ids. A test population must
 // begin from a specific value. Overlapping test ranges are permitted.
-const computeVariantFromMvtCookie = (test: ABTest): Variant | null => {
+const computeVariantFromMvtCookie = (test: ABTest): Variant | void => {
 	const smallestTestId = getMvtNumValues() * test.audienceOffset;
 	const largestTestId = smallestTestId + getMvtNumValues() * test.audience;
 	const mvtCookieId = getMvtValue();
@@ -58,7 +58,7 @@ const computeVariantFromMvtCookie = (test: ABTest): Variant | null => {
 		return test.variants[mvtCookieId % test.variants.length];
 	}
 
-	return null;
+	return;
 };
 
 // This is the heart of the A/B testing framework.
@@ -71,7 +71,7 @@ const runnableTest = (test: ABTest): Runnable<ABTest> | null => {
 	const fromUrl = getVariantFromUrl(test);
 	const fromLocalStorage = getVariantFromLocalStorage(test);
 	const fromCookie = computeVariantFromMvtCookie(test);
-	const variantToRun = fromUrl ?? fromLocalStorage ?? fromCookie ?? null;
+	const variantToRun = fromUrl ?? fromLocalStorage ?? fromCookie;
 	const ignoreCanRun = fromUrl && getIgnoreCanRunFromUrl(); // check fromUrl to only ignore can run for forced tests
 
 	if (variantToRun && ignoreCanRun) {

--- a/src/lib/experiments/ab-url.ts
+++ b/src/lib/experiments/ab-url.ts
@@ -7,12 +7,15 @@ export const getForcedParticipationsFromUrl = (): Participations => {
 
 		return tokens.reduce((obj, token) => {
 			const [testId, variantId] = token.split('=');
-			return {
-				...obj,
-				[testId]: {
-					variant: variantId,
-				},
-			};
+			if (testId && variantId) {
+				return {
+					...obj,
+					[testId]: {
+						variant: variantId,
+					},
+				};
+			}
+			return obj;
 		}, {});
 	}
 

--- a/src/lib/experiments/ab.spec.ts
+++ b/src/lib/experiments/ab.spec.ts
@@ -1,6 +1,7 @@
 import type { ABTest, Runnable } from '@guardian/ab-core';
 import type { Config } from 'types/global';
 import { _ } from '../analytics/mvt-cookie';
+import type { concurrentTests as concurrentTestsMock } from './__mocks__/ab-tests';
 import {
 	getAsyncTestsToRun,
 	getSynchronousTestsToRun,
@@ -12,10 +13,12 @@ import {
 	getParticipationsFromLocalStorage,
 	setParticipationsInLocalStorage,
 } from './ab-local-storage';
-import { concurrentTests } from './ab-tests';
+import { concurrentTests as _concurrentTests } from './ab-tests';
 import { runnableTestsToParticipations } from './ab-utils';
 
 const { overwriteMvtCookie } = _;
+
+const concurrentTests = _concurrentTests as typeof concurrentTestsMock;
 
 // This is required as loading these seems to cause an error locally (and in CI)
 // because of some implicit dependency evil that I haven't been able to figure out.
@@ -76,11 +79,14 @@ describe('A/B', () => {
 			};
 
 			const shouldRun = [
+				// @ts-expect-error -- this is mocked in __mocks__/ab-tests.ts
 				jest.spyOn(concurrentTests[0].variants[0], 'test'),
+				// @ts-expect-error -- this is mocked in __mocks__/ab-tests.ts
 				jest.spyOn(concurrentTests[1].variants[0], 'test'),
 			];
 
 			const shouldNotRun = [
+				// @ts-expect-error -- this is mocked in __mocks__/ab-tests.ts
 				jest.spyOn(concurrentTests[2].variants[0], 'test'),
 			];
 
@@ -111,6 +117,7 @@ describe('A/B', () => {
 		test('tests with notintest participations should not run, but this should be persisted to localStorage', () => {
 			expect.assertions(3);
 
+			// @ts-expect-error -- this is mocked in __mocks__/ab-tests.ts
 			const spy = jest.spyOn(concurrentTests[0].variants[0], 'test');
 			expect(spy).not.toHaveBeenCalled();
 			setParticipationsInLocalStorage({
@@ -175,6 +182,7 @@ describe('A/B', () => {
 			expect.assertions(2);
 
 			window.location.hash = '#ab-DummyTest=variant';
+			// @ts-expect-error -- this is mocked in __mocks__/ab-tests.ts
 			expect(getSynchronousTestsToRun()[0].variantToRun.id).toEqual(
 				'variant',
 			);


### PR DESCRIPTION
## What does this change?
A lot were in the `ab.spec.ts` file, most of them were from the mocked concurrent tests array, asserting it as `const` fixed most, however the mocked variants would require some typescript gymnastics, so as it's a spec file I though it would be okay to ignore those.

