### PR TITLE
Various `noUncheckedIndexedAccess` fixes

### DIFF
--- a/.changeset/dirty-scissors-scream.md
+++ b/.changeset/dirty-scissors-scream.md
@@ -1,0 +1,13 @@
+---
+'@guardian/commercial': patch
+---
+
+Fix instances of no unchecked indexed access errors in:
+
+- src/lib/consentless/dynamic/liveblog-inline.ts
+- src/lib/dfp/init-slot-ias.spec.ts
+- src/lib/dfp/prepare-permutive.spec.ts
+- src/lib/spacefinder/article-aside-adverts.ts
+- src/lib/spacefinder/liveblog-adverts.ts
+- src/lib/third-party-tags.ts
+- src/lib/utils/geolocation.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,8 @@ module.exports = {
 		'no-use-before-define': ['error', { functions: true, classes: true }],
 		'import/exports-last': 'error',
 		'no-else-return': 'error',
+		// TODO - remove this once we've unable no unchecked indexed access on main
+		'@typescript-eslint/no-unnecessary-condition': 'warn',
 	},
 	overrides: [
 		{

--- a/src/lib/consentless/dynamic/liveblog-inline.ts
+++ b/src/lib/consentless/dynamic/liveblog-inline.ts
@@ -100,7 +100,7 @@ const insertAds: SpacefinderWriter = async (paras) => {
 	const fastdomPromises = [];
 	for (let i = 0; i < paras.length && AD_COUNTER < MAX_ADS; i += 1) {
 		const para = paras[i];
-		if (para.parentNode) {
+		if (para?.parentNode) {
 			const result = insertAdAtPara(para);
 			fastdomPromises.push(result);
 			AD_COUNTER += 1;

--- a/src/lib/dfp/init-slot-ias.spec.ts
+++ b/src/lib/dfp/init-slot-ias.spec.ts
@@ -42,7 +42,7 @@ describe('initSlotIas', () => {
 
 		expect(queue).toHaveLength(1);
 
-		const { adSlots, dataHandler } = queue[0];
+		const { adSlots, dataHandler } = queue[0]!;
 
 		expect(adSlots).toEqual([
 			{

--- a/src/lib/dfp/prepare-permutive.spec.ts
+++ b/src/lib/dfp/prepare-permutive.spec.ts
@@ -330,7 +330,7 @@ describe('Generating Permutive payload utils', () => {
 			);
 			const err = (logger.mock.calls[0] as Error[])[0];
 			expect(err).toBeInstanceOf(Error);
-			expect(err.message).toBe('Global Permutive setup error');
+			expect(err?.message).toBe('Global Permutive setup error');
 		});
 		it('calls the permutive addon method with the correct payload', () => {
 			const mockPermutive = { addon: jest.fn(), identify: jest.fn() };

--- a/src/lib/dfp/prepare-permutive.spec.ts
+++ b/src/lib/dfp/prepare-permutive.spec.ts
@@ -376,8 +376,8 @@ describe('Generating Permutive payload utils', () => {
 			_.runPermutive(config, mockPermutive, logger);
 			const [identifyCallOrder] =
 				mockPermutive.identify.mock.invocationCallOrder;
-			const [addonCallOrder] =
-				mockPermutive.addon.mock.invocationCallOrder;
+			const [addonCallOrder] = mockPermutive.addon.mock
+				.invocationCallOrder as [number];
 			expect(identifyCallOrder).toBeLessThan(addonCallOrder);
 		});
 		it('does not call the identify method if no browser ID is present', () => {

--- a/src/lib/spacefinder/article-aside-adverts.ts
+++ b/src/lib/spacefinder/article-aside-adverts.ts
@@ -67,7 +67,7 @@ export const init = (): Promise<void | boolean> => {
 			return [
 				mainCol.get(0).offsetHeight,
 				immersiveElementOffset - mainColOffset,
-			];
+			] as const;
 		})
 		.then(([mainColHeight, immersiveOffset]) => {
 			// we do all the adjustments server-side if the page has a ShowcaseMainElement!
@@ -83,7 +83,7 @@ export const init = (): Promise<void | boolean> => {
 			) {
 				return fastdom.mutate(() => {
 					removeStickyClasses(adSlotsWithinRightCol);
-					adSlotsWithinRightCol[0].setAttribute(
+					adSlotsWithinRightCol[0]?.setAttribute(
 						'data-mobile',
 						getAllowedSizesForImmersive(immersiveOffset),
 					);
@@ -95,7 +95,7 @@ export const init = (): Promise<void | boolean> => {
 			if (mainColHeight < minArticleHeight) {
 				return fastdom.mutate(() => {
 					removeStickyClasses(adSlotsWithinRightCol);
-					adSlotsWithinRightCol[0].setAttribute(
+					adSlotsWithinRightCol[0]?.setAttribute(
 						'data-mobile',
 						'1,1|2,2|300,250|300,274|fluid',
 					);

--- a/src/lib/spacefinder/liveblog-adverts.ts
+++ b/src/lib/spacefinder/liveblog-adverts.ts
@@ -130,7 +130,7 @@ const insertAds: SpacefinderWriter = async (paras) => {
 	const fastdomPromises = [];
 	for (let i = 0; i < paras.length && AD_COUNTER < MAX_ADS; i += 1) {
 		const para = paras[i];
-		if (para.parentNode) {
+		if (para?.parentNode) {
 			const result = insertAdAtPara(para);
 			fastdomPromises.push(result);
 			AD_COUNTER += 1;

--- a/src/lib/third-party-tags.ts
+++ b/src/lib/third-party-tags.ts
@@ -54,7 +54,7 @@ const addScripts = (tags: ThirdPartyTag[]) => {
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- false positive
 	if (hasScriptsToInsert) {
 		return fastdom.mutate(() => {
-			if (ref.parentNode) {
+			if (ref?.parentNode) {
 				ref.parentNode.insertBefore(frag, ref);
 			}
 		});

--- a/src/lib/utils/geolocation.ts
+++ b/src/lib/utils/geolocation.ts
@@ -1,13 +1,14 @@
 import { getCookie, isString, storage } from '@guardian/libs';
 import type { CountryCode } from '@guardian/libs';
+import type { Edition } from 'types/global';
 
-const editionToGeolocationMap: Record<string, CountryCode> = {
+const editionToGeolocationMap: Record<Edition, CountryCode> = {
 	UK: 'GB',
 	US: 'US',
 	AU: 'AU',
 };
 
-const editionToGeolocation = (editionKey = 'UK'): CountryCode =>
+const editionToGeolocation = (editionKey: Edition = 'UK'): CountryCode =>
 	editionToGeolocationMap[editionKey];
 
 const countryCookieName = 'GU_geo_country';


### PR DESCRIPTION
## What does this change?

Fixe instances of no unchecked indexed access errors in:
- src/lib/consentless/dynamic/liveblog-inline.ts
- src/lib/dfp/init-slot-ias.spec.ts
- src/lib/dfp/prepare-permutive.spec.ts
- src/lib/spacefinder/article-aside-adverts.ts
- src/lib/spacefinder/liveblog-adverts.ts
- src/lib/third-party-tags.ts
- src/lib/utils/geolocation.ts

I've also switched the `no-unnecessary-condition` rule to `warn` whilst we squash these errors. We can re-enable it once this work is complete.

## Why?

Better type safety once the rule is enabled.
