### PR TITLE
Stop recording Cypress videos in CI

### DIFF
--- a/.github/workflows/e2e-cypress.yml
+++ b/.github/workflows/e2e-cypress.yml
@@ -62,11 +62,8 @@ jobs:
         run: yarn cypress run --spec cypress/e2e/parallel-${{ matrix.group }}/*
         working-directory: ./commercial
 
-      # Only capture videos and screenshots on failure
-      # In order to minimize unused artifacts
-
       - uses: actions/upload-artifact@v2
-        if: failure()
+        if: always()
         with:
           name: cypress-videos
           path: commercial/cypress/videos

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -9,9 +9,7 @@ export default defineConfig({
 		runMode: 2,
 		openMode: 0,
 	},
-	// Record videos in CI
-	// This environment var is always set to "true" in CI (i.e. Github Actions)
-	video: !!process.env.CI,
+	video: false,
 	e2e: {
 		setupNodeEvents(on, config) {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-var-requires -- cypress api


### PR DESCRIPTION
Reverts guardian/commercial#1035.

I've found I get lots of errors when compressing the video artefacts in CI. Since we're moving away from Cypress, I figure we may as well revert this.