### PR TITLE
bump ophan-tracker-js

### DIFF
--- a/.changeset/spicy-dogs-cry.md
+++ b/.changeset/spicy-dogs-cry.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+bump ophan-tracker-js

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
 		"@octokit/core": "^4.0.5",
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",
-		"ophan-tracker-js": "^1.4.0",
+		"ophan-tracker-js": "^2.0.1",
 		"prebid.js": "guardian/prebid.js#356f371",
 		"process": "^0.11.10",
 		"raven-js": "^3.27.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7195,10 +7195,10 @@ opener@^1.5.2:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
-ophan-tracker-js@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.4.0.tgz#6c0e8f56157f2bd1473beaa6b79b54b99f5a7b1d"
-  integrity sha512-X5JoLOYxvfvNRI0Vo8xBT0UgJdiU9snPYOGgQUTk5ZnPYgX3xGW/yt7xdePeg9yM0eCuP5SeYQTLfF4bp0GFuw==
+ophan-tracker-js@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-2.0.1.tgz#568c9a8c127f511d4dc19e9d3421cc88e04ea910"
+  integrity sha512-HXH0rjZlLeV9ri4V9Q0t0AaD5Q3ue4o+YMCuBsov6cWLPWcWBiARHtSRlpY6fJD+/iUIEiSPsrlfPIJUz7inYA==
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -7468,13 +7468,6 @@ playwright-core@1.37.1:
   version "1.37.1"
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.37.1.tgz#cb517d52e2e8cb4fa71957639f1cd105d1683126"
   integrity sha512-17EuQxlSIYCmEMwzMqusJ2ztDgJePjrbttaefgdsiqeLWidjYz9BxXaTaZWxH1J95SHGk6tjE+dwgWILJoUZfA==
-
-playwright@^1.37.1:
-  version "1.37.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.37.1.tgz#6e488d82d7d98b9127c5db9c701f9c956ab47e76"
-  integrity sha512-bgUXRrQKhT48zHdxDYQTpf//0xDfDd5hLeEhjuSw8rXEGoT9YeElpfvs/izonTNY21IQZ7d3s22jLxYaAnubbQ==
-  dependencies:
-    playwright-core "1.37.1"
 
 prebid.js@guardian/prebid.js#356f371:
   version "7.54.5"


### PR DESCRIPTION
## What does this change?

- bumps ophan-tracker-js to 2.0.1
- Playwright is removed from yarn.lock (this is fine, playwright-core is what we need)

