### PR TITLE
Hide fronts-banner ads when collapsing slots

### DIFF
--- a/.changeset/dull-paws-attend.md
+++ b/.changeset/dull-paws-attend.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Hide fronts-banner ads when collapsing slots

--- a/src/lib/dfp/render-advert.ts
+++ b/src/lib/dfp/render-advert.ts
@@ -98,7 +98,8 @@ const outOfPageCallback = (advert: Advert) => {
 	const parent = advert.node.parentNode as HTMLElement;
 	return fastdom.mutate(() => {
 		advert.node.classList.add('ad-slot--collapse');
-		// Special case for top-above-nav which has a container with its own height
+
+		// top-above-nav and fronts-banner have an extra container
 		if (advert.id.includes('top-above-nav')) {
 			const adContainer = advert.node.closest<HTMLElement>(
 				'.top-banner-ad-container',
@@ -107,6 +108,15 @@ const outOfPageCallback = (advert: Advert) => {
 				adContainer.style.display = 'none';
 			}
 		}
+		if (advert.id.includes('fronts-banner')) {
+			const adContainer = advert.node.closest<HTMLElement>(
+				'.top-fronts-banner-ad-container',
+			);
+			if (adContainer) {
+				adContainer.style.display = 'none';
+			}
+		}
+
 		// if in a slice, add the 'no mpu' class
 		if (parent.classList.contains('fc-slice__item--mpu-candidate')) {
 			parent.classList.add('fc-slice__item--no-mpu');


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

- Collapses the fronts-banner ad slot containers when the ad slot is collapsed

## Why?

- So we don't show an empty ad slot when we collapse an ad
