### PR TITLE
Unit tests for shouldLazyLoad

### DIFF
--- a/src/lib/dfp/dfp-env.spec.ts
+++ b/src/lib/dfp/dfp-env.spec.ts
@@ -1,0 +1,56 @@
+import { getCurrentBreakpoint as getCurrentBreakpoint_ } from 'lib/detect/detect-breakpoint';
+import { getUrlVars as getUrlVars_ } from 'lib/utils/url';
+import { dfpEnv } from './dfp-env';
+
+const getCurrentBreakpoint = getCurrentBreakpoint_ as jest.MockedFunction<
+	typeof getCurrentBreakpoint_
+>;
+
+const getUrlVars = getUrlVars_ as jest.MockedFunction<
+	() => Record<string, string>
+>;
+
+jest.mock('lib/detect/detect-breakpoint', () => ({
+	getCurrentBreakpoint: jest.fn(),
+}));
+
+jest.mock('lib/utils/url', () => ({
+	getUrlVars: jest.fn(),
+}));
+
+describe('lazy loading', () => {
+	it('should lazy load ads when there is no pageskin on a desktop view', () => {
+		getCurrentBreakpoint.mockReturnValue('desktop');
+		window.guardian.config.page.hasPageSkin = false;
+		getUrlVars.mockReturnValue({});
+		expect(dfpEnv.shouldLazyLoad()).toBe(true);
+	});
+
+	it('should not lazy load ads when there is a pageskin on a desktop view', () => {
+		getCurrentBreakpoint.mockReturnValue('desktop');
+		window.guardian.config.page.hasPageSkin = true;
+		getUrlVars.mockReturnValue({});
+		expect(dfpEnv.shouldLazyLoad()).toBe(false);
+	});
+
+	it('should lazy load ads when there is no pageskin on a mobile or tablet view', () => {
+		getCurrentBreakpoint.mockReturnValue('tablet');
+		window.guardian.config.page.hasPageSkin = false;
+		getUrlVars.mockReturnValue({});
+		expect(dfpEnv.shouldLazyLoad()).toBe(true);
+	});
+
+	it('should lazy load ads when there is a pageskin on a mobile or tablet view', () => {
+		getCurrentBreakpoint.mockReturnValue('tablet');
+		window.guardian.config.page.hasPageSkin = true;
+		getUrlVars.mockReturnValue({});
+		expect(dfpEnv.shouldLazyLoad()).toBe(true);
+	});
+
+	it('should not lazy load ads when there is a dll = 1 URL parameter', () => {
+		getCurrentBreakpoint.mockReturnValue('desktop');
+		window.guardian.config.page.hasPageSkin = false;
+		getUrlVars.mockReturnValue({ dll: '1' });
+		expect(dfpEnv.shouldLazyLoad()).toBe(false);
+	});
+});

--- a/src/lib/dfp/prepare-googletag.spec.ts
+++ b/src/lib/dfp/prepare-googletag.spec.ts
@@ -587,18 +587,6 @@ describe('DFP', () => {
 		expect(result_4[1]).toEqual('2');
 	});
 
-	describe('pageskin loading', () => {
-		it('should lazy load ads when there is no pageskin', () => {
-			window.guardian.config.page.hasPageSkin = false;
-			expect(dfpEnv.shouldLazyLoad()).toBe(true);
-		});
-
-		it('should not lazy load ads when there is a pageskin', () => {
-			window.guardian.config.page.hasPageSkin = true;
-			expect(dfpEnv.shouldLazyLoad()).toBe(false);
-		});
-	});
-
 	describe('keyword targeting', () => {
 		it('should send page level keywords', async () => {
 			mockOnConsent(tcfv2WithConsent);


### PR DESCRIPTION
## What does this change?
- Moves the existing two tests for shouldLazyLoad to a new file
- Adds a mocked version for getCurrentBreakpoint to test the behaviour of shouldLazyLoad at different breakpoints
- Adds a test to cover when `dll = 1`

## Why?
We had an incident earlier this year where shouldLazyLoad was not returning the value we expected on mobile view. We wanted to add more rigorous unit testing to help catch this before it becomes a problem in production.
