### PR TITLE
Provide the full hash for prebid in dependencies

### DIFF
--- a/.changeset/thin-goats-lay.md
+++ b/.changeset/thin-goats-lay.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Use the full hash for the link to `guardian/prebid.js` in deps

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",
 		"ophan-tracker-js": "^2.0.1",
-		"prebid.js": "guardian/prebid.js#0b4cccd",
+		"prebid.js": "guardian/prebid.js#0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5",
 		"process": "^0.11.10",
 		"raven-js": "^3.27.2",
 		"tslib": "^2.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6911,7 +6911,7 @@ playwright-core@1.37.1:
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.37.1.tgz#cb517d52e2e8cb4fa71957639f1cd105d1683126"
   integrity sha512-17EuQxlSIYCmEMwzMqusJ2ztDgJePjrbttaefgdsiqeLWidjYz9BxXaTaZWxH1J95SHGk6tjE+dwgWILJoUZfA==
 
-prebid.js@guardian/prebid.js#0b4cccd:
+prebid.js@guardian/prebid.js#0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5:
   version "7.54.5"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/0b4cccd55ab4e170b36bb944e9bdd2807a9da1c5"
   dependencies:


### PR DESCRIPTION
## What does this change?

add the full hash for the link to the prebid commit

## Why?

yarn 4 won't stand for the short hash