### PR TITLE
Prevent overlap of labs banner and inline2+ ads

### DIFF
--- a/.changeset/violet-cycles-doubt.md
+++ b/.changeset/violet-cycles-doubt.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Prevent inline2+ and banner overlapping on paid content pages

--- a/src/lib/spacefinder/sticky-inlines.ts
+++ b/src/lib/spacefinder/sticky-inlines.ts
@@ -19,17 +19,22 @@ type RightColItem = {
 /**
  * The minimum buffer between two adverts (aka winning paragraphs) in the right column
  */
-const paragraphBufferPx = 600;
+const PARAGRAPH_BUFFER_PX = 600;
 
 /**
  * The minimum buffer between a right column advert and an immersive element
  */
-const immersiveBufferPx = 100;
+const IMMERSIVE_BUFFER_PX = 100;
 
 /**
  * The minimum buffer between a right column advert and the bottom of the article body
  */
-const articleBottomBufferPx = 100;
+const ARTICLE_BOTTOM_BUFFER_PX = 100;
+
+/**
+ * The height of the labs header on paid content pages
+ */
+const LABS_HEADER_HEIGHT = 55;
 
 /**
  * Add a stylesheet to the document that adds height properties for a given set of class names
@@ -41,9 +46,17 @@ const articleBottomBufferPx = 100;
 const insertHeightStyles = (
 	heightMapping: Array<[string, number]>,
 ): Promise<void> => {
+	/**
+	 * Paid content has a banner at the top of the page. We don't want this
+	 * banner to overlap the advert. Adds extra padding for visual benefit
+	 */
+	const top = window.guardian.config.page.isPaidContent
+		? `${LABS_HEADER_HEIGHT + 6}px`
+		: 0;
+
 	const heightClasses = heightMapping.reduce(
 		(css, [name, height]) =>
-			`${css} .${name} { min-height: ${height}px; } .${name} > * { position: sticky; top: 0; }`,
+			`${css} .${name} { min-height: ${height}px; } .${name} > * { position: sticky; top: ${top}; }`,
 		'',
 	);
 
@@ -123,15 +136,15 @@ const computeStickyHeights = async (
 					return (
 						articleBodyElementHeightBottom -
 						current.top -
-						articleBottomBufferPx
+						ARTICLE_BOTTOM_BUFFER_PX
 					);
 				}
 
 				// Choose height of buffer depending on the kind of element we're measuring to
 				const buffer =
 					next.kind === 'winningPara'
-						? paragraphBufferPx
-						: immersiveBufferPx;
+						? PARAGRAPH_BUFFER_PX
+						: IMMERSIVE_BUFFER_PX;
 
 				// Compute the distance from the top of the current element to the top of the next element, minus the buffer
 				return Math.floor(next.top - current.top - buffer);


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

Sets `top: 61px` for inline2+ sticky ads on Paid Content article pages

## Why?

On Paid Content pages, there is a banner at the top of the page. The right ad slot has `top: 61px`, but inline2+ ads further down the page have `top: 0`, which meant they are partially covered by the banner. Setting the top value to the height of the banner plus a bit of padding ensures no overlap.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/commercial/assets/9574885/97795c1f-f470-413b-b61b-80e7f9ebe7db
[after]: https://github.com/guardian/commercial/assets/9574885/3541ad0a-e453-49c9-81e9-6838fb3ffcd8
