### PR TITLE
Add Ozone testgroup to Ad slot

### DIFF
--- a/src/lib/dfp/Advert.spec.ts
+++ b/src/lib/dfp/Advert.spec.ts
@@ -65,6 +65,7 @@ describe('Advert', () => {
 			setSafeFrameConfig: jest.fn(() => googleSlot),
 			setTargeting: jest.fn(() => googleSlot),
 			addService: jest.fn(() => googleSlot),
+			getTargeting: jest.fn(() => []),
 		};
 
 		const partialGoogletag: Partial<typeof googletag> = {

--- a/src/lib/dfp/Advert.ts
+++ b/src/lib/dfp/Advert.ts
@@ -100,7 +100,7 @@ class Advert {
 	hasPrebidSize = false;
 	headerBiddingBidRequest: Promise<unknown> | null = null;
 	lineItemId: number | null = null;
-	testgroup: string | undefined;
+	testgroup: string | undefined; //Ozone testgroup property
 
 	constructor(
 		adSlotNode: HTMLElement,

--- a/src/lib/dfp/Advert.ts
+++ b/src/lib/dfp/Advert.ts
@@ -119,7 +119,7 @@ class Advert {
 
 		this.slot = slotDefinition.slot;
 		this.whenSlotReady = slotDefinition.slotReady;
-		this.testgroup = slotDefinition.slot.getTargeting('testgroup');
+		this.testgroup = slotDefinition.slot.getTargeting('testgroup')[0];
 	}
 
 	/**

--- a/src/lib/dfp/Advert.ts
+++ b/src/lib/dfp/Advert.ts
@@ -100,6 +100,7 @@ class Advert {
 	hasPrebidSize = false;
 	headerBiddingBidRequest: Promise<unknown> | null = null;
 	lineItemId: number | null = null;
+	testgroup: string;
 
 	constructor(
 		adSlotNode: HTMLElement,
@@ -118,6 +119,7 @@ class Advert {
 
 		this.slot = slotDefinition.slot;
 		this.whenSlotReady = slotDefinition.slotReady;
+		this.testgroup = slotDefinition.slot.getTargeting('testgroup');
 	}
 
 	/**

--- a/src/lib/dfp/Advert.ts
+++ b/src/lib/dfp/Advert.ts
@@ -100,7 +100,7 @@ class Advert {
 	hasPrebidSize = false;
 	headerBiddingBidRequest: Promise<unknown> | null = null;
 	lineItemId: number | null = null;
-	testgroup: string;
+	testgroup: string | undefined;
 
 	constructor(
 		adSlotNode: HTMLElement,

--- a/src/lib/dfp/define-slot.spec.ts
+++ b/src/lib/dfp/define-slot.spec.ts
@@ -38,7 +38,7 @@ beforeEach(() => {
 		defineSlot: jest.fn(() => window.googletag),
 		defineSizeMapping: jest.fn(() => window.googletag),
 		addService: jest.fn(() => window.googletag),
-		setTargeting: jest.fn(),
+		setTargeting: jest.fn(() => window.googletag),
 		/* @ts-expect-error -- no way to override types */
 		pubads() {
 			return pubAds;

--- a/src/lib/dfp/define-slot.ts
+++ b/src/lib/dfp/define-slot.ts
@@ -174,7 +174,11 @@ const defineSlot = (
 		slot?.setTargeting(key, value);
 	});
 
-	slot.addService(window.googletag.pubads()).setTargeting('slot', slotTarget);
+	const testGroup = String(Math.floor(100 * Math.random()));
+
+	slot.addService(window.googletag.pubads())
+		.setTargeting('slot', slotTarget)
+		.setTargeting('testgroup', testGroup);
 
 	return {
 		slot,

--- a/src/lib/dfp/define-slot.ts
+++ b/src/lib/dfp/define-slot.ts
@@ -174,11 +174,9 @@ const defineSlot = (
 		slot?.setTargeting(key, value);
 	});
 
-	const testGroup = String(Math.floor(100 * Math.random()));
-
 	slot.addService(window.googletag.pubads())
 		.setTargeting('slot', slotTarget)
-		.setTargeting('testgroup', testGroup);
+		.setTargeting('testgroup', String(Math.floor(100 * Math.random())));
 
 	return {
 		slot,

--- a/src/lib/dfp/prepare-googletag.spec.ts
+++ b/src/lib/dfp/prepare-googletag.spec.ts
@@ -331,6 +331,7 @@ describe('DFP', () => {
 			setSafeFrameConfig: jest.fn(() => googleSlot),
 			setTargeting: jest.fn(() => googleSlot),
 			addService: jest.fn(() => googleSlot),
+			getTargeting: jest.fn(() => []),
 		} as unknown as googletag.Slot;
 
 		googleTag = {

--- a/src/lib/dfp/should-refresh.spec.ts
+++ b/src/lib/dfp/should-refresh.spec.ts
@@ -36,6 +36,7 @@ describe('shouldRefresh', () => {
 			setSafeFrameConfig: jest.fn(() => googleSlot),
 			setTargeting: jest.fn(() => googleSlot),
 			addService: jest.fn(() => googleSlot),
+			getTargeting: jest.fn(() => []),
 		};
 
 		const partialGoogletag: Partial<typeof googletag> = {

--- a/src/lib/header-bidding/prebid/bid-config.ts
+++ b/src/lib/header-bidding/prebid/bid-config.ts
@@ -4,6 +4,7 @@ import {
 	buildAppNexusTargeting,
 	buildAppNexusTargetingObject,
 } from 'lib/build-page-targeting';
+import { dfpEnv } from 'lib/dfp/dfp-env';
 import { includeBillboardsInMerchHigh } from 'lib/dfp/merchandising-high-test';
 import { isInAuOrNz, isInUk, isInUsa, isInUsOrCa } from 'lib/utils/geo-utils';
 import { pbTestNameMap } from 'lib/utils/url';
@@ -275,7 +276,9 @@ const ozoneClientSideBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
 				settings: {},
 				targeting: {
 					// Assigns a random integer between 0 and 99
-					testgroup: String(Math.floor(100 * Math.random())),
+					testgroup: dfpEnv.adverts.find(
+						(ad) => ad.id === _slotId && ad.testgroup,
+					).testgroup[0],
 					...buildAppNexusTargetingObject(pageTargeting),
 				},
 			},

--- a/src/lib/header-bidding/prebid/bid-config.ts
+++ b/src/lib/header-bidding/prebid/bid-config.ts
@@ -267,24 +267,27 @@ const ozoneClientSideBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
 	bidParams: (
 		_slotId: string,
 		sizes: HeaderBiddingSize[],
-	): PrebidOzoneParams => ({
-		publisherId: 'OZONEGMG0001',
-		siteId: '4204204209',
-		placementId: getOzonePlacementId(sizes),
-		customData: [
-			{
-				settings: {},
-				targeting: {
-					// Assigns a random integer between 0 and 99
-					testgroup: dfpEnv.adverts.find(
-						(ad) => ad.id === _slotId && ad.testgroup,
-					).testgroup[0],
-					...buildAppNexusTargetingObject(pageTargeting),
+	): PrebidOzoneParams => {
+		const advert = dfpEnv.adverts.find((ad) => ad.id === _slotId);
+		const testgroup = advert ? { testgroup: advert.testgroup } : {};
+
+		return {
+			publisherId: 'OZONEGMG0001',
+			siteId: '4204204209',
+			placementId: getOzonePlacementId(sizes),
+			customData: [
+				{
+					settings: {},
+					targeting: {
+						// Assigns a random integer between 0 and 99
+						...testgroup,
+						...buildAppNexusTargetingObject(pageTargeting),
+					},
 				},
-			},
-		],
-		ozoneData: {}, // TODO: confirm if we need to send any
-	}),
+			],
+			ozoneData: {}, // TODO: confirm if we need to send any
+		};
+	},
 });
 
 const sonobiBidder: (pageTargeting: PageTargeting) => PrebidBidder = (

--- a/src/lib/header-bidding/slot-config.spec.ts
+++ b/src/lib/header-bidding/slot-config.spec.ts
@@ -36,6 +36,7 @@ const slotPrototype = {
 	addService: () => slotPrototype,
 	setTargeting: () => slotPrototype,
 	setSafeFrameConfig: () => slotPrototype,
+	getTargeting: () => slotPrototype,
 };
 
 // Mock window.googletag


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

This PR adds Ozone testgroup to the GAM request. We add it to ad slot object `DefineSlot` in order to get the same value of the testgroup in prebid. We create the testgroup in `DefineSlot` which is then stored in the Advert class. We read this value back in the `OzoneClientSideBidder` object. 

## Why?

We’d like to compare Ozone data with Ad Manager data which it wasn't the case before when we had just key-value in the Ozone prebid configuration but not in Google Ad Manager.

