### PR TITLE
Updated @guardian/consent-management-platform to 13.7.0

### DIFF
--- a/.changeset/three-dolls-accept.md
+++ b/.changeset/three-dolls-accept.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Bumped version of consent-management-platform to 13.7.0

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"@cypress/webpack-preprocessor": "^5.17.1",
 		"@guardian/ab-core": "5.0.0",
 		"@guardian/browserslist-config": "^5.1.0",
-		"@guardian/consent-management-platform": "13.6.1",
+		"@guardian/consent-management-platform": "^13.7.0",
 		"@guardian/core-web-vitals": "5.1.0",
 		"@guardian/eslint-config-typescript": "^6.0.0",
 		"@guardian/identity-auth": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1656,10 +1656,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-5.1.0.tgz#61cd822388dc196cea1b39c693366ed550edcd10"
   integrity sha512-QsyaZ7OZ6jBl8lByiLWtnobcS0IvIPVzDeGz9XY+CvPy5v5Kb0RJo+fFLEZbCqRLrfK+5f2sjrwPqrwtJBe2Sw==
 
-"@guardian/consent-management-platform@13.6.1":
-  version "13.6.1"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.6.1.tgz#528ed9193b1bd96e9f84964a5a1a080de43e29c1"
-  integrity sha512-5KQ4dZrqIBKuJCSJ/TTWXZ4F0WXY9ecpMnfOfvNIU9tXF1LAeT+LNv7hfV8eC5qMJskj2yvZZUi7hlwWD+Nq/A==
+"@guardian/consent-management-platform@^13.7.0":
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.7.0.tgz#c5f6511b822a3f16c3a78337653204f072396416"
+  integrity sha512-GQPhLOch8FIKko9muw8Fsm28+f+KubLGNbNfUxX4slg9+0jM4J57Kajr75RTqdtzWmKkp0cdYI9QDIVsbhgcuQ==
 
 "@guardian/core-web-vitals@5.1.0":
   version "5.1.0"


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?
Updating the version of @guardian/consent-management-platform to the latest version.
## Why?
