### PR TITLE
Support defining fixtures locally in E2E tests

### DIFF
--- a/playwright/fixtures/pages/articles.ts
+++ b/playwright/fixtures/pages/articles.ts
@@ -5,40 +5,40 @@ const stage = getStage();
 
 const articles: GuPage[] = [
 	{
-		path: getTestUrl(
+		path: getTestUrl({
 			stage,
-			'/politics/2022/feb/10/keir-starmer-says-stop-the-war-coalition-gives-help-to-authoritarians-like-putin',
-		),
+			path: '/politics/2022/feb/10/keir-starmer-says-stop-the-war-coalition-gives-help-to-authoritarians-like-putin',
+		}),
 	},
 	{
-		path: getTestUrl(
+		path: getTestUrl({
 			stage,
-			'/sport/2022/feb/10/team-gb-winter-olympic-struggles-go-on-with-problems-for-skeleton-crew',
-		),
+			path: '/sport/2022/feb/10/team-gb-winter-olympic-struggles-go-on-with-problems-for-skeleton-crew',
+		}),
 	},
 	{
-		path: getTestUrl(
+		path: getTestUrl({
 			stage,
-			'/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife',
-		),
+			path: '/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife',
+		}),
 		name: 'inlineSlots',
 		expectedMinInlineSlotsOnDesktop: 11,
 		expectedMinInlineSlotsOnMobile: 16,
 	},
 	{
-		path: getTestUrl(
+		path: getTestUrl({
 			stage,
-			'/society/2020/aug/13/disabled-wont-receive-critical-care-covid-terrifying',
-		),
+			path: '/society/2020/aug/13/disabled-wont-receive-critical-care-covid-terrifying',
+		}),
 		name: 'sensitive-content',
 	},
 	{
-		path: getTestUrl(
+		path: getTestUrl({
 			stage,
-			'/politics/2022/feb/10/keir-starmer-says-stop-the-war-coalition-gives-help-to-authoritarians-like-putin',
-			'article',
-			'comdev',
-		),
+			path: '/politics/2022/feb/10/keir-starmer-says-stop-the-war-coalition-gives-help-to-authoritarians-like-putin',
+			type: 'article',
+			adtest: 'comdev',
+		}),
 	},
 ];
 

--- a/playwright/fixtures/pages/blogs.ts
+++ b/playwright/fixtures/pages/blogs.ts
@@ -5,28 +5,28 @@ const stage = getStage();
 
 const blogs: GuPage[] = [
 	{
-		path: getTestUrl(
+		path: getTestUrl({
 			stage,
-			'/politics/live/2022/jan/31/uk-politics-live-omicron-nhs-workers-coronavirus-vaccines-no-10-sue-gray-report',
-			'liveblog',
-		),
+			path: '/politics/live/2022/jan/31/uk-politics-live-omicron-nhs-workers-coronavirus-vaccines-no-10-sue-gray-report',
+			type: 'liveblog',
+		}),
 		name: 'live-update',
 	},
 	{
-		path: getTestUrl(
+		path: getTestUrl({
 			stage,
-			'/football/live/2023/aug/08/carabao-cup-first-round-wrexham-v-wigan-gillingham-v-southampton-live',
-			'liveblog',
-		),
+			path: '/football/live/2023/aug/08/carabao-cup-first-round-wrexham-v-wigan-gillingham-v-southampton-live',
+			type: 'liveblog',
+		}),
 		name: 'ad-limit',
 		expectedMinInlineSlotsOnDesktop: 5,
 	},
 	{
-		path: getTestUrl(
+		path: getTestUrl({
 			stage,
-			'/business/live/2023/aug/07/halifax-house-prices-gradual-drop-annual-fall-in-july-interest-rates-mortgages-business-live',
-			'liveblog',
-		),
+			path: '/business/live/2023/aug/07/halifax-house-prices-gradual-drop-annual-fall-in-july-interest-rates-mortgages-business-live',
+			type: 'liveblog',
+		}),
 		expectedMinInlineSlotsOnDesktop: 4,
 		expectedMinInlineSlotsOnMobile: 5,
 	},

--- a/playwright/fixtures/pages/fronts.ts
+++ b/playwright/fixtures/pages/fronts.ts
@@ -9,21 +9,41 @@ const stage = getStage();
 
 const fronts: Front[] = [
 	{
-		path: getTestUrl(stage, '/uk', 'front', 'puppies-pageskin'),
+		path: getTestUrl({
+			stage,
+			path: '/uk',
+			type: 'front',
+			adtest: 'puppies-pageskin',
+		}),
 		section: 'uk',
 	},
 	{
-		path: getTestUrl(stage, '/commentisfree', 'front', 'puppies-pageskin'),
+		path: getTestUrl({
+			stage,
+			path: '/commentisfree',
+			type: 'front',
+			adtest: 'puppies-pageskin',
+		}),
 		section: 'commentisfree',
 	},
 	{
-		path: getTestUrl(stage, '/sport', 'front', 'puppies-pageskin'),
+		path: getTestUrl({
+			stage,
+			path: '/sport',
+			type: 'front',
+			adtest: 'puppies-pageskin',
+		}),
 		section: 'sport',
 	},
 ];
 
 const frontWithPageSkin: Front = {
-	path: getTestUrl(stage, '/uk', 'front', 'puppies-pageskin'),
+	path: getTestUrl({
+		stage,
+		path: '/uk',
+		type: 'front',
+		adtest: 'puppies-pageskin',
+	}),
 	section: 'uk',
 };
 

--- a/playwright/lib/util.ts
+++ b/playwright/lib/util.ts
@@ -63,13 +63,19 @@ const getPath = (
  * @fixtureId string
  * @returns {string} The full URL
  */
-const getTestUrl = (
-	stage: Stage,
-	path: string,
-	type: 'article' | 'liveblog' | 'front' = 'article',
+const getTestUrl = ({
+	stage,
+	path,
+	type = 'article',
 	adtest = 'fixed-puppies-ci',
-	fixtureId?: string,
-) => {
+	fixtureId,
+}: {
+	stage: Stage;
+	path: string;
+	type?: 'article' | 'liveblog' | 'front';
+	adtest?: string;
+	fixtureId?: string;
+}) => {
 	const url = new URL(getPath(stage, type, path, fixtureId), getHost(stage));
 
 	if (type === 'liveblog') {

--- a/playwright/lib/util.ts
+++ b/playwright/lib/util.ts
@@ -29,12 +29,6 @@ const getHost = (stage?: Stage | undefined) => {
 
 /**
  * Generate the path for the request to DCR
- *
- * @param {'dev' | 'code' | 'prod'}  stage
- * @param type
- * @param path
- * @param fixtureId
- * @returns
  */
 const getPath = (
 	stage: Stage,

--- a/playwright/lib/util.ts
+++ b/playwright/lib/util.ts
@@ -40,13 +40,19 @@ const getPath = (
 	stage: Stage,
 	type: 'article' | 'liveblog' | 'front' = 'article',
 	path: string,
-	fixtureId?: string,
+	fixtureId: string | undefined,
+	fixture: Record<string, unknown> | undefined,
 ) => {
 	if (stage === 'dev') {
 		const dcrContentType =
 			type === 'liveblog' || type === 'article' ? 'Article' : 'Front';
 		if (fixtureId) {
-			return `${dcrContentType}/http://localhost:3031/renderFixture/${fixtureId}/${path}`;
+			return `${dcrContentType}/http://localhost:3031/renderFixtureWithId/${fixtureId}/${path}`;
+		}
+		if (fixture) {
+			const fixtureJson = JSON.stringify(fixture);
+			const base64Fixture = Buffer.from(fixtureJson).toString('base64');
+			return `${dcrContentType}/http://localhost:3031/renderFixture/${path}?fixture=${base64Fixture}`;
 		}
 		return `${dcrContentType}/https://www.theguardian.com${path}`;
 	}
@@ -69,14 +75,19 @@ const getTestUrl = ({
 	type = 'article',
 	adtest = 'fixed-puppies-ci',
 	fixtureId,
+	fixture,
 }: {
 	stage: Stage;
 	path: string;
 	type?: 'article' | 'liveblog' | 'front';
 	adtest?: string;
 	fixtureId?: string;
+	fixture?: Record<string, unknown>;
 }) => {
-	const url = new URL(getPath(stage, type, path, fixtureId), getHost(stage));
+	const url = new URL(
+		getPath(stage, type, path, fixtureId, fixture),
+		getHost(stage),
+	);
 
 	if (type === 'liveblog') {
 		url.searchParams.append('live', '1');

--- a/playwright/tests/parallel-1/consent.spec.ts
+++ b/playwright/tests/parallel-1/consent.spec.ts
@@ -35,13 +35,13 @@ const adSlotsAreNotPresent = async (page: Page) =>
 	expect(await adSlotsArePresent(page)).toBeFalsy();
 
 const visitArticleNoOkta = async (page: Page) => {
-	const url = getTestUrl(
-		getStage(),
-		'politics/2022/feb/10/keir-starmer-says-stop-the-war-coalition-gives-help-to-authoritarians-like-putin',
-		'article',
-		undefined, // use the default ad test
-		'overwriteOktaSwitchFalse',
-	);
+	const url = getTestUrl({
+		stage: getStage(),
+		path: 'politics/2022/feb/10/keir-starmer-says-stop-the-war-coalition-gives-help-to-authoritarians-like-putin',
+		type: 'article',
+		adtest: undefined,
+		fixtureId: 'overwriteOktaSwitchFalse',
+	});
 	await loadPage(page, url);
 };
 

--- a/playwright/tests/parallel-1/consent.spec.ts
+++ b/playwright/tests/parallel-1/consent.spec.ts
@@ -35,12 +35,20 @@ const adSlotsAreNotPresent = async (page: Page) =>
 	expect(await adSlotsArePresent(page)).toBeFalsy();
 
 const visitArticleNoOkta = async (page: Page) => {
+	const fixture = {
+		config: {
+			switches: {
+				okta: false,
+				idCookieRefresh: false,
+			},
+		},
+	};
 	const url = getTestUrl({
 		stage: getStage(),
 		path: 'politics/2022/feb/10/keir-starmer-says-stop-the-war-coalition-gives-help-to-authoritarians-like-putin',
 		type: 'article',
 		adtest: undefined,
-		fixtureId: 'overwriteOktaSwitchFalse',
+		fixture,
 	});
 	await loadPage(page, url);
 };

--- a/playwright/tests/parallel-2/googletag-switch.spec.ts
+++ b/playwright/tests/parallel-2/googletag-switch.spec.ts
@@ -5,12 +5,19 @@ import { getStage, getTestUrl, waitForSlot } from '../../lib/util';
 
 test.describe('shouldLoadGoogletagSwitch', () => {
 	test('ad slot should be filled when switch is true', async ({ page }) => {
+		const fixture = {
+			config: {
+				switches: {
+					shouldLoadGoogletag: true,
+				},
+			},
+		};
 		const path = getTestUrl({
 			stage: getStage(),
 			path: 'uk',
 			type: 'front',
 			adtest: undefined,
-			fixtureId: 'overwriteShouldLoadGoogletagTrue',
+			fixture,
 		});
 		await loadPage(page, path);
 		await cmpAcceptAll(page);
@@ -18,12 +25,19 @@ test.describe('shouldLoadGoogletagSwitch', () => {
 	});
 
 	test('ad slot should be filled when switch is false', async ({ page }) => {
+		const fixture = {
+			config: {
+				switches: {
+					shouldLoadGoogletag: false,
+				},
+			},
+		};
 		const path = getTestUrl({
 			stage: getStage(),
 			path: 'uk',
 			type: 'front',
 			adtest: undefined,
-			fixtureId: 'overwriteShouldLoadGoogletagFalse',
+			fixture,
 		});
 		await loadPage(page, path);
 		await cmpAcceptAll(page);

--- a/playwright/tests/parallel-2/googletag-switch.spec.ts
+++ b/playwright/tests/parallel-2/googletag-switch.spec.ts
@@ -5,28 +5,26 @@ import { getStage, getTestUrl, waitForSlot } from '../../lib/util';
 
 test.describe('shouldLoadGoogletagSwitch', () => {
 	test('ad slot should be filled when switch is true', async ({ page }) => {
-		// Construct a path that uses a fixture where the `shouldLoadGoogletag` switch is set to true
-		const path = getTestUrl(
-			getStage(),
-			'uk',
-			'front',
-			undefined,
-			'overwriteShouldLoadGoogletagTrue',
-		);
+		const path = getTestUrl({
+			stage: getStage(),
+			path: 'uk',
+			type: 'front',
+			adtest: undefined,
+			fixtureId: 'overwriteShouldLoadGoogletagTrue',
+		});
 		await loadPage(page, path);
 		await cmpAcceptAll(page);
 		await waitForSlot(page, 'top-above-nav');
 	});
 
 	test('ad slot should be filled when switch is false', async ({ page }) => {
-		// Construct a path that uses a fixture where the `shouldLoadGoogletag` switch is set to false
-		const path = getTestUrl(
-			getStage(),
-			'uk',
-			'front',
-			undefined,
-			'overwriteShouldLoadGoogletagFalse',
-		);
+		const path = getTestUrl({
+			stage: getStage(),
+			path: 'uk',
+			type: 'front',
+			adtest: undefined,
+			fixtureId: 'overwriteShouldLoadGoogletagFalse',
+		});
 		await loadPage(page, path);
 		await cmpAcceptAll(page);
 

--- a/playwright/tests/parallel-2/sponsor-logo.spec.ts
+++ b/playwright/tests/parallel-2/sponsor-logo.spec.ts
@@ -8,13 +8,13 @@ test.describe('sponsorshipLogo', () => {
 		page,
 	}) => {
 		// Construct a path that uses a fixture where a thrasher contains a sponsor logo
-		const path = getTestUrl(
-			getStage(),
-			'uk',
-			'front',
-			undefined,
-			'sponsorshipLogoInThrasher',
-		);
+		const path = getTestUrl({
+			stage: getStage(),
+			path: 'uk',
+			type: 'front',
+			adtest: undefined,
+			fixtureId: 'sponsorshipLogoInThrasher',
+		});
 
 		await loadPage(page, path);
 

--- a/playwright/tests/parallel-2/sponsor-logo.spec.ts
+++ b/playwright/tests/parallel-2/sponsor-logo.spec.ts
@@ -7,13 +7,138 @@ test.describe('sponsorshipLogo', () => {
 	test('sponsor logo ad is correctly filled in thrasher fixture', async ({
 		page,
 	}) => {
-		// Construct a path that uses a fixture where a thrasher contains a sponsor logo
+		const fixture = {
+			pressedPage: {
+				collections: [
+					{
+						id: '37eb5448-482f-4e0e-9850-fbfb25efbe78',
+						displayName: 'Thrasher Test',
+						curated: [
+							{
+								properties: {
+									isBreaking: false,
+									showMainVideo: false,
+									showKickerTag: false,
+									showByline: false,
+									imageSlideshowReplace: false,
+									isLiveBlog: false,
+									isCrossword: false,
+									byline: 'Guardian Visuals',
+									webTitle: '',
+									embedType: 'interactive',
+									embedUri:
+										'https://content.guardianapis.com/atom/interactive/interactives/thrashers/2023/01/us-soccer-thrasher/default',
+									maybeFrontPublicationDate: 1691057681991,
+									href: 'https://content.guardianapis.com/atom/interactive/interactives/thrashers/2023/01/us-soccer-thrasher/default',
+									webUrl: 'https://content.guardianapis.com/atom/interactive/interactives/thrashers/2023/01/us-soccer-thrasher/default',
+									editionBrandings: [],
+									atomId: 'atom/interactive/interactives/thrashers/2023/01/us-soccer-thrasher/default',
+								},
+								header: {
+									isVideo: false,
+									isComment: false,
+									isGallery: false,
+									isAudio: false,
+									headline: 'Default — default',
+									url: 'snap/1691057660962',
+									hasMainVideoElement: false,
+								},
+								card: {
+									id: 'snap/1691057660962',
+									cardStyle: {
+										type: 'ExternalLink',
+									},
+									shortUrl: '',
+									group: '0',
+									isLive: false,
+								},
+								discussion: {
+									isCommentable: false,
+									isClosedForComments: false,
+								},
+								display: {
+									isBoosted: false,
+									showBoostedHeadline: false,
+									showQuotedHeadline: false,
+									imageHide: false,
+									showLivePlayable: false,
+								},
+								format: {
+									design: 'ArticleDesign',
+									theme: 'NewsPillar',
+									display: 'StandardDisplay',
+								},
+								enriched: {
+									embedHtml: `<div class="ad-slot-container">
+										<div
+										id="dfp-ad--sponsor-logo"
+										data-link-name="ad slot sponsor-logo"
+										data-name="sponsor-logo"
+										aria-hidden="true"
+										class="js-ad-slot ad-slot ad-slot--sponsor-logo ad-slot--rendered"
+										data-label="false"
+										data-refresh="false"></div></div>`,
+									embedCss: '',
+									embedJs: '',
+								},
+								type: 'LinkSnap',
+							},
+						],
+						backfill: [],
+						treats: [],
+						lastUpdated: 1691057753473,
+						href: 'atom/interactive/interactives/thrashers/2019/12/charity-appeal/default',
+						collectionType: 'fixed/thrasher',
+						uneditable: false,
+						showTags: false,
+						showSections: false,
+						hideKickers: false,
+						showDateHeader: false,
+						showLatestUpdate: false,
+						config: {
+							displayName: 'Thrasher Test',
+							collectionType: 'fixed/thrasher',
+							href: 'atom/interactive/interactives/thrashers/2019/12/charity-appeal/default',
+							uneditable: false,
+							showTags: false,
+							showSections: false,
+							hideKickers: false,
+							showDateHeader: false,
+							showLatestUpdate: false,
+							excludeFromRss: false,
+							showTimestamps: false,
+							hideShowMore: false,
+							platform: 'Any',
+						},
+						hasMore: false,
+					},
+				],
+			},
+		};
 		const path = getTestUrl({
 			stage: getStage(),
 			path: 'uk',
 			type: 'front',
 			adtest: undefined,
-			fixtureId: 'sponsorshipLogoInThrasher',
+			fixture,
+		});
+
+		await loadPage(page, path);
+
+		await cmpAcceptAll(page);
+
+		await waitForSlot(page, 'sponsor-logo');
+	});
+
+	test('sponsor logo ad is correctly populated when it fires a custom event', async ({
+		page,
+	}) => {
+		const path = getTestUrl({
+			stage: getStage(),
+			path: 'uk',
+			type: 'front',
+			adtest: undefined,
+			fixtureId: 'advertThatFiresEventInThrasher',
 		});
 
 		await loadPage(page, path);

--- a/scripts/fixtures/fixtures-server.js
+++ b/scripts/fixtures/fixtures-server.js
@@ -44,20 +44,11 @@ const fetchDcrDataModel = async (path, _headers) => {
 };
 
 /**
- * Add an additional endpoint that proxies Frontend,
- * merging into the resulting JSON any overrides provided
- * as a fixture.
+ * Add additional endpoints that proxy Frontend, merging into the resulting JSON
+ * any overrides provided as a fixture.
  *
- * These fixtures are stored in fixtures.json in an object keyed
- * by the fixture ID, and are merged into the JSON returned for the
- * rest of the path. For example, to override the data for the /uk
- * path with fixture id 'foo' you could call:
- *
- * 	`http://localhost:PORT/renderFixtureWithId/foo/uk.json`
- *
- * These can then be used by an E2E test in order to fix certain
- * behavior about the system-under-test e.g. override a switch state
- * to always be true.
+ * These can then be used by an E2E test in order to fix certain behavior about
+ * the system-under-test e.g. override a switch state to always be true.
  *
  * @param {import('webpack-dev-server')} devServer
  */
@@ -69,9 +60,12 @@ const setupFixturesServer = (devServer) => {
 	devServer.app.get(
 		'/renderFixture/*.json',
 		/**
-		 * TODO
+		 * Pass a base-64 encoded JSON fixture as a query parameter. This is
+		 * merged into the DCR data retrieved from frontend for the given path
+		 *
+		 *  `http://localhost:PORT/renderFixture/uk.json?fixture=...`
 		 */
-		async (req, res) => {
+		async function (req, res) {
 			const path = req.params[0];
 			const fixtureQuery = req.query['fixture'];
 			const fixture = JSON.parse(
@@ -98,9 +92,17 @@ const setupFixturesServer = (devServer) => {
 	devServer.app.get(
 		'/renderFixtureWithId/:fixtureId/*.json',
 		/**
-		 * TODO
+		 * Take a fixture stored with the fixtures server and apply it by
+		 * passing in its ID
+		 *
+		 * These fixtures are stored in fixtures.js in an object keyed by the
+		 * fixture ID, and are merged into the JSON returned for the rest of the
+		 * path. For example, to override the data for the /uk path with fixture
+		 * id 'foo' you could call:
+		 *
+		 *  `http://localhost:PORT/renderFixtureWithId/fixtureFoo/uk.json`
 		 */
-		async (req, res) => {
+		async function (req, res) {
 			const path = req.params[0];
 			const fixtureId = req.params.fixtureId;
 			const fixture = fixtures[fixtureId];

--- a/scripts/fixtures/fixtures.js
+++ b/scripts/fixtures/fixtures.js
@@ -1,131 +1,3 @@
-const overwriteShouldLoadGoogletagTrue = {
-	config: {
-		switches: {
-			shouldLoadGoogletag: true,
-		},
-	},
-};
-
-const overwriteShouldLoadGoogletagFalse = {
-	config: {
-		switches: {
-			shouldLoadGoogletag: false,
-		},
-	},
-};
-
-const sponsorshipLogoInThrasher = {
-	pressedPage: {
-		collections: [
-			{
-				id: '37eb5448-482f-4e0e-9850-fbfb25efbe78',
-				displayName: 'Thrasher Test',
-				curated: [
-					{
-						properties: {
-							isBreaking: false,
-							showMainVideo: false,
-							showKickerTag: false,
-							showByline: false,
-							imageSlideshowReplace: false,
-							isLiveBlog: false,
-							isCrossword: false,
-							byline: 'Guardian Visuals',
-							webTitle: '',
-							embedType: 'interactive',
-							embedUri:
-								'https://content.guardianapis.com/atom/interactive/interactives/thrashers/2023/01/us-soccer-thrasher/default',
-							maybeFrontPublicationDate: 1691057681991,
-							href: 'https://content.guardianapis.com/atom/interactive/interactives/thrashers/2023/01/us-soccer-thrasher/default',
-							webUrl: 'https://content.guardianapis.com/atom/interactive/interactives/thrashers/2023/01/us-soccer-thrasher/default',
-							editionBrandings: [],
-							atomId: 'atom/interactive/interactives/thrashers/2023/01/us-soccer-thrasher/default',
-						},
-						header: {
-							isVideo: false,
-							isComment: false,
-							isGallery: false,
-							isAudio: false,
-							headline: 'Default — default',
-							url: 'snap/1691057660962',
-							hasMainVideoElement: false,
-						},
-						card: {
-							id: 'snap/1691057660962',
-							cardStyle: {
-								type: 'ExternalLink',
-							},
-							shortUrl: '',
-							group: '0',
-							isLive: false,
-						},
-						discussion: {
-							isCommentable: false,
-							isClosedForComments: false,
-						},
-						display: {
-							isBoosted: false,
-							showBoostedHeadline: false,
-							showQuotedHeadline: false,
-							imageHide: false,
-							showLivePlayable: false,
-						},
-						format: {
-							design: 'ArticleDesign',
-							theme: 'NewsPillar',
-							display: 'StandardDisplay',
-						},
-						enriched: {
-							embedHtml: `
-							<div class="ad-slot-container">
-								<div
-									id="dfp-ad--sponsor-logo"
-									data-link-name="ad slot sponsor-logo"
-									data-name="sponsor-logo"
-									aria-hidden="true"
-									class="js-ad-slot ad-slot ad-slot--sponsor-logo ad-slot--rendered"
-									data-label="false"
-									data-refresh="false"
-								></div>
-							</div>`,
-							embedCss: '',
-							embedJs: '',
-						},
-						type: 'LinkSnap',
-					},
-				],
-				backfill: [],
-				treats: [],
-				lastUpdated: 1691057753473,
-				href: 'atom/interactive/interactives/thrashers/2019/12/charity-appeal/default',
-				collectionType: 'fixed/thrasher',
-				uneditable: false,
-				showTags: false,
-				showSections: false,
-				hideKickers: false,
-				showDateHeader: false,
-				showLatestUpdate: false,
-				config: {
-					displayName: 'Thrasher Test',
-					collectionType: 'fixed/thrasher',
-					href: 'atom/interactive/interactives/thrashers/2019/12/charity-appeal/default',
-					uneditable: false,
-					showTags: false,
-					showSections: false,
-					hideKickers: false,
-					showDateHeader: false,
-					showLatestUpdate: false,
-					excludeFromRss: false,
-					showTimestamps: false,
-					hideShowMore: false,
-					platform: 'Any',
-				},
-				hasMore: false,
-			},
-		],
-	},
-};
-
 const advertThatFiresEventInThrasher = {
 	pressedPage: {
 		collections: [
@@ -250,15 +122,6 @@ const advertThatFiresEventInThrasher = {
 	},
 };
 
-const overwriteOktaSwitchFalse = {
-	config: {
-		switches: {
-			okta: false,
-			idCookieRefresh: false,
-		},
-	},
-};
-
 /**
  * The fixtures represent a set of objects that is deeply merged into the JSON
  * data that is used by DCR. It can be used to override properties for the
@@ -268,11 +131,7 @@ const overwriteOktaSwitchFalse = {
  * Each of the fixtures is available via an endpoint (see fixtures-server.js)
  */
 const fixtures = {
-	overwriteShouldLoadGoogletagTrue,
-	overwriteShouldLoadGoogletagFalse,
-	sponsorshipLogoInThrasher,
 	advertThatFiresEventInThrasher,
-	overwriteOktaSwitchFalse,
 };
 
 module.exports = {


### PR DESCRIPTION
## What does this change?

This PR builds on the work in #948, adding support for defining a fixture object within a test. This is base64 * encoded and passed via a query parameter `?fixture=...` to the fixtures server. The fixtures server decodes this object and merges it into the data retrieved from Frontend, in the usual way.

(*) I chose base64 arbitrarily because it's simple to use without pulling in a dependency, although I'm sure their are other schemes which compress JSON better.

There was some discussion (cc @arelra) around POSTing the fixture data, to avoid hitting the maximum length of a URL. This is possible, but when I tried this before it causes a headache trying to fix all of the paths that are relative to DCR, so this PR sticks with a simple GET request.

## Why?

Allows us to define fixtures closer to the test in which they're used. Due to maximum URL lengths, this won't always be possible, so I've left one fixture that is used in the previous way as an example.
