### PR TITLE
Added E2E tests for `fronts-banner` ads

### DIFF
--- a/playwright/fixtures/pages/fronts.ts
+++ b/playwright/fixtures/pages/fronts.ts
@@ -5,7 +5,7 @@ type Front = GuPage & {
 	section: string;
 };
 
-type TaggedFront = GuPage;
+type TagFront = GuPage;
 
 const stage = getStage();
 
@@ -39,12 +39,12 @@ const fronts: Front[] = [
 	},
 ];
 
-const taggedFronts: TaggedFront[] = [
+const tagFronts: TagFront[] = [
 	{
 		path: getTestUrl({
 			stage,
-			path: '/world/americas', // tagged front
-			type: 'taggedFront',
+			path: '/world/americas',
+			type: 'tagFront',
 			adtest: 'fixed-puppies',
 		}),
 	},
@@ -60,4 +60,4 @@ const frontWithPageSkin: Front = {
 	section: 'uk',
 };
 
-export { frontWithPageSkin, fronts, taggedFronts };
+export { frontWithPageSkin, fronts, tagFronts };

--- a/playwright/fixtures/pages/fronts.ts
+++ b/playwright/fixtures/pages/fronts.ts
@@ -5,6 +5,8 @@ type Front = GuPage & {
 	section: string;
 };
 
+type TaggedFront = GuPage;
+
 const stage = getStage();
 
 const fronts: Front[] = [
@@ -13,27 +15,38 @@ const fronts: Front[] = [
 			stage,
 			path: '/uk',
 			type: 'front',
-			adtest: 'puppies-pageskin',
+			adtest: 'fixed-puppies',
 		}),
 		section: 'uk',
 	},
 	{
 		path: getTestUrl({
 			stage,
-			path: '/commentisfree',
+			path: '/uk/commentisfree',
 			type: 'front',
-			adtest: 'puppies-pageskin',
+			adtest: 'fixed-puppies',
 		}),
 		section: 'commentisfree',
 	},
 	{
 		path: getTestUrl({
 			stage,
-			path: '/sport',
+			path: '/uk/sport',
 			type: 'front',
-			adtest: 'puppies-pageskin',
+			adtest: 'fixed-puppies',
 		}),
 		section: 'sport',
+	},
+];
+
+const taggedFronts: TaggedFront[] = [
+	{
+		path: getTestUrl({
+			stage,
+			path: '/world/americas', // tagged front
+			type: 'taggedFront',
+			adtest: 'fixed-puppies',
+		}),
 	},
 ];
 
@@ -47,4 +60,4 @@ const frontWithPageSkin: Front = {
 	section: 'uk',
 };
 
-export { fronts, frontWithPageSkin };
+export { frontWithPageSkin, fronts, taggedFronts };

--- a/playwright/fixtures/pages/index.ts
+++ b/playwright/fixtures/pages/index.ts
@@ -1,7 +1,7 @@
 import { articles } from './articles';
 import { blogs } from './blogs';
-import { fronts, frontWithPageSkin, taggedFronts } from './fronts';
+import { fronts, frontWithPageSkin, tagFronts } from './fronts';
 
 const allPages = [...articles, ...blogs];
 
-export { allPages, articles, blogs, fronts, frontWithPageSkin, taggedFronts };
+export { allPages, articles, blogs, fronts, frontWithPageSkin, tagFronts };

--- a/playwright/fixtures/pages/index.ts
+++ b/playwright/fixtures/pages/index.ts
@@ -1,7 +1,7 @@
 import { articles } from './articles';
 import { blogs } from './blogs';
-import { fronts, frontWithPageSkin } from './fronts';
+import { fronts, frontWithPageSkin, taggedFronts } from './fronts';
 
 const allPages = [...articles, ...blogs];
 
-export { articles, blogs, fronts, frontWithPageSkin, allPages };
+export { allPages, articles, blogs, fronts, frontWithPageSkin, taggedFronts };

--- a/playwright/lib/util.ts
+++ b/playwright/lib/util.ts
@@ -3,7 +3,7 @@ import type { UserFeaturesResponse } from '../../src/types/membership';
 
 type Stage = 'code' | 'prod' | 'dev';
 
-type ContentType = 'article' | 'liveblog' | 'front' | 'taggedFront';
+type ContentType = 'article' | 'liveblog' | 'front' | 'tagFront';
 
 const normalizeStage = (stage: string): Stage =>
 	['code', 'prod', 'dev'].includes(stage) ? (stage as Stage) : 'dev';
@@ -36,7 +36,7 @@ const getDcrContentType = (
 		case 'front':
 			return 'Front';
 
-		case 'taggedFront':
+		case 'tagFront':
 			return 'TagFront';
 
 		default:

--- a/playwright/tests/parallel-2/front-inline-slots.spec.ts
+++ b/playwright/tests/parallel-2/front-inline-slots.spec.ts
@@ -1,0 +1,27 @@
+import { test } from '@playwright/test';
+import { fronts, taggedFronts } from '../../fixtures/pages';
+import { cmpAcceptAll } from '../../lib/cmp';
+import { loadPage } from '../../lib/load-page';
+import { waitForSlot } from '../../lib/util';
+
+test.describe('Slots and iframes load on fronts pages', () => {
+	fronts.forEach(({ path }) => {
+		test(`fronts-banner ads are loaded on ${path}`, async ({ page }) => {
+			await loadPage(page, path);
+			await cmpAcceptAll(page);
+
+			await waitForSlot(page, 'fronts-banner-1');
+		});
+	});
+});
+
+test.describe('Slots and iframes load on tagged fronts pages', () => {
+	taggedFronts.forEach(({ path }) => {
+		test(`fronts-banner ads are loaded on ${path}`, async ({ page }) => {
+			await loadPage(page, path);
+			await cmpAcceptAll(page);
+
+			await waitForSlot(page, 'fronts-banner-1');
+		});
+	});
+});

--- a/playwright/tests/parallel-2/front-inline-slots.spec.ts
+++ b/playwright/tests/parallel-2/front-inline-slots.spec.ts
@@ -1,5 +1,5 @@
 import { test } from '@playwright/test';
-import { fronts, taggedFronts } from '../../fixtures/pages';
+import { fronts, tagFronts } from '../../fixtures/pages';
 import { cmpAcceptAll } from '../../lib/cmp';
 import { loadPage } from '../../lib/load-page';
 import { waitForSlot } from '../../lib/util';
@@ -16,7 +16,7 @@ test.describe('Slots and iframes load on fronts pages', () => {
 });
 
 test.describe('Slots and iframes load on tagged fronts pages', () => {
-	taggedFronts.forEach(({ path }) => {
+	tagFronts.forEach(({ path }) => {
 		test(`fronts-banner ads are loaded on ${path}`, async ({ page }) => {
 			await loadPage(page, path);
 			await cmpAcceptAll(page);


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

- Added E2E tests for fronts-banner ads
- Since fronts pages may change their layout, this test doesn't intend to ensure the correct amount of `fronts-banner` ad slots are present, since the removal of collections may lead to fewer ad slots being inserted. Instead, this test merely ensures that the first `fronts-banner` ad slot is being inserted.

## Why?

- Testing coverage