### PR TITLE
remove logic related to expiry-ad-free-cookie and its switch

### DIFF
--- a/.changeset/rude-lemons-eat.md
+++ b/.changeset/rude-lemons-eat.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+removing ad free expiry switch and logic:

--- a/cypress/fixtures/pages/articles.ts
+++ b/cypress/fixtures/pages/articles.ts
@@ -1497,7 +1497,6 @@ export const Standard = {
 			adaptiveSite: true,
 			prebidPermutiveAudience: true,
 			compareVariantDecision: false,
-			adFreeStrictExpiryEnforcement: false,
 			enableSentryReporting: true,
 			lazyLoadContainers: true,
 			ampArticleSwitch: true,

--- a/src/lib/manage-ad-free-cookie.ts
+++ b/src/lib/manage-ad-free-cookie.ts
@@ -1,19 +1,10 @@
 import { getCookie, setCookie } from '@guardian/libs';
-import { cookieIsExpiredOrMissing } from 'lib/cookie';
 
 // cookie to trigger server-side ad-freeness
 const AD_FREE_USER_COOKIE = 'GU_AF1';
 
 const getAdFreeCookie = (): string | null =>
 	getCookie({ name: AD_FREE_USER_COOKIE });
-
-const adFreeDataIsOld = (): boolean => {
-	const { switches } = window.guardian.config;
-	return (
-		Boolean(switches.adFreeStrictExpiryEnforcement) &&
-		cookieIsExpiredOrMissing(AD_FREE_USER_COOKIE)
-	);
-};
 
 const adFreeDataIsPresent = (): boolean => {
 	const cookieVal = getAdFreeCookie();
@@ -36,9 +27,4 @@ const setAdFreeCookie = (daysToLive = 1): void => {
 	});
 };
 
-export {
-	setAdFreeCookie,
-	getAdFreeCookie,
-	adFreeDataIsOld,
-	adFreeDataIsPresent,
-};
+export { setAdFreeCookie, getAdFreeCookie, adFreeDataIsPresent };

--- a/src/lib/user-features.spec.ts
+++ b/src/lib/user-features.spec.ts
@@ -84,16 +84,6 @@ const setAllFeaturesData = (opts: { isExpired: boolean }) => {
 	addCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE, 'test');
 };
 
-const setExpiredAdFreeData = () => {
-	const currentTime = new Date().getTime();
-	const msInOneDay = 24 * 60 * 60 * 1000;
-	const expiryDate = new Date(currentTime - msInOneDay * 2);
-	addCookie(
-		PERSISTENCE_KEYS.AD_FREE_USER_COOKIE,
-		expiryDate.getTime().toString(),
-	);
-};
-
 const deleteAllFeaturesData = () => {
 	removeCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE);
 	removeCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE);
@@ -105,7 +95,6 @@ const deleteAllFeaturesData = () => {
 };
 
 beforeAll(() => {
-	window.guardian.config.switches.adFreeStrictExpiryEnforcement = true;
 	window.guardian.config.page.userAttributesApiUrl = '';
 });
 
@@ -163,19 +152,6 @@ describe('Refreshing the features data', () => {
 			// Set everything except paying-member cookie
 			setAllFeaturesData({ isExpired: true });
 			removeCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE);
-
-			await refresh();
-			expect(fetchJsonSpy).toHaveBeenCalledTimes(1);
-		});
-
-		it('Performs an update if the ad-free state is stale and strict expiry enforcement is enabled', async () => {
-			// This is a slightly synthetic setup - the ad-free cookie is rewritten with every
-			// refresh that happens as a result of expired features data, but we want to check
-			// that a refresh could be triggered based on ad-free state alone if the strict
-			// expiry enforcement switch is ON.
-			// Set everything except the ad-free cookie
-			setAllFeaturesData({ isExpired: false });
-			setExpiredAdFreeData();
 
 			await refresh();
 			expect(fetchJsonSpy).toHaveBeenCalledTimes(1);

--- a/src/lib/user-features.ts
+++ b/src/lib/user-features.ts
@@ -2,7 +2,6 @@ import { getCookie, isObject, removeCookie, setCookie } from '@guardian/libs';
 import type { HeaderPayload } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
 import { cookieIsExpiredOrMissing, timeInDaysFromNow } from 'lib/cookie';
 import {
-	adFreeDataIsOld,
 	adFreeDataIsPresent,
 	getAdFreeCookie,
 	setAdFreeCookie,
@@ -183,9 +182,7 @@ const isDigitalSubscriber = (): boolean =>
 	getCookie({ name: DIGITAL_SUBSCRIBER_COOKIE }) === 'true';
 
 const userNeedsNewFeatureData = (): boolean =>
-	featuresDataIsOld() ||
-	(adFreeDataIsPresent() && adFreeDataIsOld()) ||
-	(isDigitalSubscriber() && !adFreeDataIsPresent());
+	featuresDataIsOld() || (isDigitalSubscriber() && !adFreeDataIsPresent());
 
 const userHasDataAfterSignout = async (): Promise<boolean> =>
 	!(await isUserLoggedInOktaRefactor()) && userHasData();
@@ -356,7 +353,7 @@ const fakeOneOffContributor = (): void => {
 };
 
 const isAdFreeUser = (): boolean =>
-	isDigitalSubscriber() || (adFreeDataIsPresent() && !adFreeDataIsOld());
+	isDigitalSubscriber() || adFreeDataIsPresent();
 
 // Extend the expiry of the contributions cookie by 1 year beyond the date of the contribution
 const extendContribsCookieExpiry = (): void => {


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?
This PR removes any related logic to the `AdFreeStrictExpiryEnforcement` switch.
This was also removed from the related PR in `frontend` [here](https://github.com/guardian/frontend/pull/26587)
## Why?

Currently we have a switch `AdFreeStrictExpiryEnforcement` 
When this switch is ON and the website loads, it checks to see if the user's ad-free cookie has expired. If so, it will refetch data to update this cookie. This switch has been OFF for a long time and is no longer needed.
We are not concerned with how old the cookie is so therefore we are removing any logic which checks for date or expiry for that cookie.

so the `ad-free-strict-expiry-enforcement` the logic related to this along with the tests have been removed.

