### PR TITLE
Fix liveblog Playwright tests

### DIFF
--- a/playwright/tests/parallel-3/liveblog-ad-limit.spec.ts
+++ b/playwright/tests/parallel-3/liveblog-ad-limit.spec.ts
@@ -14,9 +14,6 @@ const desktopBreakpoint = breakpoints.filter(
 
 const maxAdSlots = 8;
 
-const countInlineSlots = (page: Page) =>
-	page.locator('#liveblog-body .ad-slot--liveblog-inline').count();
-
 const addAndAwaitNewBlocks = async (page: Page, blockContent: string) => {
 	// scroll to the top so we get a toast to click on
 	await page.evaluate(() => window.scrollTo(0, 0));
@@ -45,6 +42,9 @@ const addAndAwaitNewBlocks = async (page: Page, blockContent: string) => {
 	const newBlock = page.getByText(blockContent).first();
 	await expect(newBlock).toBeVisible();
 };
+
+const countInlineSlots = (page: Page) =>
+	page.locator('#liveblog-body .ad-slot--liveblog-inline').count();
 
 test.describe.serial('Ad slot limits', () => {
 	pages.forEach(({ path, expectedMinInlineSlotsOnDesktop }) => {

--- a/playwright/tests/parallel-3/liveblog-ad-limit.spec.ts
+++ b/playwright/tests/parallel-3/liveblog-ad-limit.spec.ts
@@ -23,14 +23,14 @@ const addAndAwaitNewBlocks = async (page: Page, blockContent: string) => {
 		window.mockLiveUpdate({
 			numNewBlocks: 7,
 			html: `
-			<p style="height:1000px;" class="pending block">${blockContent}</p>
-			<p style="height:1000px;" class="pending block">New block</p>
-			<p style="height:1000px;" class="pending block">New block</p>
-			<p style="height:1000px;" class="pending block">New block</p>
-			<p style="height:1000px;" class="pending block">New block</p>
-			<p style="height:1000px;" class="pending block">New block</p>
-			<p style="height:1000px;" class="pending block">New block</p>
-		`,
+				<p style="height:1000px;" class="pending block">${blockContent}</p>
+				<p style="height:1000px;" class="pending block">New block</p>
+				<p style="height:1000px;" class="pending block">New block</p>
+				<p style="height:1000px;" class="pending block">New block</p>
+				<p style="height:1000px;" class="pending block">New block</p>
+				<p style="height:1000px;" class="pending block">New block</p>
+				<p style="height:1000px;" class="pending block">New block</p>
+			`,
 			mostRecentBlockId: 'abc',
 		});
 	}, blockContent);

--- a/playwright/tests/parallel-3/liveblog-ad-limit.spec.ts
+++ b/playwright/tests/parallel-3/liveblog-ad-limit.spec.ts
@@ -18,20 +18,19 @@ const addAndAwaitNewBlocks = async (page: Page, blockContent: string) => {
 	// scroll to the top so we get a toast to click on
 	await page.evaluate(() => window.scrollTo(0, 0));
 	await page.evaluate((blockContent) => {
-		const htmlBlocks = `
-			<p style="height:1000px;" class="pending block">${blockContent}</p>
-			<p style="height:1000px;" class="pending block">${blockContent}</p>
-			<p style="height:1000px;" class="pending block">${blockContent}</p>
-			<p style="height:1000px;" class="pending block">${blockContent}</p>
-			<p style="height:1000px;" class="pending block">${blockContent}</p>
-			<p style="height:1000px;" class="pending block">${blockContent}</p>
-			<p style="height:1000px;" class="pending block">${blockContent}</p>
-		`;
 		// @ts-expect-error -- browser land
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-call -- browser land
 		window.mockLiveUpdate({
 			numNewBlocks: 7,
-			html: htmlBlocks,
+			html: `
+			<p style="height:1000px;" class="pending block">${blockContent}</p>
+			<p style="height:1000px;" class="pending block">New block</p>
+			<p style="height:1000px;" class="pending block">New block</p>
+			<p style="height:1000px;" class="pending block">New block</p>
+			<p style="height:1000px;" class="pending block">New block</p>
+			<p style="height:1000px;" class="pending block">New block</p>
+			<p style="height:1000px;" class="pending block">New block</p>
+		`,
 			mostRecentBlockId: 'abc',
 		});
 	}, blockContent);

--- a/playwright/tests/parallel-3/liveblog-ad-limit.spec.ts
+++ b/playwright/tests/parallel-3/liveblog-ad-limit.spec.ts
@@ -12,46 +12,46 @@ const desktopBreakpoint = breakpoints.filter(
 	({ breakpoint }) => breakpoint === 'desktop',
 )[0] as unknown as BreakpointSizes;
 
-/**
- * TODO e2e flakey test
- * - sometimes window.mockLiveUpdate is not available because the article does not switch to 'live'
- * - sometimes the maxAdSlots is 7 and not 8
- */
-
 const maxAdSlots = 8;
-
-const addNewBlocks = async (page: Page) => {
-	// scroll to the top so we get a toast to click on
-	await page.evaluate(() => window.scrollTo(0, 0));
-	await page.evaluate(() => {
-		// @ts-expect-error -- browser land
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-call -- browser land
-		window.mockLiveUpdate({
-			numNewBlocks: 7,
-			html: `
-					<p style="height:1000px;" class="pending block">New block</p>
-					<p style="height:1000px;" class="pending block">New block</p>
-					<p style="height:1000px;" class="pending block">New block</p>
-					<p style="height:1000px;" class="pending block">New block</p>
-					<p style="height:1000px;" class="pending block">New block</p>
-					<p style="height:1000px;" class="pending block">New block</p>
-					<p style="height:1000px;" class="pending block">New block</p>
-				`,
-			mostRecentBlockId: 'abc',
-		});
-	});
-	// click on the toast to insert and scroll to the new blocks
-	await page.getByRole('button', { name: '7 new updates' }).click();
-};
 
 const countInlineSlots = (page: Page) =>
 	page.locator('#liveblog-body .ad-slot--liveblog-inline').count();
 
-test.describe('Ad slot limits', () => {
+const addAndAwaitNewBlocks = async (page: Page, blockContent: string) => {
+	// scroll to the top so we get a toast to click on
+	await page.evaluate(() => window.scrollTo(0, 0));
+	await page.evaluate((blockContent) => {
+		const htmlBlocks = `
+			<p style="height:1000px;" class="pending block">${blockContent}</p>
+			<p style="height:1000px;" class="pending block">${blockContent}</p>
+			<p style="height:1000px;" class="pending block">${blockContent}</p>
+			<p style="height:1000px;" class="pending block">${blockContent}</p>
+			<p style="height:1000px;" class="pending block">${blockContent}</p>
+			<p style="height:1000px;" class="pending block">${blockContent}</p>
+			<p style="height:1000px;" class="pending block">${blockContent}</p>
+		`;
+		// @ts-expect-error -- browser land
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call -- browser land
+		window.mockLiveUpdate({
+			numNewBlocks: 7,
+			html: htmlBlocks,
+			mostRecentBlockId: 'abc',
+		});
+	}, blockContent);
+	// click on the toast to insert and scroll to the new blocks
+	await page.getByRole('button', { name: '7 new updates' }).click();
+
+	// Here, we force the test to wait until the blocks are visible on the page before counting the ad slots
+	const newBlock = page.getByText(blockContent).first();
+	await expect(newBlock).toBeVisible();
+};
+
+test.describe.serial('Ad slot limits', () => {
 	pages.forEach(({ path, expectedMinInlineSlotsOnDesktop }) => {
-		test.skip(`doesn't insert more than ${maxAdSlots} ads on desktop`, async ({
-			page,
-		}) => {
+		let page: Page;
+		test.beforeAll(async ({ browser }) => {
+			const context = await browser.newContext();
+			page = await context.newPage();
 			await page.setViewportSize({
 				width: desktopBreakpoint.width,
 				height: desktopBreakpoint.height,
@@ -59,23 +59,43 @@ test.describe('Ad slot limits', () => {
 
 			await loadPage(page, path);
 			await cmpAcceptAll(page);
+		});
 
-			const initialSlotCount = await countInlineSlots(page);
+		test.afterAll(({ browser }) => {
+			browser.close;
+		});
+
+		test('Initial slot count and first insertion', async () => {
+			const initialSlotCount: number = await countInlineSlots(page);
+			console.log(`initial slot count is ${initialSlotCount}`);
 			expect(initialSlotCount).toEqual(expectedMinInlineSlotsOnDesktop);
 
-			// extra ad slots added after blocks inserted
-			await addNewBlocks(page);
+			await addAndAwaitNewBlocks(page, 'First batch of inserted blocks');
+
 			const afterFirstInsertSlotCount = await countInlineSlots(page);
+			console.log(
+				`slot count after first insertion is ${afterFirstInsertSlotCount}`,
+			);
 			expect(afterFirstInsertSlotCount).toBeGreaterThan(initialSlotCount);
+		});
 
-			// no extra ad slots added after blocks inserted
-			await addNewBlocks(page);
+		test('Count slots after second insertion', async () => {
+			await addAndAwaitNewBlocks(page, 'Second batch of inserted blocks');
+
 			const afterSecondInsertSlotCount = await countInlineSlots(page);
+			console.log(
+				`slot count after second insertion is ${afterSecondInsertSlotCount}`,
+			);
 			expect(afterSecondInsertSlotCount).toEqual(maxAdSlots);
+		});
 
-			// no extra ad slots added after blocks inserted
-			await addNewBlocks(page);
+		test('Count slots after third insertion', async () => {
+			await addAndAwaitNewBlocks(page, 'Third batch of inserted blocks');
+
 			const afterThirdInsertSlotCount = await countInlineSlots(page);
+			console.log(
+				`slot count after third insertion is ${afterThirdInsertSlotCount}`,
+			);
 			expect(afterThirdInsertSlotCount).toEqual(maxAdSlots);
 		});
 	});

--- a/playwright/tests/parallel-3/liveblog-ad-limit.spec.ts
+++ b/playwright/tests/parallel-3/liveblog-ad-limit.spec.ts
@@ -6,6 +6,11 @@ import { blogs } from '../../fixtures/pages';
 import { cmpAcceptAll } from '../../lib/cmp';
 import { loadPage } from '../../lib/load-page';
 
+/**
+ * TODO serial e2e tests
+ * - It would be good to see if these tests could be run in parallel in the future
+ */
+
 const pages = blogs.filter(({ name }) => name === 'ad-limit');
 
 const desktopBreakpoint = breakpoints.filter(

--- a/playwright/tests/parallel-3/liveblog-live-update.spec.ts
+++ b/playwright/tests/parallel-3/liveblog-live-update.spec.ts
@@ -87,6 +87,5 @@ test.describe('Liveblog live updates', () => {
 				expect(endSlotCount).toBeGreaterThan(startSlotCount);
 			});
 		});
-		//});
 	});
 });

--- a/playwright/tests/parallel-3/liveblog-live-update.spec.ts
+++ b/playwright/tests/parallel-3/liveblog-live-update.spec.ts
@@ -4,12 +4,6 @@ import { blogs } from '../../fixtures/pages';
 import { cmpAcceptAll } from '../../lib/cmp';
 import { loadPage } from '../../lib/load-page';
 
-/**
- * TODO e2e flakey test
- * - sometimes window.mockLiveUpdate is not available because the article does not switch to 'live'
- * - sometimes no extra ads are inserted when new blocks are inserted. Is this a bug in the code?
- */
-
 const pages = blogs.filter(({ name }) => name === 'live-update');
 
 test.describe.serial('Liveblog live updates', () => {

--- a/playwright/tests/parallel-3/liveblog-live-update.spec.ts
+++ b/playwright/tests/parallel-3/liveblog-live-update.spec.ts
@@ -4,6 +4,11 @@ import { blogs } from '../../fixtures/pages';
 import { cmpAcceptAll } from '../../lib/cmp';
 import { loadPage } from '../../lib/load-page';
 
+/**
+ * TODO serial e2e tests
+ * - It would be good to see if these tests could be run in parallel in the future
+ */
+
 const pages = blogs.filter(({ name }) => name === 'live-update');
 
 test.describe.serial('Liveblog live updates', () => {

--- a/playwright/tests/parallel-3/liveblog-live-update.spec.ts
+++ b/playwright/tests/parallel-3/liveblog-live-update.spec.ts
@@ -12,8 +12,7 @@ import { loadPage } from '../../lib/load-page';
 
 const pages = blogs.filter(({ name }) => name === 'live-update');
 
-test.describe.configure({ mode: 'serial' });
-test.describe('Liveblog live updates', () => {
+test.describe.serial('Liveblog live updates', () => {
 	pages.forEach(({ path }) => {
 		breakpoints.forEach(({ breakpoint, width, height }) => {
 			test(`Test ads are inserted when liveblogs update, breakpoint: ${breakpoint}`, async ({

--- a/playwright/tests/parallel-3/liveblog-live-update.spec.ts
+++ b/playwright/tests/parallel-3/liveblog-live-update.spec.ts
@@ -12,10 +12,11 @@ import { loadPage } from '../../lib/load-page';
 
 const pages = blogs.filter(({ name }) => name === 'live-update');
 
+test.describe.configure({ mode: 'serial' });
 test.describe('Liveblog live updates', () => {
 	pages.forEach(({ path }) => {
 		breakpoints.forEach(({ breakpoint, width, height }) => {
-			test.skip(`Test ads are inserted when liveblogs update, breakpoint: ${breakpoint}`, async ({
+			test(`Test ads are inserted when liveblogs update, breakpoint: ${breakpoint}`, async ({
 				page,
 			}) => {
 				await page.setViewportSize({
@@ -81,8 +82,11 @@ test.describe('Liveblog live updates', () => {
 					.locator('#liveblog-body .ad-slot--liveblog-inline')
 					.count();
 
+				console.log(`end slot count is ${endSlotCount}`);
+
 				expect(endSlotCount).toBeGreaterThan(startSlotCount);
 			});
 		});
+		//});
 	});
 });


### PR DESCRIPTION
## What does this change?

- Makes the liveblog-live-update tests run in order instead of concurrently, as this resolves the flakiness
- Adds an extra console log line to the liveblog-live-update test for easier local testing and debugging
- Forces the code to wait until newly inserted blocks are visible before counting them in the liveblog-ad-limit test
- Separates out the liveblog-ad-limit tests into individual tests on a shared web page context, so that we're only testing one thing at a time instead of having three test conditions in one test

## Why?
These changes improve the flakiness in the liveblog-live-update and liveblog-ad-limit tests.

## How reliable are the tests now?

I ran these tests a large number of times locally to get these percentage pass rates, to give us a rough idea of how flaky the tests are:

Liveblog-live-update test: 98% pass rate
Liveblog-ad-limit test: 84% pass rate

So these tests aren't perfect, but they are definitely much more reliable than they were before.