### PR TITLE
Use a `Map` to track adverts on the page

### DIFF
--- a/src/lib/dfp/dfp-env.ts
+++ b/src/lib/dfp/dfp-env.ts
@@ -9,7 +9,6 @@ interface DfpEnv {
 	adSlotSelector: string;
 	lazyLoadEnabled: boolean;
 	lazyLoadObserve: boolean;
-	creativeIDs: string[];
 	advertsToLoad: Advert[];
 	adverts: Map<Advert['id'], Advert>;
 	shouldLazyLoad: () => boolean;
@@ -27,9 +26,6 @@ const dfpEnv: DfpEnv = {
 
 	/* lazyLoadObserve: boolean. Use IntersectionObserver in supporting browsers */
 	lazyLoadObserve: 'IntersectionObserver' in window,
-
-	/* creativeIDs - List of loaded creative IDs */
-	creativeIDs: [],
 
 	/* advertsToLoad - Lists adverts waiting to be loaded */
 	advertsToLoad: [],

--- a/src/lib/dfp/dfp-env.ts
+++ b/src/lib/dfp/dfp-env.ts
@@ -10,9 +10,8 @@ interface DfpEnv {
 	lazyLoadEnabled: boolean;
 	lazyLoadObserve: boolean;
 	creativeIDs: string[];
-	advertIds: Record<string, number>;
 	advertsToLoad: Advert[];
-	adverts: Advert[];
+	adverts: Map<Advert['id'], Advert>;
 	shouldLazyLoad: () => boolean;
 }
 
@@ -29,17 +28,14 @@ const dfpEnv: DfpEnv = {
 	/* lazyLoadObserve: boolean. Use IntersectionObserver in supporting browsers */
 	lazyLoadObserve: 'IntersectionObserver' in window,
 
-	/* creativeIDs: array<string>. List of loaded creative IDs */
+	/* creativeIDs - List of loaded creative IDs */
 	creativeIDs: [],
 
-	/* advertIds: map<string -> int>. Keeps track of slot IDs and their position in the array of adverts */
-	advertIds: {},
-
-	/* advertsToLoad: array<Advert>. Lists adverts waiting to be loaded */
+	/* advertsToLoad - Lists adverts waiting to be loaded */
 	advertsToLoad: [],
 
-	/* adverts: array<Advert>. Keeps track of adverts and their state */
-	adverts: [],
+	/* adverts - Keeps track of adverts and their state */
+	adverts: new Map(),
 
 	/* shouldLazyLoad: () -> boolean. Determines whether ads should be lazy loaded */
 	shouldLazyLoad(): boolean {

--- a/src/lib/dfp/empty-advert.ts
+++ b/src/lib/dfp/empty-advert.ts
@@ -3,15 +3,8 @@ import type { Advert } from './Advert';
 import { dfpEnv } from './dfp-env';
 
 const removeFromDfpEnv = (advert: Advert) => {
-	const removeAdvert = (adverts: Advert[]) =>
-		adverts.filter((_) => _ !== advert);
-
-	dfpEnv.adverts = removeAdvert(dfpEnv.adverts);
-	dfpEnv.advertsToLoad = removeAdvert(dfpEnv.advertsToLoad);
-	dfpEnv.advertIds = {};
-	dfpEnv.adverts.forEach((ad, i) => {
-		dfpEnv.advertIds[ad.id] = i;
-	});
+	dfpEnv.adverts.delete(advert.id);
+	dfpEnv.advertsToLoad = dfpEnv.advertsToLoad.filter((_) => _ !== advert);
 };
 
 const removeAd = (advert: Advert) => {

--- a/src/lib/dfp/fill-dynamic-advert-slot.ts
+++ b/src/lib/dfp/fill-dynamic-advert-slot.ts
@@ -26,7 +26,7 @@ const fillDynamicAdSlot = (
 	return new Promise((resolve) => {
 		window.googletag.cmd.push(() => {
 			// Don't recreate an advert if one has already been created for this slot
-			if (adSlot.id in dfpEnv.advertIds) {
+			if (dfpEnv.adverts.has(adSlot.id)) {
 				const errorMessage = `Attempting to add slot with exisiting id ${adSlot.id}`;
 				log('commercial', errorMessage);
 				reportError(
@@ -44,7 +44,7 @@ const fillDynamicAdSlot = (
 			const advert = createAdvert(adSlot, additionalSizes, slotTargeting);
 			if (advert === null) return;
 
-			dfpEnv.advertIds[advert.id] = dfpEnv.adverts.push(advert) - 1;
+			dfpEnv.adverts.set(advert.id, advert);
 			displayAd(advert, forceDisplay);
 
 			resolve(advert);

--- a/src/lib/dfp/fill-slot-listener.ts
+++ b/src/lib/dfp/fill-slot-listener.ts
@@ -30,7 +30,7 @@ export const createSlotFillListener = () => {
 		if (isCustomEvent(event)) {
 			const { slotId } = (<ExternalSlotCustomEvent>event).detail;
 
-			if (slotId in dfpEnv.advertIds) {
+			if (dfpEnv.adverts.has(slotId)) {
 				return;
 			}
 

--- a/src/lib/dfp/fill-static-advert-slots.ts
+++ b/src/lib/dfp/fill-static-advert-slots.ts
@@ -72,7 +72,7 @@ const fillStaticAdvertSlots = async (): Promise<void> => {
 	const adverts = [
 		...document.querySelectorAll<HTMLElement>(dfpEnv.adSlotSelector),
 	]
-		.filter((adSlot) => !(adSlot.id in dfpEnv.advertIds))
+		.filter((adSlot) => !dfpEnv.adverts.has(adSlot.id))
 		// TODO: find cleaner workaround
 		// we need to not init top-above-nav on mobile view in DCR
 		// as the DOM element needs to be removed and replaced to be inline
@@ -86,11 +86,9 @@ const fillStaticAdvertSlots = async (): Promise<void> => {
 		})
 		.filter(isNonNullable);
 
-	const currentLength = dfpEnv.adverts.length;
-	dfpEnv.adverts = dfpEnv.adverts.concat(adverts);
-	adverts.forEach((advert, index) => {
-		dfpEnv.advertIds[advert.id] = currentLength + index;
-	});
+	for (const advert of adverts) {
+		dfpEnv.adverts.set(advert.id, advert);
+	}
 
 	adverts.forEach(queueAdvert);
 	if (dfpEnv.shouldLazyLoad()) {

--- a/src/lib/dfp/get-advert-by-id.ts
+++ b/src/lib/dfp/get-advert-by-id.ts
@@ -1,11 +1,7 @@
 import type { Advert } from './Advert';
 import { dfpEnv } from './dfp-env';
 
-const getAdvertById = (id: string): Advert | null => {
-	const advertIndex = dfpEnv.advertIds[id];
-	if (advertIndex !== undefined) {
-		return dfpEnv.adverts[advertIndex] ?? null;
-	}
-	return null;
-};
+const getAdvertById = (id: string): Advert | null =>
+	dfpEnv.adverts.get(id) ?? null;
+
 export { getAdvertById };

--- a/src/lib/dfp/on-slot-render.ts
+++ b/src/lib/dfp/on-slot-render.ts
@@ -2,7 +2,6 @@ import { isString } from '@guardian/libs';
 import type { AdSize } from 'core/ad-sizes';
 import { createAdSize } from 'core/ad-sizes';
 import { reportError } from 'lib/utils/report-error';
-import { dfpEnv } from './dfp-env';
 import { emptyAdvert } from './empty-advert';
 import { getAdvertById } from './get-advert-by-id';
 import { renderAdvert } from './render-advert';
@@ -61,10 +60,6 @@ export const onSlotRender = (
 		 * */
 		if (!advert.hasPrebidSize && event.size) {
 			advert.size = sizeEventToAdSize(event.size);
-		}
-
-		if (event.creativeId) {
-			dfpEnv.creativeIDs.push(String(event.creativeId));
 		}
 
 		// Associate the line item id with the advert

--- a/src/lib/dfp/prepare-googletag.spec.ts
+++ b/src/lib/dfp/prepare-googletag.spec.ts
@@ -50,8 +50,6 @@ const getAdverts = (withEmpty: boolean) => {
 	});
 };
 
-const getCreativeIDs = () => dfpEnv.creativeIDs;
-
 const getCurrentBreakpoint = getCurrentBreakpoint_ as jest.MockedFunction<
 	typeof getCurrentBreakpoint_
 >;
@@ -367,12 +365,6 @@ describe('DFP', () => {
 		window.googletag = undefined;
 	});
 
-	it('should exist', () => {
-		expect(prepareGoogletag).toBeDefined();
-		expect(getAdverts).toBeDefined();
-		expect(getCreativeIDs).toBeDefined();
-	});
-
 	it('hides all ad slots when all DFP advertising is disabled', async () => {
 		commercialFeatures.shouldLoadGoogletag = false;
 		await prepareGoogletag();
@@ -576,10 +568,6 @@ describe('DFP', () => {
 
 		listeners.slotRenderEnded?.(fakeEventOne);
 		listeners.slotRenderEnded?.(fakeEventTwo);
-		const result_4 = getCreativeIDs();
-		expect(result_4.length).toBe(2);
-		expect(result_4[0]).toEqual('1');
-		expect(result_4[1]).toEqual('2');
 	});
 
 	describe('keyword targeting', () => {

--- a/src/lib/dfp/prepare-googletag.spec.ts
+++ b/src/lib/dfp/prepare-googletag.spec.ts
@@ -8,10 +8,8 @@ import type * as AdSizesType from 'core/ad-sizes';
 import { commercialFeatures } from 'lib/commercial-features';
 import _config from 'lib/config';
 import { getCurrentBreakpoint as getCurrentBreakpoint_ } from 'lib/detect/detect-breakpoint';
-import type { Advert } from './Advert';
 import { dfpEnv } from './dfp-env';
 import { fillStaticAdvertSlots } from './fill-static-advert-slots';
-import { getAdvertById } from './get-advert-by-id';
 import { loadAdvert } from './load-advert';
 import { init as prepareGoogletag } from './prepare-googletag';
 
@@ -42,18 +40,15 @@ const config = _config as {
 	) => void;
 };
 
-const getAdverts = (withEmpty: boolean) =>
-	Object.keys(dfpEnv.advertIds).reduce(
-		(advertsById: Record<string, Advert | null>, id) => {
-			const advert = getAdvertById(id);
-			// Do not return empty slots unless explicitly requested
-			if (withEmpty || (advert && !advert.isEmpty)) {
-				advertsById[id] = advert;
-			}
-			return advertsById;
-		},
-		{},
-	);
+const getAdverts = (withEmpty: boolean) => {
+	return [...dfpEnv.adverts.values()].map((advert) => {
+		// Do not return empty slots unless explicitly requested
+		if (withEmpty || !advert.isEmpty) {
+			return advert;
+		}
+		return null;
+	});
+};
 
 const getCreativeIDs = () => dfpEnv.creativeIDs;
 
@@ -182,8 +177,7 @@ const makeFakeEvent = (
 });
 
 const reset = () => {
-	dfpEnv.advertIds = {};
-	dfpEnv.adverts = [];
+	dfpEnv.adverts = new Map();
 	dfpEnv.advertsToLoad = [];
 	window.guardian.config.switches = {
 		prebidHeaderBidding: false,

--- a/src/lib/header-bidding/prebid/bid-config.ts
+++ b/src/lib/header-bidding/prebid/bid-config.ts
@@ -268,7 +268,7 @@ const ozoneClientSideBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
 		_slotId: string,
 		sizes: HeaderBiddingSize[],
 	): PrebidOzoneParams => {
-		const advert = dfpEnv.adverts.find((ad) => ad.id === _slotId);
+		const advert = dfpEnv.adverts.get(_slotId);
 		const testgroup = advert?.testgroup
 			? { testgroup: advert.testgroup }
 			: {};

--- a/src/lib/messenger/disable-refresh.ts
+++ b/src/lib/messenger/disable-refresh.ts
@@ -27,7 +27,7 @@ self.addEventListener('message', function onMessage(evt) {
 */
 
 const findAdvert = (adSlot: HTMLElement) => {
-	for (const [, advert] of dfpEnv.adverts) {
+	for (const advert of dfpEnv.adverts.values()) {
 		if (advert.node.isSameNode(adSlot)) {
 			return advert;
 		}

--- a/src/lib/messenger/disable-refresh.ts
+++ b/src/lib/messenger/disable-refresh.ts
@@ -26,8 +26,14 @@ self.addEventListener('message', function onMessage(evt) {
 </script>
 */
 
-const findAdvert = (adSlot: HTMLElement) =>
-	dfpEnv.adverts.find((advert) => advert.node.isSameNode(adSlot));
+const findAdvert = (adSlot: HTMLElement) => {
+	for (const [, advert] of dfpEnv.adverts) {
+		if (advert.node.isSameNode(adSlot)) {
+			return advert;
+		}
+	}
+	return undefined;
+};
 
 const init = (register: RegisterListener): void => {
 	register('disable-refresh', (specs, ret, iframe) => {

--- a/src/lib/messenger/disable-refresh.ts
+++ b/src/lib/messenger/disable-refresh.ts
@@ -26,22 +26,13 @@ self.addEventListener('message', function onMessage(evt) {
 </script>
 */
 
-const findAdvert = (adSlot: HTMLElement) => {
-	for (const advert of dfpEnv.adverts.values()) {
-		if (advert.node.isSameNode(adSlot)) {
-			return advert;
-		}
-	}
-	return undefined;
-};
-
 const init = (register: RegisterListener): void => {
 	register('disable-refresh', (specs, ret, iframe) => {
 		if (iframe) {
 			const adSlot = iframe.closest('.js-ad-slot');
 
 			if (adSlot instanceof HTMLElement) {
-				const advert = findAdvert(adSlot);
+				const advert = dfpEnv.adverts.get(adSlot.id);
 				if (advert) {
 					advert.shouldRefresh = false;
 				}


### PR DESCRIPTION
## What does this change?

- Remove the `advertIds` property from `dfpEnv` and instead store adverts as a `Map` from their string ids to the adverts themselves. This allows us to store the same information in a single structure, with clearer semantics around getting/setting elements.

- Remove the unused `creativeIds` property. It appears this array is only ever pushed to, and the values never retrieved from it.

## Why?

Should be clearer when managing which adverts are being tracked in the `dfpEnv`.


In the browser console, for `window.guardian.commercial.dfpEnv.adverts`:

<img width="369" alt="Screenshot 2023-10-25 at 12 17 24" src="https://github.com/guardian/commercial/assets/8000415/ed81de70-bf52-48ec-94e2-3de0d5395352">

