### PR TITLE
Catch errors from Okta

### DIFF
--- a/.changeset/giant-ducks-exist.md
+++ b/.changeset/giant-ducks-exist.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Catch Okta errors

--- a/src/lib/identity/api.ts
+++ b/src/lib/identity/api.ts
@@ -118,15 +118,20 @@ const isUserLoggedIn = (): boolean => getUserFromCookie() !== null;
 
 const getAuthStatus = async (): Promise<AuthStatus> => {
 	if (useOkta) {
-		const { isSignedInWithOktaAuthState } = await import('./okta');
-		const authState = await isSignedInWithOktaAuthState();
-		if (authState.isAuthenticated) {
-			return {
-				kind: 'SignedInWithOkta',
-				accessToken: authState.accessToken,
-				idToken: authState.idToken,
-			};
+		try {
+			const { isSignedInWithOktaAuthState } = await import('./okta');
+			const authState = await isSignedInWithOktaAuthState();
+			if (authState.isAuthenticated) {
+				return {
+					kind: 'SignedInWithOkta',
+					accessToken: authState.accessToken,
+					idToken: authState.idToken,
+				};
+			}
+		} catch (e) {
+			console.error(e);
 		}
+
 		return {
 			kind: 'SignedOutWithOkta',
 		};

--- a/src/lib/identity/okta.ts
+++ b/src/lib/identity/okta.ts
@@ -5,7 +5,7 @@ import type {
 import { getIdentityAuth } from '@guardian/identity-auth-frontend';
 import type { CustomIdTokenClaims } from '../../types/global';
 
-export async function isSignedInWithOktaAuthState(): Promise<
+export function isSignedInWithOktaAuthState(): Promise<
 	IdentityAuthState<AccessTokenClaims, CustomIdTokenClaims>
 > {
 	return getIdentityAuth().isSignedInWithAuthState();


### PR DESCRIPTION
I think uncaught exceptions from the Identity Auth library might be contributing to the spike in dropped errors in Sentry.

In DCR, we catch errors and print them to console. I think it is sensible to do the same here.

https://github.com/guardian/dotcom-rendering/blob/7fe3c9adf5cddc28830d433421a69085a2415fb2/dotcom-rendering/src/lib/useAuthStatus.ts#L88-L102

Part of https://github.com/guardian/dotcom-rendering/issues/8820

See [this chat thread](https://chat.google.com/room/AAAAG9rU0m0/jgCCywOVkm8) for more info.