### PR TITLE
Remove fronts banner test

### DIFF
--- a/.changeset/breezy-beds-sleep.md
+++ b/.changeset/breezy-beds-sleep.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Use correct placement IDs for AppNexus and Improve for fronts-banner ads in UK desktop

--- a/src/lib/header-bidding/prebid/appnexus.ts
+++ b/src/lib/header-bidding/prebid/appnexus.ts
@@ -1,6 +1,5 @@
 import type { PageTargeting } from 'core/targeting/build-page-targeting';
 import { buildAppNexusTargetingObject } from 'lib/build-page-targeting';
-import { includeBillboardsInMerchHigh } from 'lib/dfp/merchandising-high-test';
 import { isInAuOrNz } from 'lib/utils/geo-utils';
 import type { HeaderBiddingSize } from '../prebid-types';
 import {
@@ -36,10 +35,7 @@ const getAppNexusInvCode = (sizes: HeaderBiddingSize[]): string | undefined => {
 	}
 };
 
-const getAppNexusDirectPlacementId = (
-	sizes: HeaderBiddingSize[],
-	isInFrontsBannerVariant: boolean,
-): string => {
+const getAppNexusDirectPlacementId = (sizes: HeaderBiddingSize[]): string => {
 	if (isInAuOrNz()) {
 		return '11016434';
 	}
@@ -47,12 +43,10 @@ const getAppNexusDirectPlacementId = (
 	const defaultPlacementId = '9251752';
 	switch (getBreakpointKey()) {
 		case 'D':
-			if (isInFrontsBannerVariant || includeBillboardsInMerchHigh()) {
-				// The only prebid compatible size for fronts-banner-ads and the merchandising-high is the billboard (970x250)
-				// This check is to distinguish from the top-above-nav which includes a leaderboard
-				if (containsBillboardNotLeaderboard(sizes)) {
-					return '30017511';
-				}
+			// The only prebid compatible size for fronts-banner-ads and the merchandising-high is the billboard (970x250)
+			// This check is to distinguish from the top-above-nav which includes a leaderboard
+			if (containsBillboardNotLeaderboard(sizes)) {
+				return '30017511';
 			}
 			if (containsMpuOrDmpu(sizes)) {
 				return '9251752';
@@ -82,7 +76,6 @@ const getAppNexusDirectPlacementId = (
 export const getAppNexusDirectBidParams = (
 	sizes: HeaderBiddingSize[],
 	pageTargeting: PageTargeting,
-	isInFrontsBannerVariant: boolean,
 ): AppNexusDirectBidParams => {
 	if (isInAuOrNz() && window.guardian.config.switches.prebidAppnexusInvcode) {
 		const invCode = getAppNexusInvCode(sizes);
@@ -98,10 +91,7 @@ export const getAppNexusDirectBidParams = (
 		}
 	}
 	return {
-		placementId: getAppNexusDirectPlacementId(
-			sizes,
-			isInFrontsBannerVariant,
-		),
+		placementId: getAppNexusDirectPlacementId(sizes),
 		keywords: buildAppNexusTargetingObject(pageTargeting),
 	};
 };

--- a/src/lib/header-bidding/prebid/bid-config.spec.ts
+++ b/src/lib/header-bidding/prebid/bid-config.spec.ts
@@ -11,6 +11,7 @@ import {
 import type { HeaderBiddingSize, PrebidBidder } from '../prebid-types';
 import {
 	containsBillboard as containsBillboard_,
+	containsBillboardNotLeaderboard as containsBillboardNotLeaderboard_,
 	containsDmpu as containsDmpu_,
 	containsLeaderboard as containsLeaderboard_,
 	containsLeaderboardOrBillboard as containsLeaderboardOrBillboard_,
@@ -61,6 +62,8 @@ jest.mock('lib/raven');
 
 jest.mock('../utils');
 const containsBillboard = containsBillboard_ as jest.Mock;
+const containsBillboardNotLeaderboard =
+	containsBillboardNotLeaderboard_ as jest.Mock;
 const containsDmpu = containsDmpu_ as jest.Mock;
 const containsLeaderboard = containsLeaderboard_ as jest.Mock;
 const containsLeaderboardOrBillboard =
@@ -126,7 +129,6 @@ const resetConfig = () => {
 describe('getImprovePlacementId', () => {
 	beforeEach(() => {
 		resetConfig();
-		getBreakpointKey.mockReturnValue('D');
 	});
 
 	afterEach(() => {
@@ -147,6 +149,36 @@ describe('getImprovePlacementId', () => {
 
 	test('should return -1 if no cases match', () => {
 		expect(getImprovePlacementId([createAdSize(1, 2)])).toBe(-1);
+	});
+
+	test('should give the expected values when there is a billboard but NOT a leaderboard', () => {
+		isInUk.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('D');
+		containsBillboardNotLeaderboard.mockReturnValueOnce(true);
+		containsMpuOrDmpu.mockReturnValueOnce(false);
+		containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+
+		expect(getImprovePlacementId([])).toEqual(22987847);
+	});
+
+	test('should give the expected values when there is a leaderboard but NOT a billboard', () => {
+		isInUk.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('D');
+		containsBillboardNotLeaderboard.mockReturnValueOnce(false);
+		containsMpuOrDmpu.mockReturnValueOnce(false);
+		containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+
+		expect(getImprovePlacementId([])).toEqual(1116397);
+	});
+
+	test('should give the expected values when there is a billboard AND a leaderboard', () => {
+		isInUk.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('D');
+		containsBillboardNotLeaderboard.mockReturnValueOnce(false);
+		containsMpuOrDmpu.mockReturnValueOnce(false);
+		containsLeaderboardOrBillboard.mockReturnValueOnce(true);
+
+		expect(getImprovePlacementId([])).toEqual(1116397);
 	});
 
 	test('should return the expected values when geolocated in UK and on desktop device', () => {

--- a/src/lib/header-bidding/prebid/bid-config.spec.ts
+++ b/src/lib/header-bidding/prebid/bid-config.spec.ts
@@ -11,7 +11,6 @@ import {
 import type { HeaderBiddingSize, PrebidBidder } from '../prebid-types';
 import {
 	containsBillboard as containsBillboard_,
-	containsBillboardNotLeaderboard as containsBillboardNotLeaderboard_,
 	containsDmpu as containsDmpu_,
 	containsLeaderboard as containsLeaderboard_,
 	containsLeaderboardOrBillboard as containsLeaderboardOrBillboard_,
@@ -66,8 +65,6 @@ const containsDmpu = containsDmpu_ as jest.Mock;
 const containsLeaderboard = containsLeaderboard_ as jest.Mock;
 const containsLeaderboardOrBillboard =
 	containsLeaderboardOrBillboard_ as jest.Mock;
-const containsBillboardNotLeaderboard =
-	containsBillboardNotLeaderboard_ as jest.Mock;
 const containsMobileSticky = containsMobileSticky_ as jest.Mock;
 const containsMpu = containsMpu_ as jest.Mock;
 const containsMpuOrDmpu = containsMpuOrDmpu_ as jest.Mock;
@@ -145,26 +142,11 @@ describe('getImprovePlacementId', () => {
 			[createAdSize(1, 2)],
 		];
 
-		return prebidSizes.map((size) => getImprovePlacementId(size, false));
+		return prebidSizes.map((size) => getImprovePlacementId(size));
 	};
 
 	test('should return -1 if no cases match', () => {
-		expect(getImprovePlacementId([createAdSize(1, 2)], false)).toBe(-1);
-	});
-
-	test('should give the expected values when in the fronts banner test in uk on desktop', () => {
-		isInUk.mockReturnValue(true);
-		getBreakpointKey.mockReturnValue('D');
-		containsMpuOrDmpu.mockReturnValue(false);
-		containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-		containsBillboardNotLeaderboard.mockReturnValue(true);
-
-		expect(getImprovePlacementId([createAdSize(970, 250)], true)).toEqual(
-			22987847,
-		);
-		expect(getImprovePlacementId([createAdSize(970, 250)], false)).toEqual(
-			1116397,
-		);
+		expect(getImprovePlacementId([createAdSize(1, 2)])).toBe(-1);
 	});
 
 	test('should return the expected values when geolocated in UK and on desktop device', () => {
@@ -359,7 +341,7 @@ describe('indexExchangeBidders', () => {
 			createAdSize(300, 250),
 			createAdSize(300, 600),
 		];
-		const bidders: PrebidBidder[] = indexExchangeBidders(slotSizes, false);
+		const bidders: PrebidBidder[] = indexExchangeBidders(slotSizes);
 		expect(bidders).toEqual([
 			expect.objectContaining<Partial<PrebidBidder>>({
 				name: 'ix',
@@ -379,7 +361,7 @@ describe('indexExchangeBidders', () => {
 			createAdSize(300, 250),
 			createAdSize(300, 600),
 		];
-		const bidders: PrebidBidder[] = indexExchangeBidders(slotSizes, false);
+		const bidders: PrebidBidder[] = indexExchangeBidders(slotSizes);
 		expect(bidders[0]?.bidParams('type', [createAdSize(1, 2)])).toEqual({
 			siteId: '123456',
 			size: [300, 250],
@@ -748,7 +730,7 @@ describe('getXaxisPlacementId', () => {
 	};
 
 	test('should return -1 if no cases match', () => {
-		expect(getImprovePlacementId([createAdSize(1, 2)], false)).toBe(-1);
+		expect(getImprovePlacementId([createAdSize(1, 2)])).toBe(-1);
 	});
 
 	test('should return the expected values for desktop device', () => {

--- a/src/lib/header-bidding/prebid/improve-digital.ts
+++ b/src/lib/header-bidding/prebid/improve-digital.ts
@@ -1,4 +1,3 @@
-import { includeBillboardsInMerchHigh } from 'lib/dfp/merchandising-high-test';
 import { isInRow, isInUk } from 'lib/utils/geo-utils';
 import type { HeaderBiddingSize } from '../prebid-types';
 import {
@@ -10,19 +9,14 @@ import {
 	stripTrailingNumbersAbove1,
 } from '../utils';
 
-const getImprovePlacementId = (
-	sizes: HeaderBiddingSize[],
-	isInFrontsBannerVariant: boolean,
-): number => {
+const getImprovePlacementId = (sizes: HeaderBiddingSize[]): number => {
 	if (isInUk()) {
 		switch (getBreakpointKey()) {
 			case 'D': // Desktop
-				if (isInFrontsBannerVariant || includeBillboardsInMerchHigh()) {
-					// The only prebid compatible size for fronts-banner-ads and the merchandising-high is the billboard (970x250)
-					// This check is to distinguish from the top-above-nav which includes a leaderboard
-					if (containsBillboardNotLeaderboard(sizes)) {
-						return 22987847;
-					}
+				// The only prebid compatible size for fronts-banner-ads and the merchandising-high is the billboard (970x250)
+				// This check is to distinguish from the top-above-nav which includes a leaderboard
+				if (containsBillboardNotLeaderboard(sizes)) {
+					return 22987847;
 				}
 				if (containsMpuOrDmpu(sizes)) {
 					return 1116396;
@@ -122,6 +116,6 @@ const getImproveSizeParam = (
 
 export {
 	getImprovePlacementId,
-	getImproveSkinPlacementId,
 	getImproveSizeParam,
+	getImproveSkinPlacementId,
 };


### PR DESCRIPTION
## What does this change?

Removes the logic checking whether the fronts banner test is running.

## Why?

The fronts banner test has been removed a while ago and this was missed.