### PR TITLE
New ad sizes for merchandising slots

### DIFF
--- a/.changeset/warm-seas-grow.md
+++ b/.changeset/warm-seas-grow.md
@@ -1,0 +1,5 @@
+---
+"@guardian/commercial": minor
+---
+
+Show MPUs and Billboard ads in merchandising and merchandising-high slots

--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -342,12 +342,30 @@ const slotSizeMappings = {
 			adSizes.merchandisingHigh,
 			adSizes.fluid,
 		],
+		// The mobile mapping is given an additional size when filling the slot.
+		// We do not want this extra size applied to tablet, so we provide a
+		// mapping for tablet here.
+		tablet: [
+			adSizes.outOfPage,
+			adSizes.empty,
+			adSizes.merchandisingHigh,
+			adSizes.fluid,
+		],
 	},
 	'merchandising-high-lucky': {
 		mobile: [adSizes.outOfPage, adSizes.empty, adSizes.fluid],
 	},
 	merchandising: {
 		mobile: [
+			adSizes.outOfPage,
+			adSizes.empty,
+			adSizes.merchandising,
+			adSizes.fluid,
+		],
+		// The mobile mapping is given an additional size when filling the slot.
+		// We do not want this extra size applied to tablet, so we provide a
+		// mapping for tablet here.
+		tablet: [
 			adSizes.outOfPage,
 			adSizes.empty,
 			adSizes.merchandising,

--- a/src/lib/dfp/ads-in-merchandising-test.ts
+++ b/src/lib/dfp/ads-in-merchandising-test.ts
@@ -1,0 +1,6 @@
+import { isInVariantSynchronous } from 'lib/experiments/ab';
+import { adsInMerch } from 'lib/experiments/tests/ads-in-merch';
+
+export const includeAdsInMerch = () => {
+	return isInVariantSynchronous(adsInMerch, 'variant');
+};

--- a/src/lib/dfp/fill-static-advert-slots.ts
+++ b/src/lib/dfp/fill-static-advert-slots.ts
@@ -4,11 +4,11 @@ import { adSizes, createAdSize } from 'core/ad-sizes';
 import { commercialFeatures } from 'lib/commercial-features';
 import { getCurrentBreakpoint } from 'lib/detect/detect-breakpoint';
 import { removeDisabledSlots } from '../remove-slots';
+import { includeAdsInMerch } from './ads-in-merchandising-test';
 import { createAdvert } from './create-advert';
 import { dfpEnv } from './dfp-env';
 import { displayAds } from './display-ads';
 import { displayLazyAds } from './display-lazy-ads';
-import { includeBillboardsInMerchHigh } from './merchandising-high-test';
 import { setupPrebidOnce } from './prepare-prebid';
 import { queueAdvert } from './queue-advert';
 
@@ -22,7 +22,7 @@ const decideAdditionalSizes = (adSlot: HTMLElement): SizeMapping => {
 		};
 	} else if (
 		(name === 'merchandising-high' || name === 'merchandising') &&
-		includeBillboardsInMerchHigh()
+		includeAdsInMerch()
 	) {
 		return {
 			mobile: [adSizes.mpu],

--- a/src/lib/dfp/fill-static-advert-slots.ts
+++ b/src/lib/dfp/fill-static-advert-slots.ts
@@ -21,10 +21,11 @@ const decideAdditionalSizes = (adSlot: HTMLElement): SizeMapping => {
 			desktop: [adSizes.billboard, createAdSize(900, 250)],
 		};
 	} else if (
-		name === 'merchandising-high' &&
+		(name === 'merchandising-high' || name === 'merchandising') &&
 		includeBillboardsInMerchHigh()
 	) {
 		return {
+			mobile: [adSizes.mpu],
 			desktop: [adSizes.billboard],
 		};
 	} else if (contentType === 'LiveBlog' && name?.includes('inline')) {

--- a/src/lib/dfp/merchandising-high-test.ts
+++ b/src/lib/dfp/merchandising-high-test.ts
@@ -1,6 +1,0 @@
-import { isInVariantSynchronous } from 'lib/experiments/ab';
-import { billboardsInMerchHigh } from 'lib/experiments/tests/billboards-in-merch-high';
-
-export const includeBillboardsInMerchHigh = () => {
-	return isInVariantSynchronous(billboardsInMerchHigh, 'variant');
-};

--- a/src/lib/experiments/ab-tests.ts
+++ b/src/lib/experiments/ab-tests.ts
@@ -1,5 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
-import { billboardsInMerchHigh } from './tests/billboards-in-merch-high';
+import { adsInMerch } from './tests/ads-in-merch';
 import { consentlessAds } from './tests/consentlessAds';
 import { eagerPrebid } from './tests/eager-prebid';
 import { elementsManager } from './tests/elements-manager';
@@ -18,7 +18,7 @@ export const concurrentTests: readonly ABTest[] = [
 	signInGateCopyTestJan2023,
 	consentlessAds,
 	integrateIma,
-	billboardsInMerchHigh,
+	adsInMerch,
 	elementsManager,
 	eagerPrebid,
 	publicGoodTest,

--- a/src/lib/experiments/tests/ads-in-merch.ts
+++ b/src/lib/experiments/tests/ads-in-merch.ts
@@ -1,7 +1,7 @@
 import type { ABTest } from '@guardian/ab-core';
 
-export const billboardsInMerchHigh: ABTest = {
-	id: 'BillboardsInMerchHigh',
+export const adsInMerch: ABTest = {
+	id: 'AdsInMerch',
 	author: '@commercial-dev',
 	start: '2022-12-07',
 	expiry: '2023-11-30',

--- a/src/lib/header-bidding/prebid-types.ts
+++ b/src/lib/header-bidding/prebid-types.ts
@@ -10,6 +10,7 @@ export type HeaderBiddingSlotName =
 	| 'mostpop'
 	| 'right'
 	| 'top-above-nav'
+	| 'merchandising'
 	| 'merchandising-high'
 	| `fronts-banner-${number}`
 	| `inline${number}`;

--- a/src/lib/header-bidding/slot-config.ts
+++ b/src/lib/header-bidding/slot-config.ts
@@ -191,7 +191,12 @@ const getSlots = (): HeaderBiddingSizeMapping => {
 			desktop: isCrossword ? [adSizes.leaderboard] : [],
 			tablet: isCrossword ? [adSizes.leaderboard] : [],
 		},
+		merchandising: {
+			mobile: includeAdsInMerch() ? [adSizes.mpu] : [],
+			desktop: includeAdsInMerch() ? [adSizes.billboard] : [],
+		},
 		'merchandising-high': {
+			mobile: includeAdsInMerch() ? [adSizes.mpu] : [],
 			desktop: includeAdsInMerch() ? [adSizes.billboard] : [],
 		},
 	};

--- a/src/lib/header-bidding/slot-config.ts
+++ b/src/lib/header-bidding/slot-config.ts
@@ -1,7 +1,7 @@
 import type { AdSize } from 'core/ad-sizes';
 import { adSizes, createAdSize } from 'core/ad-sizes';
+import { includeAdsInMerch } from 'lib/dfp/ads-in-merchandising-test';
 import type { Advert } from 'lib/dfp/Advert';
-import { includeBillboardsInMerchHigh } from 'lib/dfp/merchandising-high-test';
 import type {
 	HeaderBiddingSizeKey,
 	HeaderBiddingSizeMapping,
@@ -192,7 +192,7 @@ const getSlots = (): HeaderBiddingSizeMapping => {
 			tablet: isCrossword ? [adSizes.leaderboard] : [],
 		},
 		'merchandising-high': {
-			desktop: includeBillboardsInMerchHigh() ? [adSizes.billboard] : [],
+			desktop: includeAdsInMerch() ? [adSizes.billboard] : [],
 		},
 	};
 };


### PR DESCRIPTION
## What does this change?

- adds MPU size to `merchandising-high` slot
- adds MPU and billboard sizes to `merchandising` slot
- enables header bidding for these slots and sizes

## Why?

Commercial have identified a number of Black Friday opportunities, one of which is to show ads in `merchandising-high` and `merchandising` slots on fronts and articles.

This change ensures that ads of Billboard and MPU sizes can be added to these slots.

There was an AB test added in guardian/commercial#954 to support showing Billboard ads in `merchandising-high`. This change extends the scope of this test to include new sizes and the `merchandising` slot. 

By extending the scope of the AB test, I thought it appropriate to update the name of the test. Corresponding name changes will also be needed in DCR and frontend.

This change will not be rolled out as an AB test, it will go live to all users. However I decided not to delete the AB test logic at this stage: by using the `#ab-AdsInMerch ` URL hash, Ad Ops may want to test the changes in PROD before we set it live.

## Related PRs

- guardian/frontend#26682
- guardian/dotcom-rendering#9454