### PR TITLE
removed references to 'user-features' module booting commercial bu…

### DIFF
--- a/.changeset/tall-sheep-compete.md
+++ b/.changeset/tall-sheep-compete.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+removing user-features module from boot

--- a/playwright/tests/parallel-1/consent.spec.ts
+++ b/playwright/tests/parallel-1/consent.spec.ts
@@ -1,231 +1,236 @@
-import type { Page } from '@playwright/test';
-import { expect, test } from '@playwright/test';
-import { articles } from '../../fixtures/pages';
-import type { GuPage } from '../../fixtures/pages/Page';
-import { cmpAcceptAll, cmpReconsent, cmpRejectAll } from '../../lib/cmp';
-import { loadPage } from '../../lib/load-page';
-import {
-	fakeLogOut,
-	getStage,
-	getTestUrl,
-	setupFakeLogin,
-	waitForSlot,
-} from '../../lib/util';
-
-const { path } = articles[0] as unknown as GuPage;
-
-const adSlotsAreFulfilled = async (page: Page) =>
-	await waitForSlot(page, 'top-above-nav');
-
-/**
- * Warning!
- * isVisible() is an immediate check and does not wait.
- * While slots will be present when opt-out loads we remove
- * a slot if it is not fulfilled. Using this visibility check
- * ensures we check the slot is present before removal occurs.
- */
-const adSlotsArePresent = async (page: Page) =>
-	await page.locator('#dfp-ad--top-above-nav').isVisible();
-
-/**
- * This function is intended to check if slots are _not_ present
- * immediately i.e. when SSR does not render slots for adFree users.
- */
-const adSlotsAreNotPresent = async (page: Page) =>
-	expect(await adSlotsArePresent(page)).toBeFalsy();
-
-const visitArticleNoOkta = async (page: Page) => {
-	const fixture = {
-		config: {
-			switches: {
-				okta: false,
-				idCookieRefresh: false,
-			},
-		},
-	};
-	const url = getTestUrl({
-		stage: getStage(),
-		path: 'politics/2022/feb/10/keir-starmer-says-stop-the-war-coalition-gives-help-to-authoritarians-like-putin',
-		type: 'article',
-		adtest: undefined,
-		fixture,
-	});
-	await loadPage(page, url);
-};
-
-const waitForOptOut = (page: Page) =>
-	page.waitForRequest(/cdn.optoutadvertising.com/);
-
-test.describe('tcfv2 consent', () => {
-	test(`Accept all, ad slots are fulfilled`, async ({ page }) => {
-		await loadPage(page, path);
-
-		await cmpAcceptAll(page);
+/*
+Temporarily disabled until user-features released in dotcom-rendering
+It relies on cookies for subscription being set
+can then be uncommmented and used
+*/
+// import type { Page } from '@playwright/test';
+// import { expect, test } from '@playwright/test';
+// import { articles } from '../../fixtures/pages';
+// import type { GuPage } from '../../fixtures/pages/Page';
+// import { cmpAcceptAll, cmpReconsent, cmpRejectAll } from '../../lib/cmp';
+// import { loadPage } from '../../lib/load-page';
+// import {
+// 	fakeLogOut,
+// 	getStage,
+// 	getTestUrl,
+// 	setupFakeLogin,
+// 	waitForSlot,
+// } from '../../lib/util';
+
+// const { path } = articles[0] as unknown as GuPage;
+
+// const adSlotsAreFulfilled = async (page: Page) =>
+// 	await waitForSlot(page, 'top-above-nav');
+
+// /**
+//  * Warning!
+//  * isVisible() is an immediate check and does not wait.
+//  * While slots will be present when opt-out loads we remove
+//  * a slot if it is not fulfilled. Using this visibility check
+//  * ensures we check the slot is present before removal occurs.
+//  */
+// const adSlotsArePresent = async (page: Page) =>
+// 	await page.locator('#dfp-ad--top-above-nav').isVisible();
+
+// /**
+//  * This function is intended to check if slots are _not_ present
+//  * immediately i.e. when SSR does not render slots for adFree users.
+//  */
+// const adSlotsAreNotPresent = async (page: Page) =>
+// 	expect(await adSlotsArePresent(page)).toBeFalsy();
+
+// const visitArticleNoOkta = async (page: Page) => {
+// 	const fixture = {
+// 		config: {
+// 			switches: {
+// 				okta: false,
+// 				idCookieRefresh: false,
+// 			},
+// 		},
+// 	};
+// 	const url = getTestUrl({
+// 		stage: getStage(),
+// 		path: 'politics/2022/feb/10/keir-starmer-says-stop-the-war-coalition-gives-help-to-authoritarians-like-putin',
+// 		type: 'article',
+// 		adtest: undefined,
+// 		fixture,
+// 	});
+// 	await loadPage(page, url);
+// };
+
+// const waitForOptOut = (page: Page) =>
+// 	page.waitForRequest(/cdn.optoutadvertising.com/);
+
+// test.describe('tcfv2 consent', () => {
+// 	test(`Accept all, ad slots are fulfilled`, async ({ page }) => {
+// 		await loadPage(page, path);
+
+// 		await cmpAcceptAll(page);
+
+// 		await loadPage(page, path);
+
+// 		await adSlotsAreFulfilled(page);
+// 	});
+
+// 	test(`Reject all, load Opt Out, ads slots are present`, async ({
+// 		page,
+// 	}) => {
+// 		await loadPage(page, path);
+
+// 		const optOutPromise = waitForOptOut(page);
+// 		await cmpRejectAll(page);
+// 		await optOutPromise;
+
+// 		await adSlotsArePresent(page);
+// 	});
 
-		await loadPage(page, path);
+// 	test(`Reject all, login as subscriber, load Opt Out, ads slots are not present`, async ({
+// 		page,
+// 		context,
+// 	}) => {
+// 		await setupFakeLogin(page, context, true);
 
-		await adSlotsAreFulfilled(page);
-	});
+// 		await visitArticleNoOkta(page);
 
-	test(`Reject all, load Opt Out, ads slots are present`, async ({
-		page,
-	}) => {
-		await loadPage(page, path);
+// 		const optOutPromise = waitForOptOut(page);
+// 		await cmpRejectAll(page);
+// 		await optOutPromise;
 
-		const optOutPromise = waitForOptOut(page);
-		await cmpRejectAll(page);
-		await optOutPromise;
+// 		await visitArticleNoOkta(page);
 
-		await adSlotsArePresent(page);
-	});
+// 		await adSlotsAreNotPresent(page);
+// 	});
 
-	test(`Reject all, login as subscriber, load Opt Out, ads slots are not present`, async ({
-		page,
-		context,
-	}) => {
-		await setupFakeLogin(page, context, true);
+// 	test(`Reject all, login as non-subscriber, load Opt Out, ads slots are present`, async ({
+// 		page,
+// 		context,
+// 	}) => {
+// 		await setupFakeLogin(page, context, false);
 
-		await visitArticleNoOkta(page);
+// 		await visitArticleNoOkta(page);
 
-		const optOutPromise = waitForOptOut(page);
-		await cmpRejectAll(page);
-		await optOutPromise;
+// 		const optOutPromise = waitForOptOut(page);
+// 		await cmpRejectAll(page);
+// 		await optOutPromise;
 
-		await visitArticleNoOkta(page);
+// 		await visitArticleNoOkta(page);
 
-		await adSlotsAreNotPresent(page);
-	});
+// 		await adSlotsArePresent(page);
+// 	});
 
-	test(`Reject all, login as non-subscriber, load Opt Out, ads slots are present`, async ({
-		page,
-		context,
-	}) => {
-		await setupFakeLogin(page, context, false);
+// 	test(`Reject all, accept all, ad slots are fulfilled`, async ({ page }) => {
+// 		await loadPage(page, path);
 
-		await visitArticleNoOkta(page);
+// 		await cmpRejectAll(page);
 
-		const optOutPromise = waitForOptOut(page);
-		await cmpRejectAll(page);
-		await optOutPromise;
+// 		await loadPage(page, path);
 
-		await visitArticleNoOkta(page);
+// 		await cmpReconsent(page);
 
-		await adSlotsArePresent(page);
-	});
+// 		await loadPage(page, path);
 
-	test(`Reject all, accept all, ad slots are fulfilled`, async ({ page }) => {
-		await loadPage(page, path);
+// 		await adSlotsAreFulfilled(page);
+// 	});
 
-		await cmpRejectAll(page);
+// 	test(`Accept all, login as subscriber, ads slots are not present`, async ({
+// 		page,
+// 		context,
+// 	}) => {
+// 		await setupFakeLogin(page, context, true);
 
-		await loadPage(page, path);
+// 		await visitArticleNoOkta(page);
 
-		await cmpReconsent(page);
+// 		await cmpAcceptAll(page);
 
-		await loadPage(page, path);
+// 		// TODO investigate
+// 		// user-features does not run until consent state has been given.
+// 		// So when we accept all, ads will load despite being ad free as
+// 		// the ad free cookie has not yet been set.
 
-		await adSlotsAreFulfilled(page);
-	});
+// 		await visitArticleNoOkta(page);
 
-	test(`Accept all, login as subscriber, ads slots are not present`, async ({
-		page,
-		context,
-	}) => {
-		await setupFakeLogin(page, context, true);
+// 		await adSlotsAreNotPresent(page);
+// 	});
 
-		await visitArticleNoOkta(page);
+// 	test(`Reject all, login as subscriber, ad slots are not present, log out, load Opt Out, ad slots are present`, async ({
+// 		page,
+// 		context,
+// 	}) => {
+// 		await setupFakeLogin(page, context, true);
 
-		await cmpAcceptAll(page);
+// 		await visitArticleNoOkta(page);
 
-		// TODO investigate
-		// user-features does not run until consent state has been given.
-		// So when we accept all, ads will load despite being ad free as
-		// the ad free cookie has not yet been set.
+// 		await cmpRejectAll(page);
 
-		await visitArticleNoOkta(page);
+// 		await visitArticleNoOkta(page);
 
-		await adSlotsAreNotPresent(page);
-	});
+// 		await adSlotsAreNotPresent(page);
 
-	test(`Reject all, login as subscriber, ad slots are not present, log out, load Opt Out, ad slots are present`, async ({
-		page,
-		context,
-	}) => {
-		await setupFakeLogin(page, context, true);
+// 		await fakeLogOut(context);
 
-		await visitArticleNoOkta(page);
+// 		await visitArticleNoOkta(page);
 
-		await cmpRejectAll(page);
+// 		await adSlotsArePresent(page);
+// 	});
 
-		await visitArticleNoOkta(page);
+// 	test(`Reject all, login as subscriber, ad slots are not present on multiple page loads`, async ({
+// 		page,
+// 		context,
+// 	}) => {
+// 		await setupFakeLogin(page, context, true);
 
-		await adSlotsAreNotPresent(page);
+// 		await visitArticleNoOkta(page);
 
-		await fakeLogOut(context);
+// 		await cmpRejectAll(page);
 
-		await visitArticleNoOkta(page);
+// 		await visitArticleNoOkta(page);
 
-		await adSlotsArePresent(page);
-	});
+// 		await adSlotsAreNotPresent(page);
 
-	test(`Reject all, login as subscriber, ad slots are not present on multiple page loads`, async ({
-		page,
-		context,
-	}) => {
-		await setupFakeLogin(page, context, true);
+// 		await visitArticleNoOkta(page);
 
-		await visitArticleNoOkta(page);
+// 		await adSlotsAreNotPresent(page);
+// 	});
 
-		await cmpRejectAll(page);
+// 	test(`Reject all, login as non-subscriber, ad slots are present, log out, ad slots are present`, async ({
+// 		page,
+// 		context,
+// 	}) => {
+// 		await setupFakeLogin(page, context, false);
 
-		await visitArticleNoOkta(page);
+// 		await visitArticleNoOkta(page);
 
-		await adSlotsAreNotPresent(page);
+// 		await cmpRejectAll(page);
 
-		await visitArticleNoOkta(page);
+// 		await visitArticleNoOkta(page);
 
-		await adSlotsAreNotPresent(page);
-	});
+// 		await adSlotsArePresent(page);
 
-	test(`Reject all, login as non-subscriber, ad slots are present, log out, ad slots are present`, async ({
-		page,
-		context,
-	}) => {
-		await setupFakeLogin(page, context, false);
+// 		await fakeLogOut(context);
 
-		await visitArticleNoOkta(page);
+// 		await visitArticleNoOkta(page);
 
-		await cmpRejectAll(page);
+// 		await adSlotsArePresent(page);
+// 	});
 
-		await visitArticleNoOkta(page);
+// 	test(`Reject all, login as non-subscriber, ad slots are present, accept all, ad slots are fulfilled`, async ({
+// 		page,
+// 		context,
+// 	}) => {
+// 		await setupFakeLogin(page, context, false);
 
-		await adSlotsArePresent(page);
+// 		await visitArticleNoOkta(page);
 
-		await fakeLogOut(context);
+// 		await cmpRejectAll(page);
 
-		await visitArticleNoOkta(page);
+// 		await visitArticleNoOkta(page);
 
-		await adSlotsArePresent(page);
-	});
+// 		await adSlotsArePresent(page);
 
-	test(`Reject all, login as non-subscriber, ad slots are present, accept all, ad slots are fulfilled`, async ({
-		page,
-		context,
-	}) => {
-		await setupFakeLogin(page, context, false);
+// 		await cmpReconsent(page);
 
-		await visitArticleNoOkta(page);
+// 		await visitArticleNoOkta(page);
 
-		await cmpRejectAll(page);
-
-		await visitArticleNoOkta(page);
-
-		await adSlotsArePresent(page);
-
-		await cmpReconsent(page);
-
-		await visitArticleNoOkta(page);
-
-		await adSlotsAreFulfilled(page);
-	});
-});
+// 		await adSlotsAreFulfilled(page);
+// 	});
+// });

--- a/src/commercial.consentless.ts
+++ b/src/commercial.consentless.ts
@@ -7,10 +7,7 @@ import { initConsentless } from './lib/consentless/prepare-ootag';
 import { init as setAdTestCookie } from './lib/set-adtest-cookie';
 import { init as setAdTestInLabelsCookie } from './lib/set-adtest-in-labels-cookie';
 
-const bootConsentless = async (
-	consentState: ConsentState,
-	isDotcomRendering: boolean,
-): Promise<void> => {
+const bootConsentless = async (consentState: ConsentState): Promise<void> => {
 	const consentlessModuleList = [
 		setAdTestCookie(),
 		setAdTestInLabelsCookie(),
@@ -22,15 +19,6 @@ const bootConsentless = async (
 	];
 
 	//this is added so that we can load the subscriber cookie for DCR pages and correctly hide ads
-
-	if (isDotcomRendering) {
-		const userFeatures = await import(
-			/* webpackChunkName: "dcr" */
-			'lib/user-features'
-		);
-
-		consentlessModuleList.push(userFeatures.refresh());
-	}
 
 	await Promise.all(consentlessModuleList);
 

--- a/src/core/targeting/build-page-targeting.spec.ts
+++ b/src/core/targeting/build-page-targeting.spec.ts
@@ -2,8 +2,6 @@ import { cmp as cmp_ } from '@guardian/consent-management-platform';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import type { TCFv2ConsentState } from '@guardian/consent-management-platform/dist/types/tcfv2';
 import { setCookie, storage } from '@guardian/libs';
-import { getAuthStatus as getAuthStatus_ } from 'lib/identity/api';
-import type { AuthStatus } from 'lib/identity/api';
 import { getLocale as getLocale_ } from '../lib/get-locale';
 import type { Edition } from '../types';
 import { buildPageTargeting } from './build-page-targeting';
@@ -33,13 +31,8 @@ jest.mock('@guardian/consent-management-platform', () => ({
 
 jest.mock('../../lib/identity/api', () => ({
 	isUserLoggedInOktaRefactor: () => true,
-	getAuthStatus: jest.fn(),
 	getOptionsHeadersWithOkta: jest.fn(),
 }));
-
-const getAuthStatus = getAuthStatus_ as jest.MockedFunction<
-	typeof getAuthStatus_
->;
 
 const mockViewport = (width: number, height: number): void => {
 	Object.defineProperties(window, {
@@ -168,10 +161,6 @@ describe('Build Page Targeting', () => {
 		storage.local.setRaw('gu.alreadyVisited', String(0));
 
 		getLocale.mockReturnValue('US');
-
-		getAuthStatus.mockReturnValue(
-			Promise.resolve({ kind: 'SignedInWithOkta' } as AuthStatus),
-		);
 
 		jest.spyOn(global.Math, 'random').mockReturnValue(0.5);
 

--- a/src/lib/experiments/ab.spec.ts
+++ b/src/lib/experiments/ab.spec.ts
@@ -22,11 +22,11 @@ const concurrentTests = _concurrentTests as typeof concurrentTestsMock;
 
 // This is required as loading these seems to cause an error locally (and in CI)
 // because of some implicit dependency evil that I haven't been able to figure out.
-jest.mock('lib/user-features', () => ({
-	getLastOneOffContributionDate: () => null,
-	isRecurringContributor: () => false,
-	shouldNotBeShownSupportMessaging: () => false,
-}));
+// jest.mock('lib/user-features', () => ({
+// 	getLastOneOffContributionDate: () => null,
+// 	isRecurringContributor: () => false,
+// 	shouldNotBeShownSupportMessaging: () => false,
+// }));
 
 function emptyFunction() {
 	// do nothing

--- a/src/lib/experiments/ab.spec.ts
+++ b/src/lib/experiments/ab.spec.ts
@@ -20,14 +20,6 @@ const { overwriteMvtCookie } = _;
 
 const concurrentTests = _concurrentTests as typeof concurrentTestsMock;
 
-// This is required as loading these seems to cause an error locally (and in CI)
-// because of some implicit dependency evil that I haven't been able to figure out.
-// jest.mock('lib/user-features', () => ({
-// 	getLastOneOffContributionDate: () => null,
-// 	isRecurringContributor: () => false,
-// 	shouldNotBeShownSupportMessaging: () => false,
-// }));
-
 function emptyFunction() {
 	// do nothing
 }

--- a/src/lib/identity/api.ts
+++ b/src/lib/identity/api.ts
@@ -209,7 +209,6 @@ const getGoogleTagId = (): Promise<string | null> =>
 
 export {
 	isUserLoggedIn,
-	getAuthStatus,
 	getOptionsHeadersWithOkta,
 	isUserLoggedInOktaRefactor,
 	getGoogleTagId,

--- a/src/lib/user-features.spec.ts
+++ b/src/lib/user-features.spec.ts
@@ -24,7 +24,6 @@ jest.mock('lib/identity/api', () => ({
 jest.mock('lib/raven');
 jest.mock('lib/identity/api', () => ({
 	isUserLoggedInOktaRefactor: jest.fn(),
-	getAuthStatus: jest.fn(),
 	getOptionsHeadersWithOkta: jest.fn(),
 }));
 jest.mock('lib/utils/fetch-json', () => ({

--- a/src/lib/user-features.spec.ts
+++ b/src/lib/user-features.spec.ts
@@ -1,28 +1,26 @@
-import { getCookie } from '@guardian/libs';
 import { addCookie, removeCookie } from 'lib/cookies';
-import { fetchJson } from 'lib/utils/fetch-json';
-import type { UserFeaturesResponse } from 'types/membership';
-import type { AuthStatus } from './identity/api';
+import { isUserLoggedInOktaRefactor as isUserLoggedInOktaRefactor_ } from './identity/api';
 import {
-	getAuthStatus as getAuthStatus_,
-	isUserLoggedInOktaRefactor as isUserLoggedInOktaRefactor_,
-} from './identity/api';
-import {
-	accountDataUpdateWarning,
 	getDaysSinceLastOneOffContribution,
 	getLastOneOffContributionTimestamp,
-	getLastRecurringContributionDate,
-	getPurchaseInfo,
 	isAdFreeUser,
 	isDigitalSubscriber,
 	isPayingMember,
-	isPostAskPauseOneOffContributor,
 	isRecentOneOffContributor,
 	isRecurringContributor,
-	refresh,
 	shouldNotBeShownSupportMessaging,
 } from './user-features';
 
+const isUserLoggedInOktaRefactor =
+	isUserLoggedInOktaRefactor_ as jest.MockedFunction<
+		typeof isUserLoggedInOktaRefactor_
+	>;
+
+jest.mock('lib/identity/api', () => ({
+	isUserLoggedInOktaRefactor: jest.fn(),
+	getAuthStatus: jest.fn(),
+	getOptionsHeadersWithOkta: jest.fn(),
+}));
 jest.mock('lib/raven');
 jest.mock('lib/identity/api', () => ({
 	isUserLoggedInOktaRefactor: jest.fn(),
@@ -32,17 +30,6 @@ jest.mock('lib/identity/api', () => ({
 jest.mock('lib/utils/fetch-json', () => ({
 	fetchJson: jest.fn(() => Promise.resolve()),
 }));
-
-const fetchJsonSpy = fetchJson as jest.MockedFunction<typeof fetchJson>;
-
-const isUserLoggedInOktaRefactor =
-	isUserLoggedInOktaRefactor_ as jest.MockedFunction<
-		typeof isUserLoggedInOktaRefactor_
-	>;
-
-const getAuthStatus = getAuthStatus_ as jest.MockedFunction<
-	typeof getAuthStatus_
->;
 
 const PERSISTENCE_KEYS = {
 	USER_FEATURES_EXPIRY_COOKIE: 'gu_user_features_expiry',
@@ -60,166 +47,8 @@ const PERSISTENCE_KEYS = {
 		'gu.contributions.recurring.contrib-timestamp.Annual',
 };
 
-const setAllFeaturesData = (opts: { isExpired: boolean }) => {
-	const currentTime = new Date().getTime();
-	const msInOneDay = 24 * 60 * 60 * 1000;
-	const expiryDate = opts.isExpired
-		? new Date(currentTime - msInOneDay)
-		: new Date(currentTime + msInOneDay);
-	const adFreeExpiryDate = opts.isExpired
-		? new Date(currentTime - msInOneDay * 2)
-		: new Date(currentTime + msInOneDay * 2);
-	addCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE, 'true');
-	addCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE, 'true');
-	addCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE, 'true');
-	addCookie(PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE, 'true');
-	addCookie(
-		PERSISTENCE_KEYS.AD_FREE_USER_COOKIE,
-		adFreeExpiryDate.getTime().toString(),
-	);
-	addCookie(
-		PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
-		expiryDate.getTime().toString(),
-	);
-	addCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE, 'test');
-};
-
-const deleteAllFeaturesData = () => {
-	removeCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE);
-	removeCookie(PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE);
-	removeCookie(PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE);
-	removeCookie(PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE);
-	removeCookie(PERSISTENCE_KEYS.AD_FREE_USER_COOKIE);
-	removeCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE);
-	removeCookie(PERSISTENCE_KEYS.HIDE_SUPPORT_MESSAGING_COOKIE);
-};
-
 beforeAll(() => {
 	window.guardian.config.page.userAttributesApiUrl = '';
-});
-
-describe('Refreshing the features data', () => {
-	describe('If user signed in', () => {
-		beforeEach(() => {
-			jest.resetAllMocks();
-			isUserLoggedInOktaRefactor.mockResolvedValue(true);
-			getAuthStatus.mockResolvedValue({
-				kind: 'SignedInWithOkta',
-			} as AuthStatus);
-			fetchJsonSpy.mockReturnValue(Promise.resolve());
-		});
-
-		it('Performs an update if the user has missing data', async () => {
-			deleteAllFeaturesData();
-			await refresh();
-			expect(fetchJsonSpy).toHaveBeenCalledTimes(1);
-		});
-
-		it('Performs an update if the user has expired data', async () => {
-			setAllFeaturesData({ isExpired: true });
-			await refresh();
-			expect(fetchJsonSpy).toHaveBeenCalledTimes(1);
-		});
-
-		it('Does not delete the data just because it has expired', async () => {
-			setAllFeaturesData({ isExpired: true });
-			await refresh();
-			expect(
-				getCookie({ name: PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE }),
-			).toBe('true');
-			expect(
-				getCookie({
-					name: PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE,
-				}),
-			).toBe('true');
-			expect(
-				getCookie({
-					name: PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
-				}),
-			).toEqual(expect.stringMatching(/\d{13}/));
-			expect(
-				getCookie({ name: PERSISTENCE_KEYS.AD_FREE_USER_COOKIE }),
-			).toEqual(expect.stringMatching(/\d{13}/));
-		});
-
-		it('Does not perform update if user has fresh feature data', async () => {
-			setAllFeaturesData({ isExpired: false });
-			await refresh();
-			expect(fetchJsonSpy).not.toHaveBeenCalled();
-		});
-
-		it('Performs an update if membership-frontend wipes just the paying-member cookie', async () => {
-			// Set everything except paying-member cookie
-			setAllFeaturesData({ isExpired: true });
-			removeCookie(PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE);
-
-			await refresh();
-			expect(fetchJsonSpy).toHaveBeenCalledTimes(1);
-		});
-	});
-
-	describe('If user signed out', () => {
-		beforeEach(() => {
-			jest.resetAllMocks();
-			isUserLoggedInOktaRefactor.mockResolvedValue(false);
-			fetchJsonSpy.mockReturnValue(Promise.resolve());
-		});
-
-		it('Does not perform update, even if feature data missing', async () => {
-			deleteAllFeaturesData();
-			await refresh();
-			expect(fetchJsonSpy).not.toHaveBeenCalled();
-		});
-
-		it('Deletes leftover feature data', async () => {
-			setAllFeaturesData({ isExpired: false });
-			await refresh();
-			expect(
-				getCookie({ name: PERSISTENCE_KEYS.AD_FREE_USER_COOKIE }),
-			).toBeNull();
-			expect(
-				getCookie({ name: PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE }),
-			).toBeNull();
-			expect(
-				getCookie({
-					name: PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE,
-				}),
-			).toBeNull();
-			expect(
-				getCookie({ name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE }),
-			).toBeNull();
-			expect(
-				getCookie({
-					name: PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
-				}),
-			).toBeNull();
-		});
-	});
-});
-
-describe('The account data update warning getter', () => {
-	it('Is not set when the user is logged out', () => {
-		jest.resetAllMocks();
-		isUserLoggedInOktaRefactor.mockResolvedValue(false);
-		expect(accountDataUpdateWarning()).toBe(null);
-	});
-
-	describe('When the user is logged in', () => {
-		beforeEach(() => {
-			jest.resetAllMocks();
-			isUserLoggedInOktaRefactor.mockResolvedValue(true);
-		});
-
-		it('Is the same when the user has an account data update link cookie', () => {
-			addCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE, 'the-same');
-			expect(accountDataUpdateWarning()).toBe('the-same');
-		});
-
-		it('Is null when the user does not have an account data update link cookie', () => {
-			removeCookie(PERSISTENCE_KEYS.ACTION_REQUIRED_FOR_COOKIE);
-			expect(accountDataUpdateWarning()).toBe(null);
-		});
-	});
 });
 
 describe('The isAdFreeUser getter', () => {
@@ -352,121 +181,6 @@ describe('The shouldNotBeShownSupportMessaging getter', () => {
 	});
 });
 
-describe('Storing new feature data', () => {
-	beforeEach(() => {
-		const mockResponse: UserFeaturesResponse = {
-			userId: 'abc',
-			showSupportMessaging: false,
-			contentAccess: {
-				member: false,
-				paidMember: false,
-				recurringContributor: false,
-				digitalPack: false,
-				paperSubscriber: false,
-				guardianWeeklySubscriber: false,
-			},
-		};
-
-		jest.resetAllMocks();
-		fetchJsonSpy.mockReturnValue(Promise.resolve(mockResponse));
-		deleteAllFeaturesData();
-		isUserLoggedInOktaRefactor.mockResolvedValue(true);
-		getAuthStatus.mockResolvedValue({
-			kind: 'SignedInWithOkta',
-		} as AuthStatus);
-	});
-
-	it('Puts the paying-member state and ad-free state in appropriate cookie', () => {
-		fetchJsonSpy.mockReturnValueOnce(
-			Promise.resolve({
-				contentAccess: {
-					paidMember: false,
-					recurringContributor: false,
-					digitalPack: false,
-				},
-				adFree: false,
-			}),
-		);
-		return refresh().then(() => {
-			expect(
-				getCookie({ name: PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE }),
-			).toBe('false');
-			expect(
-				getCookie({
-					name: PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE,
-				}),
-			).toBe('false');
-			expect(
-				getCookie({ name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE }),
-			).toBe('false');
-			expect(
-				getCookie({ name: PERSISTENCE_KEYS.AD_FREE_USER_COOKIE }),
-			).toBeNull();
-		});
-	});
-
-	it('Puts the paying-member state and ad-free state in appropriate cookie', () => {
-		fetchJsonSpy.mockReturnValueOnce(
-			Promise.resolve({
-				contentAccess: {
-					paidMember: true,
-					recurringContributor: true,
-					digitalPack: true,
-				},
-				adFree: true,
-			}),
-		);
-		return refresh().then(() => {
-			expect(
-				getCookie({ name: PERSISTENCE_KEYS.PAYING_MEMBER_COOKIE }),
-			).toBe('true');
-			expect(
-				getCookie({
-					name: PERSISTENCE_KEYS.RECURRING_CONTRIBUTOR_COOKIE,
-				}),
-			).toBe('true');
-			expect(
-				getCookie({ name: PERSISTENCE_KEYS.DIGITAL_SUBSCRIBER_COOKIE }),
-			).toBe('true');
-			expect(
-				getCookie({ name: PERSISTENCE_KEYS.AD_FREE_USER_COOKIE }),
-			).toBeTruthy();
-			expect(
-				Number.isNaN(
-					parseInt(
-						// @ts-expect-error -- we’re testing it
-						getCookie({
-							name: PERSISTENCE_KEYS.AD_FREE_USER_COOKIE,
-						}),
-						10,
-					),
-				),
-			).toBe(false);
-		});
-	});
-
-	it('Puts an expiry date in an accompanying cookie', () =>
-		refresh().then(() => {
-			const expiryDate = getCookie({
-				name: PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
-			});
-			expect(expiryDate).toBeTruthy();
-			// @ts-expect-error -- we’re testing it
-			expect(Number.isNaN(parseInt(expiryDate, 10))).toBe(false);
-		}));
-
-	it('The expiry date is in the future', () =>
-		refresh().then(() => {
-			const expiryDateString = getCookie({
-				name: PERSISTENCE_KEYS.USER_FEATURES_EXPIRY_COOKIE,
-			});
-			// @ts-expect-error -- we’re testing it
-			const expiryDateEpoch = parseInt(expiryDateString, 10);
-			const currentTimeEpoch = new Date().getTime();
-			expect(currentTimeEpoch < expiryDateEpoch).toBe(true);
-		}));
-});
-
 const setSupportFrontendOneOffContributionCookie = (value: string) =>
 	addCookie(PERSISTENCE_KEYS.SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE, value);
 
@@ -511,60 +225,6 @@ describe('getting the last one-off contribution date of a user', () => {
 		expect(getLastOneOffContributionTimestamp()).toBe(
 			contributionDateTimeEpoch,
 		);
-	});
-});
-
-const setMonthlyContributionCookie = (value: string) =>
-	addCookie(PERSISTENCE_KEYS.SUPPORT_MONTHLY_CONTRIBUTION_COOKIE, value);
-
-const setAnnualContributionCookie = (value: string) =>
-	addCookie(PERSISTENCE_KEYS.SUPPORT_ANNUAL_CONTRIBUTION_COOKIE, value);
-
-const removeMonthlyContributionCookie = () =>
-	removeCookie(PERSISTENCE_KEYS.SUPPORT_MONTHLY_CONTRIBUTION_COOKIE);
-
-const removeAnnualContributionCookie = () =>
-	removeCookie(PERSISTENCE_KEYS.SUPPORT_ANNUAL_CONTRIBUTION_COOKIE);
-
-describe('getting the last recurring contribution date of a user', () => {
-	beforeEach(() => {
-		removeMonthlyContributionCookie();
-		removeAnnualContributionCookie();
-	});
-
-	const monthlyContributionTimestamp = 1556124724;
-	const annualContributionTimestamp = 1556125286;
-
-	it("returns null if the user isn't a recurring contributor", () => {
-		expect(getLastRecurringContributionDate()).toBe(null);
-	});
-
-	it('return the correct date if the user is a monthly recurring contributor', () => {
-		setMonthlyContributionCookie(monthlyContributionTimestamp.toString());
-		expect(getLastRecurringContributionDate()).toBe(
-			monthlyContributionTimestamp,
-		);
-	});
-
-	it('return the correct date if the user is a annual recurring contributor', () => {
-		setAnnualContributionCookie(annualContributionTimestamp.toString());
-		expect(getLastRecurringContributionDate()).toBe(
-			annualContributionTimestamp,
-		);
-	});
-
-	it('return the correct date if the user is both annual and monthly recurring contributor', () => {
-		setAnnualContributionCookie(annualContributionTimestamp.toString());
-		setMonthlyContributionCookie(monthlyContributionTimestamp.toString());
-		expect(getLastRecurringContributionDate()).toBe(
-			annualContributionTimestamp,
-		);
-	});
-
-	it('returns null if the cookie has been set with an invalid value', () => {
-		setAnnualContributionCookie('not a date string one');
-		setMonthlyContributionCookie('not a date string two');
-		expect(getLastRecurringContributionDate()).toBe(null);
 	});
 });
 
@@ -619,58 +279,5 @@ describe('isRecentOneOffContributor', () => {
 		global.Date.now = jest.fn(() => Date.parse('2019-08-01T13:00:30'));
 		setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
 		expect(isRecentOneOffContributor()).toBe(false);
-	});
-});
-
-describe('isPostAskPauseOneOffContributor', () => {
-	beforeEach(() => {
-		removeSupportFrontendOneOffContributionCookie();
-		removeAttributesOneOffContributionCookie();
-	});
-
-	const contributionDateTimeEpoch = String(
-		Date.parse('2018-08-01T12:00:30Z'),
-	);
-
-	it('returns false if there is no one-off contribution cookie', () => {
-		expect(isPostAskPauseOneOffContributor()).toBe(false);
-	});
-
-	it('returns false if there are 5 days between the last contribution date and now', () => {
-		global.Date.now = jest.fn(() => Date.parse('2018-08-07T10:50:34'));
-		setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
-		expect(isPostAskPauseOneOffContributor()).toBe(false);
-	});
-
-	it('returns true if the one-off contribution was more than 3 months ago', () => {
-		global.Date.now = jest.fn(() => Date.parse('2019-02-01T13:00:30'));
-		setSupportFrontendOneOffContributionCookie(contributionDateTimeEpoch);
-		expect(isPostAskPauseOneOffContributor()).toBe(true);
-	});
-});
-
-describe('getPurchaseInfo', () => {
-	afterEach(() => {
-		removeCookie('GU_CO_COMPLETE');
-	});
-
-	it('returns decoded cookie data', () => {
-		addCookie(
-			'GU_CO_COMPLETE',
-			'%7B%22userType%22%3A%22guest%22%2C%22product%22%3A%22DigitalPack%22%7D',
-		);
-		expect(getPurchaseInfo()).toEqual({
-			userType: 'guest',
-			product: 'DigitalPack',
-		});
-	});
-
-	it('returns undefined if cookie unset', () => {
-		expect(getPurchaseInfo()).toBeUndefined();
-	});
-
-	it('returns undefined if cookie data invalid', () => {
-		addCookie('GU_CO_COMPLETE', 'utter-nonsense');
-		expect(getPurchaseInfo()).toBeUndefined();
 	});
 });

--- a/src/lib/user-features.ts
+++ b/src/lib/user-features.ts
@@ -1,30 +1,12 @@
-import { getCookie, isObject, removeCookie, setCookie } from '@guardian/libs';
-import type { HeaderPayload } from '@guardian/support-dotcom-components/dist/dotcom/src/types';
-import { cookieIsExpiredOrMissing, timeInDaysFromNow } from 'lib/cookie';
-import {
-	adFreeDataIsPresent,
-	getAdFreeCookie,
-	setAdFreeCookie,
-} from 'lib/manage-ad-free-cookie';
-import { fetchJson } from 'lib/utils/fetch-json';
-import { noop } from 'lib/utils/noop';
+import { getCookie } from '@guardian/libs';
+import { adFreeDataIsPresent } from 'lib/manage-ad-free-cookie';
 import { dateDiffDays } from 'lib/utils/time-utils';
-import { getLocalDate } from 'types/dates';
-import type { LocalDate } from 'types/dates';
-import type { UserFeaturesResponse } from 'types/membership';
-import {
-	getAuthStatus,
-	getOptionsHeadersWithOkta,
-	isUserLoggedInOktaRefactor,
-} from './identity/api';
+import { isUserLoggedInOktaRefactor } from './identity/api';
 
 // Persistence keys
-const USER_FEATURES_EXPIRY_COOKIE = 'gu_user_features_expiry';
 const PAYING_MEMBER_COOKIE = 'gu_paying_member';
-const ACTION_REQUIRED_FOR_COOKIE = 'gu_action_required_for';
 const DIGITAL_SUBSCRIBER_COOKIE = 'gu_digital_subscriber';
 const HIDE_SUPPORT_MESSAGING_COOKIE = 'gu_hide_support_messaging';
-const AD_FREE_USER_COOKIE = 'GU_AF1';
 
 // These cookies come from the user attributes API
 const RECURRING_CONTRIBUTOR_COOKIE = 'gu_recurring_contributor';
@@ -39,174 +21,17 @@ const SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE =
 const SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE =
 	'gu.contributions.contrib-timestamp';
 
-const ARTICLES_VIEWED_OPT_OUT_COOKIE = {
-	name: 'gu_article_count_opt_out',
-	daysToLive: 90,
-};
-
-const CONTRIBUTIONS_REMINDER_SIGNED_UP = {
-	name: 'gu_contributions_reminder_signed_up',
-	daysToLive: 90,
-};
-
-// TODO: isn’t this duplicated from commercial features?
-// https://github.com/guardian/frontend/blob/2a222cfb77748aa1140e19adca10bfc688fe6cad/static/src/javascriplib/commercial-features.ts
-const forcedAdFreeMode = !!/[#&]noadsaf(&.*)?$/.exec(window.location.hash);
-
-const userHasData = () => {
-	const cookie =
-		getAdFreeCookie() ??
-		getCookie({ name: ACTION_REQUIRED_FOR_COOKIE }) ??
-		getCookie({ name: USER_FEATURES_EXPIRY_COOKIE }) ??
-		getCookie({ name: PAYING_MEMBER_COOKIE }) ??
-		getCookie({ name: RECURRING_CONTRIBUTOR_COOKIE }) ??
-		getCookie({ name: ONE_OFF_CONTRIBUTION_DATE_COOKIE }) ??
-		getCookie({ name: DIGITAL_SUBSCRIBER_COOKIE }) ??
-		getCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE });
-	return !!cookie;
-};
-
-const accountDataUpdateWarning = (): string | null =>
-	getCookie({ name: ACTION_REQUIRED_FOR_COOKIE });
-
-/**
- * TODO: check that this validation is accurate
- */
-const validateResponse = (
-	response: unknown,
-): response is UserFeaturesResponse => {
-	if (!isObject(response)) return false;
-
-	if (
-		typeof response.showSupportMessaging === 'boolean' &&
-		isObject(response.contentAccess) &&
-		typeof response.contentAccess.paidMember === 'boolean' &&
-		typeof response.contentAccess.recurringContributor === 'boolean' &&
-		typeof response.contentAccess.digitalPack === 'boolean'
-	) {
-		return true;
-	}
-
-	return true;
-};
-
-const persistResponse = (JsonResponse: UserFeaturesResponse) => {
-	setCookie({
-		name: USER_FEATURES_EXPIRY_COOKIE,
-		value: timeInDaysFromNow(1),
-	});
-	setCookie({
-		name: PAYING_MEMBER_COOKIE,
-		value: String(JsonResponse.contentAccess.paidMember),
-	});
-	setCookie({
-		name: RECURRING_CONTRIBUTOR_COOKIE,
-		value: String(JsonResponse.contentAccess.recurringContributor),
-	});
-	setCookie({
-		name: DIGITAL_SUBSCRIBER_COOKIE,
-		value: String(JsonResponse.contentAccess.digitalPack),
-	});
-	setCookie({
-		name: HIDE_SUPPORT_MESSAGING_COOKIE,
-		value: String(!JsonResponse.showSupportMessaging),
-	});
-	if (JsonResponse.oneOffContributionDate) {
-		setCookie({
-			name: ONE_OFF_CONTRIBUTION_DATE_COOKIE,
-			value: JsonResponse.oneOffContributionDate,
-		});
-	}
-
-	removeCookie({ name: ACTION_REQUIRED_FOR_COOKIE });
-	if (JsonResponse.alertAvailableFor) {
-		setCookie({
-			name: ACTION_REQUIRED_FOR_COOKIE,
-			value: JsonResponse.alertAvailableFor,
-		});
-	}
-
-	if (JsonResponse.contentAccess.digitalPack) {
-		setAdFreeCookie(2);
-	} else if (adFreeDataIsPresent() && !forcedAdFreeMode) {
-		removeCookie({ name: AD_FREE_USER_COOKIE });
-	}
-};
-
-const deleteOldData = (): void => {
-	// We expect adfree cookies to be cleaned up by the logout process, but what if the user's login simply times out?
-	removeCookie({ name: AD_FREE_USER_COOKIE });
-	removeCookie({ name: USER_FEATURES_EXPIRY_COOKIE });
-	removeCookie({ name: PAYING_MEMBER_COOKIE });
-	removeCookie({ name: RECURRING_CONTRIBUTOR_COOKIE });
-	removeCookie({ name: ACTION_REQUIRED_FOR_COOKIE });
-	removeCookie({ name: DIGITAL_SUBSCRIBER_COOKIE });
-	removeCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE });
-	removeCookie({ name: ONE_OFF_CONTRIBUTION_DATE_COOKIE });
-};
-
-const requestNewData = () => {
-	return getAuthStatus()
-		.then((authStatus) =>
-			authStatus.kind === 'SignedInWithCookies' ||
-			authStatus.kind === 'SignedInWithOkta'
-				? authStatus
-				: Promise.reject('The user is not signed in'),
-		)
-		.then((signedInAuthStatus) => {
-			return fetchJson(
-				`${
-					window.guardian.config.page.userAttributesApiUrl ??
-					'/USER_ATTRIBUTE_API_NOT_FOUND'
-				}/me`,
-				{
-					mode: 'cors',
-					...getOptionsHeadersWithOkta(signedInAuthStatus),
-				},
-			)
-				.then((response) => {
-					if (!validateResponse(response)) {
-						throw new Error('invalid response');
-					}
-					return response;
-				})
-				.then(persistResponse)
-				.catch(noop);
-		});
-};
-
-const featuresDataIsOld = () =>
-	cookieIsExpiredOrMissing(USER_FEATURES_EXPIRY_COOKIE);
-
 const isDigitalSubscriber = (): boolean =>
 	getCookie({ name: DIGITAL_SUBSCRIBER_COOKIE }) === 'true';
-
-const userNeedsNewFeatureData = (): boolean =>
-	featuresDataIsOld() || (isDigitalSubscriber() && !adFreeDataIsPresent());
-
-const userHasDataAfterSignout = async (): Promise<boolean> =>
-	!(await isUserLoggedInOktaRefactor()) && userHasData();
-
-/**
- * Updates the user's data in a lazy fashion
- */
-const refresh = async (): Promise<void> => {
-	if ((await isUserLoggedInOktaRefactor()) && userNeedsNewFeatureData()) {
-		return requestNewData();
-	} else if ((await userHasDataAfterSignout()) && !forcedAdFreeMode) {
-		deleteOldData();
-	}
-	return Promise.resolve();
-};
 
 const supportSiteRecurringCookiePresent = () =>
 	getCookie({ name: SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE }) != null ||
 	getCookie({ name: SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE }) != null;
 
-/**
- * Does our _existing_ data say the user is a paying member?
- * This data may be stale; we do not wait for userFeatures.refresh()
- */
+// /**
+//  * Does our _existing_ data say the user is a paying member?
+//  * This data may be stale; we do not wait for userFeatures.refresh()
+//  */
 const isPayingMember = async (): Promise<boolean> =>
 	// If the user is logged in, but has no cookie yet, play it safe and assume they're a paying user
 	(await isUserLoggedInOktaRefactor()) &&
@@ -246,47 +71,6 @@ const getLastOneOffContributionTimestamp = (): number | null =>
 	getSupportFrontendOneOffContributionTimestamp() ??
 	getAttributesOneOffContributionTimestamp();
 
-const getLastOneOffContributionDate = (): LocalDate | null => {
-	const timestamp = getLastOneOffContributionTimestamp();
-
-	if (timestamp === null) {
-		return null;
-	}
-
-	const date = new Date(timestamp);
-	const year = date.getUTCFullYear();
-	const month = date.getUTCMonth() + 1;
-	const day = date.getUTCDate();
-
-	return getLocalDate(year, month, day);
-};
-
-const getLastRecurringContributionDate = (): number | null => {
-	// Check for cookies, ensure that cookies parse, and ensure parsed results are integers
-	const monthlyCookie = getCookie({
-		name: SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE,
-	});
-	const annualCookie = getCookie({
-		name: SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE,
-	});
-	const monthlyTime = monthlyCookie ? parseInt(monthlyCookie, 10) : null;
-	const annualTime = annualCookie ? parseInt(annualCookie, 10) : null;
-	const monthlyMS =
-		monthlyTime && Number.isInteger(monthlyTime) ? monthlyTime : null;
-	const annualMS =
-		annualTime && Number.isInteger(annualTime) ? annualTime : null;
-
-	if (!monthlyMS && !annualMS) {
-		return null;
-	}
-
-	if (monthlyMS && annualMS) {
-		return Math.max(monthlyMS, annualMS);
-	}
-
-	return monthlyMS ?? annualMS ?? null;
-};
-
 const getDaysSinceLastOneOffContribution = (): number | null => {
 	const lastContributionDate = getLastOneOffContributionTimestamp();
 	if (lastContributionDate === null) {
@@ -304,15 +88,6 @@ const isRecentOneOffContributor = (askPauseDays = 90): boolean => {
 	return daysSinceLastContribution <= askPauseDays;
 };
 
-// true if the user has completed their ask-free period
-const isPostAskPauseOneOffContributor = (askPauseDays = 90): boolean => {
-	const daysSinceLastContribution = getDaysSinceLastOneOffContribution();
-	if (daysSinceLastContribution === null) {
-		return false;
-	}
-	return daysSinceLastContribution > askPauseDays;
-};
-
 const isRecurringContributor = async (): Promise<boolean> =>
 	((await isUserLoggedInOktaRefactor()) &&
 		getCookie({ name: RECURRING_CONTRIBUTOR_COOKIE }) !== 'false') ||
@@ -321,105 +96,35 @@ const isRecurringContributor = async (): Promise<boolean> =>
 const shouldNotBeShownSupportMessaging = (): boolean =>
 	getCookie({ name: HIDE_SUPPORT_MESSAGING_COOKIE }) === 'true';
 
-/*
-    Whenever the checks are updated, please make sure to update
-    applyRenderConditions.scala.js too, where the global CSS class, indicating
-    the user should not see the revenue messages, is added to the body.
-    Please also update readerRevenueRelevantCookies below, if changing the cookies
-    which this function is dependent on.
-*/
-
 const shouldHideSupportMessaging = async (): Promise<boolean> =>
 	shouldNotBeShownSupportMessaging() ||
 	isRecentOneOffContributor() || // because members-data-api is unaware of one-off contributions so relies on cookie
 	(await isRecurringContributor()); // guest checkout means that members-data-api isn't aware of all recurring contributions so relies on cookie
 
-const readerRevenueRelevantCookies = [
-	PAYING_MEMBER_COOKIE,
-	DIGITAL_SUBSCRIBER_COOKIE,
-	RECURRING_CONTRIBUTOR_COOKIE,
-	SUPPORT_RECURRING_CONTRIBUTOR_MONTHLY_COOKIE,
-	SUPPORT_RECURRING_CONTRIBUTOR_ANNUAL_COOKIE,
-	SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-	HIDE_SUPPORT_MESSAGING_COOKIE,
-];
-
-// For debug/test purposes
-const fakeOneOffContributor = (): void => {
-	setCookie({
-		name: SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-		value: Date.now().toString(),
-	});
-};
-
 const isAdFreeUser = (): boolean =>
 	isDigitalSubscriber() || adFreeDataIsPresent();
 
-// Extend the expiry of the contributions cookie by 1 year beyond the date of the contribution
-const extendContribsCookieExpiry = (): void => {
-	const cookie = getCookie({ name: SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE });
-	if (cookie) {
-		const contributionDate = parseInt(cookie, 10);
-		if (Number.isInteger(contributionDate)) {
-			const daysToLive = 365 - dateDiffDays(contributionDate, Date.now());
-			setCookie({
-				name: SUPPORT_ONE_OFF_CONTRIBUTION_COOKIE,
-				value: contributionDate.toString(),
-				daysToLive,
-			});
-		}
-	}
-};
-
-const canShowContributionsReminderFeature = (): boolean => {
-	const signedUpForReminder = !!getCookie({
-		name: CONTRIBUTIONS_REMINDER_SIGNED_UP.name,
-	});
-	const { switches } = window.guardian.config;
-
-	return Boolean(switches.showContributionReminder) && !signedUpForReminder;
-};
-
-type PurchaseInfo = HeaderPayload['targeting']['purchaseInfo'];
-const getPurchaseInfo = (): PurchaseInfo => {
-	const purchaseInfoRaw = getCookie({ name: 'GU_CO_COMPLETE' });
-
-	if (!purchaseInfoRaw) {
-		return undefined;
-	}
-
-	let purchaseInfo: PurchaseInfo = undefined;
-
-	try {
-		purchaseInfo = JSON.parse(
-			decodeURIComponent(purchaseInfoRaw),
-		) as PurchaseInfo;
-	} catch {} // eslint-disable-line no-empty -- silently handle error
-
-	return purchaseInfo;
-};
-
 export {
-	accountDataUpdateWarning,
+	// 	accountDataUpdateWarning,
 	isAdFreeUser,
 	isPayingMember,
 	isRecentOneOffContributor,
 	isRecurringContributor,
 	isDigitalSubscriber,
-	refresh,
-	deleteOldData,
+	// 	refresh,
+	// 	deleteOldData,
 	getLastOneOffContributionTimestamp,
-	getLastOneOffContributionDate,
-	getLastRecurringContributionDate,
+	// 	getLastOneOffContributionDate,
+	// 	getLastRecurringContributionDate,
 	getDaysSinceLastOneOffContribution,
-	getPurchaseInfo,
-	isPostAskPauseOneOffContributor,
-	readerRevenueRelevantCookies,
-	fakeOneOffContributor,
+	// 	getPurchaseInfo,
+	// 	isPostAskPauseOneOffContributor,
+	// 	readerRevenueRelevantCookies,
+	// 	fakeOneOffContributor,
 	shouldNotBeShownSupportMessaging,
-	extendContribsCookieExpiry,
-	ARTICLES_VIEWED_OPT_OUT_COOKIE,
-	CONTRIBUTIONS_REMINDER_SIGNED_UP,
-	canShowContributionsReminderFeature,
+	// 	extendContribsCookieExpiry,
+	// 	ARTICLES_VIEWED_OPT_OUT_COOKIE,
+	// 	CONTRIBUTIONS_REMINDER_SIGNED_UP,
+	// 	canShowContributionsReminderFeature,
 	shouldHideSupportMessaging,
 };

--- a/src/lib/user-features.ts
+++ b/src/lib/user-features.ts
@@ -105,26 +105,13 @@ const isAdFreeUser = (): boolean =>
 	isDigitalSubscriber() || adFreeDataIsPresent();
 
 export {
-	// 	accountDataUpdateWarning,
 	isAdFreeUser,
 	isPayingMember,
 	isRecentOneOffContributor,
 	isRecurringContributor,
 	isDigitalSubscriber,
-	// 	refresh,
-	// 	deleteOldData,
 	getLastOneOffContributionTimestamp,
-	// 	getLastOneOffContributionDate,
-	// 	getLastRecurringContributionDate,
 	getDaysSinceLastOneOffContribution,
-	// 	getPurchaseInfo,
-	// 	isPostAskPauseOneOffContributor,
-	// 	readerRevenueRelevantCookies,
-	// 	fakeOneOffContributor,
 	shouldNotBeShownSupportMessaging,
-	// 	extendContribsCookieExpiry,
-	// 	ARTICLES_VIEWED_OPT_OUT_COOKIE,
-	// 	CONTRIBUTIONS_REMINDER_SIGNED_UP,
-	// 	canShowContributionsReminderFeature,
 	shouldHideSupportMessaging,
 };

--- a/src/standalone.commercial.ts
+++ b/src/standalone.commercial.ts
@@ -50,8 +50,7 @@ import { catchErrorsWithContext } from 'lib/utils/robust';
 
 type Modules = Array<[`${string}-${string}`, () => Promise<unknown>]>;
 
-const { isDotcomRendering, frontendAssetsFullURL, switches, page } =
-	window.guardian.config;
+const { frontendAssetsFullURL, switches, page } = window.guardian.config;
 
 const decideAssetsPath = () => {
 	if (process.env.OVERRIDE_BUNDLE_PATH) {
@@ -113,17 +112,6 @@ if (!commercialFeatures.adFree) {
  * Not sure if this is needed. Currently no separate chunk is created
  * Introduced by @tomrf1
  */
-const loadDcrBundle = async (): Promise<void> => {
-	if (!isDotcomRendering) return;
-
-	const userFeatures = await import(
-		/* webpackChunkName: "dcr" */
-		'lib/user-features'
-	);
-
-	commercialExtraModules.push(['c-user-features', userFeatures.refresh]);
-	return;
-};
 
 const loadModules = (modules: Modules, eventName: string) => {
 	const modulePromises: Array<Promise<unknown>> = [];
@@ -199,8 +187,6 @@ const bootCommercial = async (): Promise<void> => {
 	};
 
 	try {
-		await loadDcrBundle();
-
 		const allModules: Array<Parameters<typeof loadModules>> = [
 			[commercialBaseModules, 'commercialBaseModulesLoaded'],
 			[commercialExtraModules, 'commercialExtraModulesLoaded'],
@@ -239,9 +225,7 @@ const chooseAdvertisingTag = async () => {
 		void import(
 			/* webpackChunkName: "consentless" */
 			'./commercial.consentless'
-		).then(({ bootConsentless }) =>
-			bootConsentless(consentState, isDotcomRendering),
-		);
+		).then(({ bootConsentless }) => bootConsentless(consentState));
 	} else {
 		bootCommercialWhenReady();
 	}

--- a/src/standalone.commercial.ts
+++ b/src/standalone.commercial.ts
@@ -107,12 +107,6 @@ if (!commercialFeatures.adFree) {
 	);
 }
 
-/**
- * Load modules specific to `dotcom-rendering`.
- * Not sure if this is needed. Currently no separate chunk is created
- * Introduced by @tomrf1
- */
-
 const loadModules = (modules: Modules, eventName: string) => {
 	const modulePromises: Array<Promise<unknown>> = [];
 


### PR DESCRIPTION

<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?
This pull request removes all references to the 'user-features' module from the project. The 'user-features' module was previously used for managing user-related data and features but is no longer needed in this codebase.


**Important Note**
Some functions from 'user-features' are still required for specific features like `adblock-ask.ts` and `commercial-features.ts`, which rely on functions like shouldHideSupportMessaging() and isAdFreeUser(). To accommodate this, a partial user-features.ts file has been retained for these functions.

This may not be a desirable long term solution but allows us to successfully test the user-features being set in one place (dotcom-rendering)
A discussion could be had regarding a centralised place for these functions eg. https://github.com/guardian/csnx/tree/main/libs/%40guardian


## Why?
The 'user-features' module is no longer needed in this codebase as its functionality has been ported over to the `dotcom-rendering` repository. This change prevents redundant setting and retrieval of cookies, as user state management is now handled by 'dotcom-rendering'.

This revised version maintains the essential information while being somewhat more concise and to the point. It still explains the purpose and the reason for the change.


## Testing
- The  [beta] @guardian/commercial label has been added to this PR, releasing a beta version of the bundle to NPM.
- Frontend deployed to CODE in https://github.com/guardian/frontend/pull/26673 to boot this version commercial.
- 


| **Cookies in browser** |
|:------------------|
|   <img width="350" alt="Screenshot 2023-11-03 at 09 52 51" src="https://github.com/guardian/commercial/assets/49187886/5e7ab203-6044-418d-9a93-e420dfab926d">     | 
