### PR TITLE
Add testgroup to Ozone targeting

### DIFF
--- a/.changeset/fresh-buttons-brush.md
+++ b/.changeset/fresh-buttons-brush.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Adds testgroup key to ozone targeting object

--- a/src/lib/build-page-targeting.ts
+++ b/src/lib/build-page-targeting.ts
@@ -5,7 +5,7 @@ import type { PageTargeting } from 'core/targeting/build-page-targeting';
 import { buildPageTargeting } from 'core/targeting/build-page-targeting';
 import { getSynchronousParticipations } from 'lib/experiments/ab';
 import { commercialFeatures } from './commercial-features';
-import { removeFalseyValues } from './header-bidding/utils';
+import { removeFalsyValues } from './header-bidding/utils';
 
 const formatAppNexusTargeting = (obj: Record<string, string | string[]>) => {
 	const asKeyValues = Object.entries(obj).map((entry) => {
@@ -21,7 +21,7 @@ const formatAppNexusTargeting = (obj: Record<string, string | string[]>) => {
 
 const buildAppNexusTargetingObject = once(
 	(pageTargeting: PageTargeting): Record<string, string | string[]> =>
-		removeFalseyValues({
+		removeFalsyValues({
 			sens: pageTargeting.sens,
 			pt1: pageTargeting.url,
 			pt2: pageTargeting.edition,

--- a/src/lib/header-bidding/prebid/bid-config.ts
+++ b/src/lib/header-bidding/prebid/bid-config.ts
@@ -273,7 +273,11 @@ const ozoneClientSideBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
 		customData: [
 			{
 				settings: {},
-				targeting: buildAppNexusTargetingObject(pageTargeting),
+				targeting: {
+					// Assigns a random integer between 0 and 99
+					testgroup: String(Math.floor(100 * Math.random())),
+					...buildAppNexusTargetingObject(pageTargeting),
+				},
 			},
 		],
 		ozoneData: {}, // TODO: confirm if we need to send any

--- a/src/lib/header-bidding/utils.spec.ts
+++ b/src/lib/header-bidding/utils.spec.ts
@@ -11,7 +11,7 @@ import { getCountryCode as getCountryCode_ } from 'lib/utils/geolocation';
 import {
 	getBreakpointKey,
 	getLargestSize,
-	removeFalseyValues,
+	removeFalsyValues,
 	shouldIncludeAdYouLike,
 	shouldIncludeAppNexus,
 	shouldIncludeImproveDigital,
@@ -313,8 +313,8 @@ describe('Utils', () => {
 		expect(shouldIncludeAdYouLike([createAdSize(728, 90)])).toBe(false);
 	});
 
-	test('removeFalseyValues correctly remove non-truthy values', () => {
-		const result = removeFalseyValues({
+	test('removeFalsyValues correctly remove non-truthy values', () => {
+		const result = removeFalsyValues({
 			testString: 'non empty string',
 			testEmptyString: '',
 			testNull: null,
@@ -329,8 +329,8 @@ describe('Utils', () => {
 		});
 	});
 
-	test('removeFalseyValues correctly keeps arrays of strings', () => {
-		const result = removeFalseyValues({
+	test('removeFalsyValues correctly keeps arrays of strings', () => {
+		const result = removeFalsyValues({
 			testString: 'non empty string',
 			testArraysWithEmptyStrings: ['a', '', 'b', '', 'c'],
 			testEmptyArray: [],

--- a/src/lib/header-bidding/utils.ts
+++ b/src/lib/header-bidding/utils.ts
@@ -47,7 +47,7 @@ const contains = (
  * @param o object with falsey values
  * @returns {Record<string, string | string[]>} object with only non-empty strings, or arrays of non-empty strings.
  */
-export const removeFalseyValues = <O extends Record<string, unknown>>(
+export const removeFalsyValues = <O extends Record<string, unknown>>(
 	o: O,
 ): Record<string, string | string[]> =>
 	Object.entries(o).reduce<Record<string, string | string[]>>(

--- a/src/lib/header-bidding/utils.ts
+++ b/src/lib/header-bidding/utils.ts
@@ -43,8 +43,8 @@ const contains = (
 ): boolean => Boolean(sizes.find((s) => s[0] === size[0] && s[1] === size[1]));
 
 /**
- * Cleans an object for targetting. Removes empty strings and other falsey values.
- * @param o object with falsey values
+ * Cleans an object for targetting. Removes empty strings and other falsy values.
+ * @param o object with falsy values
  * @returns {Record<string, string | string[]>} object with only non-empty strings, or arrays of non-empty strings.
  */
 export const removeFalsyValues = <O extends Record<string, unknown>>(


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

- Adds a testgroup parameter to Ozone targeting which is a random integer between 0 and 99.
- Renames Falsey to the more usual Falsy: https://developer.mozilla.org/en-US/docs/Glossary/Falsy

## Why?

- Requested by Ozone so they can AB test.

## Screenshots

<img width="597" alt="Screenshot 2023-10-06 at 11 01 02" src="https://github.com/guardian/commercial/assets/9574885/7c5ae987-25d2-4fcc-a279-0c25378e0388">
