### PR TITLE
Refactor: separate inline1 and inline2+ slot insertion into separate functions

### DIFF
--- a/src/lib/dfp/on-slot-viewable.ts
+++ b/src/lib/dfp/on-slot-viewable.ts
@@ -3,14 +3,14 @@ import { outstreamSizes } from 'core/ad-sizes';
 import { AD_LABEL_HEIGHT } from 'core/constants/ad-label-height';
 import fastdom from 'lib/fastdom-promise';
 import { getUrlVars } from 'lib/utils/url';
-import { isAdSize } from './Advert';
 import type { Advert } from './Advert';
+import { isAdSize } from './Advert';
 import { getAdvertById } from './get-advert-by-id';
 import { enableLazyLoad } from './lazy-load';
 import { memoizedFetchNonRefreshableLineItemIds } from './non-refreshable-line-items';
 import { shouldRefresh } from './should-refresh';
 
-const ADVERT_REFRESH_RATE = 30_000; // 30 seconds
+const ADVERT_REFRESH_RATE = 30_000; // 30 seconds. The minimum time allowed by Google.
 
 /**
  * Prevent CLS when an advert is refreshed, by setting the

--- a/src/lib/spacefinder/article-body-adverts.ts
+++ b/src/lib/spacefinder/article-body-adverts.ts
@@ -166,7 +166,6 @@ const addDesktopInline1 = (): Promise<boolean> => {
 				minBelow: 0,
 			},
 		},
-		filter: filterNearbyCandidates(adSizes.mpu.height),
 	};
 
 	// these are added here and not in size mappings because the inline[i] name
@@ -218,6 +217,7 @@ const addDesktopInline2PlusAds = (): Promise<boolean> => {
 		minAbove += 100;
 	}
 
+	const largestSizeForSlot = adSizes.halfPage.height;
 	const rules: SpacefinderRules = {
 		bodySelector: articleBodySelector,
 		slotSelector: ' > p',
@@ -230,7 +230,7 @@ const addDesktopInline2PlusAds = (): Promise<boolean> => {
 				minBelow: 600,
 			},
 		},
-		filter: filterNearbyCandidates(adSizes.halfPage.height),
+		filter: filterNearbyCandidates(largestSizeForSlot),
 	};
 
 	const insertAds: SpacefinderWriter = async (paras) => {
@@ -258,20 +258,22 @@ const addDesktopInline2PlusAds = (): Promise<boolean> => {
 				className: containerClasses,
 			};
 
+			// these are added here and not in size mappings because the inline[i] name
+			// is also used on fronts, where we don't want outstream or tall ads
+			const additionalSizes = {
+				desktop: await decideAdditionalSizes(
+					para,
+					[adSizes.halfPage, adSizes.skyscraper],
+					isLastInline,
+				),
+			};
+
 			return insertAdAtPara(
 				para,
 				`inline${i + 2}`,
 				'inline',
 				'inline',
-				// these are added here and not in size mappings because the inline[i] name
-				// is also used on fronts, where we don't want outstream or tall ads
-				{
-					desktop: await decideAdditionalSizes(
-						para,
-						[adSizes.halfPage, adSizes.skyscraper],
-						isLastInline,
-					),
-				},
+				additionalSizes,
 				containerOptions,
 			);
 		});

--- a/src/lib/spacefinder/article-body-adverts.ts
+++ b/src/lib/spacefinder/article-body-adverts.ts
@@ -130,7 +130,7 @@ const decideAdditionalSizes = async (
 	);
 };
 
-const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
+const addDesktopInline1 = (): Promise<boolean> => {
 	const tweakpoint = getCurrentTweakpoint();
 	const hasLeftCol = ['leftCol', 'wide'].includes(tweakpoint);
 
@@ -142,7 +142,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 
 	const isImmersive = window.guardian.config.page.isImmersive;
 
-	const firstInlineRules: SpacefinderRules = {
+	const rules: SpacefinderRules = {
 		bodySelector: articleBodySelector,
 		slotSelector: ' > p',
 		minAbove: isImmersive ? 700 : 300,
@@ -169,6 +169,39 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 		filter: filterNearbyCandidates(adSizes.mpu.height),
 	};
 
+	// these are added here and not in size mappings because the inline[i] name
+	// is also used on fronts, where we don't want outstream or tall ads
+	const additionalSizes = {
+		phablet: [adSizes.outstreamDesktop, adSizes.outstreamGoogleDesktop],
+		desktop: [adSizes.outstreamDesktop, adSizes.outstreamGoogleDesktop],
+	};
+
+	const insertAd: SpacefinderWriter = async (paras) => {
+		const slots = paras.slice(0, 1).map(async (para) => {
+			return insertAdAtPara(
+				para,
+				'inline1',
+				'inline',
+				'inline',
+				additionalSizes,
+			);
+		});
+
+		await Promise.all(slots);
+	};
+
+	return spaceFiller.fillSpace(rules, insertAd, {
+		waitForImages: true,
+		waitForInteractives: true,
+		pass: 'inline1',
+	});
+};
+
+/**
+ * Inserts all inline ads on desktop except for inline1.
+ *
+ */
+const addDesktopInline2PlusAds = (): Promise<boolean> => {
 	let minAbove = 1000;
 
 	/**
@@ -185,7 +218,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 		minAbove += 100;
 	}
 
-	const subsequentInlineRules: SpacefinderRules = {
+	const rules: SpacefinderRules = {
 		bodySelector: articleBodySelector,
 		slotSelector: ' > p',
 		minAbove,
@@ -200,76 +233,48 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 		filter: filterNearbyCandidates(adSizes.halfPage.height),
 	};
 
-	const rules = isInline1 ? firstInlineRules : subsequentInlineRules;
-
 	const insertAds: SpacefinderWriter = async (paras) => {
-		// Make ads sticky on the non-inline1 pass
-		// i.e. inline2, inline3, etc...
-		const isSticky = !isInline1;
+		const stickyContainerHeights = await computeStickyHeights(
+			paras,
+			articleBodySelector,
+		);
 
-		if (isSticky) {
-			const stickyContainerHeights = await computeStickyHeights(
-				paras,
-				articleBodySelector,
+		void insertHeightStyles(
+			stickyContainerHeights.map((height, index) => [
+				getStickyContainerClassname(index),
+				height,
+			]),
+		);
+
+		const slots = paras.slice(0, paras.length).map(async (para, i) => {
+			const isLastInline = i === paras.length - 1;
+
+			const containerClasses =
+				getStickyContainerClassname(i) +
+				' offset-right ad-slot--offset-right ad-slot-container--offset-right';
+
+			const containerOptions = {
+				sticky: true,
+				className: containerClasses,
+			};
+
+			return insertAdAtPara(
+				para,
+				`inline${i + 2}`,
+				'inline',
+				'inline',
+				// these are added here and not in size mappings because the inline[i] name
+				// is also used on fronts, where we don't want outstream or tall ads
+				{
+					desktop: await decideAdditionalSizes(
+						para,
+						[adSizes.halfPage, adSizes.skyscraper],
+						isLastInline,
+					),
+				},
+				containerOptions,
 			);
-
-			void insertHeightStyles(
-				stickyContainerHeights.map((height, index) => [
-					getStickyContainerClassname(index),
-					height,
-				]),
-			);
-		}
-
-		const slots = paras
-			.slice(0, isInline1 ? 1 : paras.length)
-			.map(async (para, i) => {
-				const inlineId = i + (isInline1 ? 1 : 2);
-				const isLastInline = i === paras.length - 1;
-
-				let containerClasses = '';
-
-				if (isSticky) {
-					containerClasses += getStickyContainerClassname(i);
-				}
-
-				if (!isInline1) {
-					containerClasses +=
-						' offset-right ad-slot--offset-right ad-slot-container--offset-right';
-				}
-
-				const containerOptions = {
-					sticky: isSticky,
-					className: containerClasses,
-				};
-
-				return insertAdAtPara(
-					para,
-					`inline${inlineId}`,
-					'inline',
-					'inline',
-					// these are added here and not in size mappings because the inline[i] name is also used on fronts, where we don't want outstream or tall ads
-					isInline1
-						? {
-								phablet: [
-									adSizes.outstreamDesktop,
-									adSizes.outstreamGoogleDesktop,
-								],
-								desktop: [
-									adSizes.outstreamDesktop,
-									adSizes.outstreamGoogleDesktop,
-								],
-						  }
-						: {
-								desktop: await decideAdditionalSizes(
-									para,
-									[adSizes.halfPage, adSizes.skyscraper],
-									isLastInline,
-								),
-						  },
-					containerOptions,
-				);
-			});
+		});
 
 		await Promise.all(slots);
 	};
@@ -277,7 +282,7 @@ const addDesktopInlineAds = (isInline1: boolean): Promise<boolean> => {
 	return spaceFiller.fillSpace(rules, insertAds, {
 		waitForImages: true,
 		waitForInteractives: true,
-		pass: isInline1 ? 'inline1' : 'inline2',
+		pass: 'inline2',
 	});
 };
 
@@ -329,14 +334,17 @@ const addMobileInlineAds = (): Promise<boolean> => {
 
 const addInlineAds = (): Promise<boolean> => {
 	const isMobile = getCurrentBreakpoint() === 'mobile';
-
 	if (isMobile) {
 		return addMobileInlineAds();
 	}
+
 	if (isPaidContent) {
-		return addDesktopInlineAds(false);
+		return addDesktopInline2PlusAds();
 	}
-	return addDesktopInlineAds(true).then(() => addDesktopInlineAds(false));
+
+	// Add the rest of the inline ad slots after a position for inline1 has been found.
+	// We don't wan't inline1 and inline2 targeting the same paragraph.
+	return addDesktopInline1().then(() => addDesktopInline2PlusAds());
 };
 
 const attemptToAddInlineMerchAd = (): Promise<boolean> => {


### PR DESCRIPTION
## What does this change?

- This change is a small refactor of the addDesktopInlineAds function
- This function includes logic for inserting inline1 and then as many inlines (inline2, inline3, etc) as will fit.
- The function has been split into two smaller functions: `addDesktopInline1` and `addDesktopInline2PlusAds`

## Why?

- The logic for inserting inline1 and further inlines is very different and is confusing to follow. Splitting this function into two makes it easier to follow the logic for how the inline1 is inserted. Similarly for inline2+.