### PR TITLE
fix `noUncheckedIndexedAccess` from dfp directory

### DIFF
--- a/src/lib/dfp/display-ads.ts
+++ b/src/lib/dfp/display-ads.ts
@@ -1,4 +1,5 @@
 import { pageSkin } from '../creatives/page-skin';
+import type { Advert } from './Advert';
 import { dfpEnv } from './dfp-env';
 import { loadAdvert } from './load-advert';
 
@@ -21,8 +22,12 @@ const displayAds = (): void => {
 	window.googletag.pubads().collapseEmptyDivs();
 	window.googletag.enableServices();
 
-	loadAdvert(dfpEnv.advertsToLoad[0]);
-	dfpEnv.advertsToLoad.length = 0;
+	const firstAdvertToLoad: Advert | undefined = dfpEnv.advertsToLoad[0];
+
+	if (firstAdvertToLoad) {
+		loadAdvert(firstAdvertToLoad);
+		dfpEnv.advertsToLoad.length = 0;
+	}
 	pageSkin();
 };
 

--- a/src/lib/dfp/display-ads.ts
+++ b/src/lib/dfp/display-ads.ts
@@ -28,7 +28,7 @@ const displayAds = (): void => {
 
 	if (firstAdvertToLoad) {
 		loadAdvert(firstAdvertToLoad);
-		dfpEnv.advertsToLoad.length = 0;
+		dfpEnv.advertsToLoad = [];
 	}
 	pageSkin();
 };

--- a/src/lib/dfp/display-ads.ts
+++ b/src/lib/dfp/display-ads.ts
@@ -22,7 +22,9 @@ const displayAds = (): void => {
 	window.googletag.pubads().collapseEmptyDivs();
 	window.googletag.enableServices();
 
-	const firstAdvertToLoad: Advert | undefined = dfpEnv.advertsToLoad[0];
+	const firstAdvertToLoad: Advert | undefined = dfpEnv.advertsToLoad.length
+		? dfpEnv.advertsToLoad[0]
+		: undefined;
 
 	if (firstAdvertToLoad) {
 		loadAdvert(firstAdvertToLoad);

--- a/src/lib/dfp/get-advert-by-id.ts
+++ b/src/lib/dfp/get-advert-by-id.ts
@@ -1,7 +1,11 @@
 import type { Advert } from './Advert';
 import { dfpEnv } from './dfp-env';
 
-const getAdvertById = (id: string): Advert | null =>
-	id in dfpEnv.advertIds ? dfpEnv.adverts[dfpEnv.advertIds[id]] : null;
-
+const getAdvertById = (id: string): Advert | null => {
+	const advertIndex = dfpEnv.advertIds[id];
+	if (advertIndex !== undefined) {
+		return dfpEnv.adverts[advertIndex] ?? null;
+	}
+	return null;
+};
 export { getAdvertById };

--- a/src/lib/dfp/on-slot-render.ts
+++ b/src/lib/dfp/on-slot-render.ts
@@ -37,7 +37,7 @@ const reportEmptyResponse = (
 
 const sizeEventToAdSize = (size: string | number[]): AdSize | 'fluid' => {
 	if (isString(size)) return 'fluid';
-	return createAdSize(size[0], size[1]);
+	return createAdSize(Number(size[0]), Number(size[1]));
 };
 
 export const onSlotRender = (


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?
Fixes instances of no unchecked indexed access errors in following Dir:

- src/lib/dfp/display-ads.ts:24
- src/lib/dfp/get-advert-by-id.ts:5
- src/lib/dfp/on-slot-render.ts:40

## Why?
Better type safety once the rule is enabled.
