### PR TITLE
Centre video element in video interscroller

### DIFF
--- a/.changeset/wild-flies-flow.md
+++ b/.changeset/wild-flies-flow.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Centre video element in the video interscroller template

--- a/src/lib/messenger/background.ts
+++ b/src/lib/messenger/background.ts
@@ -220,9 +220,10 @@ const setupBackground = async (
 				video.muted = true;
 				video.playsInline = true;
 				video.src = specs.videoSource;
-				video.style.inset = '0';
+				video.style.inset = '50% 0 0 50%';
 				video.style.position = 'fixed';
 				video.style.height = '100%';
+				video.style.transform = 'translate(-50%, -50%)';
 				background.appendChild(video);
 			}
 		} else {


### PR DESCRIPTION
## What does this change?
Centres the video element of the video interscroller to make sure it appears in the middle of the container

## Before and after
| Before      | After      |
| ----------- | ---------- |
| <img width="302" alt="Screenshot 2023-10-24 at 12 51 28" src="https://github.com/guardian/commercial/assets/108270776/68946dcb-43d3-4ff0-8f77-ee890c8c4580"> | <img width="307" alt="Screenshot 2023-10-24 at 12 51 08" src="https://github.com/guardian/commercial/assets/108270776/cf874d8c-a47c-49be-baac-4f864ccd57cf"> |

