### PR TITLE
Make eager prebid a zero percent test

### DIFF
--- a/.changeset/lazy-sheep-laugh.md
+++ b/.changeset/lazy-sheep-laugh.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Set eager prebid test to 0%

--- a/src/lib/experiments/tests/eager-prebid.ts
+++ b/src/lib/experiments/tests/eager-prebid.ts
@@ -6,7 +6,7 @@ export const eagerPrebid: ABTest = {
 	author: '@commercial-dev',
 	start: '2023-09-26',
 	expiry: '2023-10-31',
-	audience: 1 / 100,
+	audience: 0 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: 'All pageviews',
 	successMeasure:


### PR DESCRIPTION
## What does this change?
Sets the eager prebid test to 0%

## Why?
Depending on the outcome of the test, we may want to test again with different numbers or keep the logic in the code, so it makes sense to preserve it behind a 0% test instead of deleting it while we wait for the test results.