### PR TITLE
Add video option to interscroller

### DIFF
--- a/.changeset/empty-bananas-work.md
+++ b/.changeset/empty-bananas-work.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Add a video version of the interscroller template to messenger

--- a/src/lib/messenger/background.ts
+++ b/src/lib/messenger/background.ts
@@ -223,7 +223,6 @@ const setupBackground = async (
 				video.style.inset = '0';
 				video.style.position = 'fixed';
 				video.style.height = '100%';
-				video.style.width = '100%';
 				background.appendChild(video);
 			}
 		} else {

--- a/src/lib/messenger/background.ts
+++ b/src/lib/messenger/background.ts
@@ -221,8 +221,8 @@ const setupBackground = async (
 				video.playsInline = true;
 				video.src = specs.videoSource;
 				video.style.inset = '0';
-				video.style.transition = 'background 100ms ease';
-				video.style.position = 'relative';
+				video.style.position = 'fixed';
+				video.style.height = '100%';
 				video.style.width = '100%';
 				background.appendChild(video);
 			}

--- a/src/lib/messenger/background.ts
+++ b/src/lib/messenger/background.ts
@@ -9,7 +9,7 @@ import {
 const isDCR = window.guardian.config.isDotcomRendering;
 
 interface BackgroundSpecs {
-	backgroundImage: string;
+	backgroundImage?: string;
 	backgroundRepeat?: string;
 	backgroundPosition?: string;
 	// native templates are sometimes using the british spelling of background-color for some reason, removed in getStylesFromSpec above
@@ -19,14 +19,19 @@ interface BackgroundSpecs {
 	transform?: string;
 	scrollType?: 'interscroller' | 'fixed' | 'parallax';
 	ctaUrl?: string;
+	videoSource?: string;
 }
 
 const getStylesFromSpec = (
 	specs: BackgroundSpecs,
-): Omit<BackgroundSpecs, 'scrollType' | 'backgroundColour' | 'ctaUrl'> => {
+): Omit<
+	BackgroundSpecs,
+	'scrollType' | 'backgroundColour' | 'ctaUrl' | 'videoSource'
+> => {
 	const styles = { ...specs };
 	delete styles.scrollType;
 	delete styles.ctaUrl;
+	delete styles.videoSource;
 
 	// native templates are sometimes using the british spelling of background-color for some reason
 	if (styles.backgroundColour) {
@@ -207,6 +212,15 @@ const setupBackground = async (
 			if (specs.ctaUrl) {
 				const anchor = setCtaURL(specs.ctaUrl, backgroundParent);
 				adSlot.insertBefore(anchor, adSlot.firstChild);
+			}
+
+			if (specs.videoSource) {
+				const video = document.createElement('video');
+				video.autoplay = true;
+				video.muted = true;
+				video.playsInline = true;
+				video.src = String(specs.videoSource);
+				background.appendChild(video);
 			}
 		} else {
 			adSlot.insertBefore(backgroundParent, adSlot.firstChild);

--- a/src/lib/messenger/background.ts
+++ b/src/lib/messenger/background.ts
@@ -219,7 +219,11 @@ const setupBackground = async (
 				video.autoplay = true;
 				video.muted = true;
 				video.playsInline = true;
-				video.src = String(specs.videoSource);
+				video.src = specs.videoSource;
+				video.style.inset = '0';
+				video.style.transition = 'background 100ms ease';
+				video.style.position = 'relative';
+				video.style.width = '100%';
 				background.appendChild(video);
 			}
 		} else {

--- a/src/lib/messenger/background.ts
+++ b/src/lib/messenger/background.ts
@@ -9,7 +9,7 @@ import {
 const isDCR = window.guardian.config.isDotcomRendering;
 
 interface BackgroundSpecs {
-	backgroundImage?: string;
+	backgroundImage: string;
 	backgroundRepeat?: string;
 	backgroundPosition?: string;
 	// native templates are sometimes using the british spelling of background-color for some reason, removed in getStylesFromSpec above


### PR DESCRIPTION
## What does this change?
Adds the functionality to messenger to create a video inside the interscroller ad if a video source has been specified.

## Why?
This allows us to support a video interscroller. The template will also be updated to add the videoSource parameter. This is an optional parameter that we check for, and if it's been added we create a video html element inside the interscroller ad.

This has been tested on CODE, demo of the video interscroller is below (video is supposed to be cropped, it's just a cropped version of another video):

https://github.com/guardian/commercial/assets/108270776/98a6a905-8e49-47ba-8fba-716a20196332


