### PR TITLE
Remove reference to simpleReach

### DIFF
--- a/cypress/fixtures/pages/articles.ts
+++ b/cypress/fixtures/pages/articles.ts
@@ -1543,7 +1543,6 @@ export const Standard = {
 			brazeTaylorReport: false,
 			abConsentlessAds: true,
 			externalVideoEmbeds: true,
-			simpleReach: true,
 			abIntegrateIma: true,
 			callouts: true,
 			sentinelLogger: true,


### PR DESCRIPTION
## What does this change?
Removes a reference to the simpleReach switch.

## Why?
We're deleting the simpleReach switch as it's no longer used, so we need to delete any references to it in the code.