### PR TITLE
Adds helper function to find smallest size for slot

### DIFF
--- a/src/dfp/Advert.spec.ts
+++ b/src/dfp/Advert.spec.ts
@@ -1,6 +1,5 @@
 import type * as AdSizesType from 'core/ad-sizes';
 import { slotSizeMappings as slotSizeMappings_ } from 'core/ad-sizes';
-import type { Breakpoint } from 'core/lib/breakpoint';
 import { _, Advert, findSmallestAdHeightForSlot } from './Advert';
 
 const { getSlotSizeMapping } = _;
@@ -174,15 +173,12 @@ describe('findSmallestAdHeightForSlot', () => {
 		['right', 'mobile', 250],
 		['right', 'tablet', 250],
 		['right', 'desktop', 250],
-	])(
+	] as const)(
 		'should find the smallest size for %s slot at %s breakpoint',
 		(slot, breakpoint, expected) => {
-			expect(
-				findSmallestAdHeightForSlot(
-					slot as AdSizesType.SlotName,
-					breakpoint as Breakpoint,
-				),
-			).toEqual(expected);
+			expect(findSmallestAdHeightForSlot(slot, breakpoint)).toEqual(
+				expected,
+			);
 		},
 	);
 });

--- a/src/dfp/Advert.spec.ts
+++ b/src/dfp/Advert.spec.ts
@@ -1,6 +1,7 @@
 import type * as AdSizesType from 'core/ad-sizes';
 import { slotSizeMappings as slotSizeMappings_ } from 'core/ad-sizes';
-import { _, Advert } from './Advert';
+import type { Breakpoint } from 'core/lib/breakpoint';
+import { _, Advert, findSmallestAdHeightForSlot } from './Advert';
 
 const { getSlotSizeMapping } = _;
 
@@ -153,6 +154,35 @@ describe('getAdSizeMapping', () => {
 			expect(getSlotSizeMapping(value)).toEqual(
 				slotSizeMappings_[slotName],
 			);
+		},
+	);
+});
+
+describe('findSmallestAdHeightForSlot', () => {
+	it.each([
+		['inline', 'desktop', 250],
+		['inline', 'phablet', 197],
+		['inline', 'tablet', 197],
+		['inline', 'mobile', 197],
+		['top-above-nav', 'desktop', 90],
+		['top-above-nav', 'tablet', 90],
+		['top-above-nav', 'phablet', 197],
+		['top-above-nav', 'mobile', 197],
+		['fronts-banner', 'mobile', null],
+		['fronts-banner', 'tablet', null],
+		['fronts-banner', 'desktop', 250],
+		['right', 'mobile', 250],
+		['right', 'tablet', 250],
+		['right', 'desktop', 250],
+	])(
+		'should find the smallest size for %s slot at %s breakpoint',
+		(slot, breakpoint, expected) => {
+			expect(
+				findSmallestAdHeightForSlot(
+					slot as AdSizesType.SlotName,
+					breakpoint as Breakpoint,
+				),
+			).toEqual(expected);
 		},
 	);
 });


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

Adds a helper function that finds the smallest known (i.e. not fluid, fabric, or other ad size of varying width/height) ad size that can be selected to fill a slot.

## Why?

This is useful when attempting to minimise CLS. Our strategy in this regard is to reserve space on the page for the height of smallest ad size that can be inserted into a slot, then expand the slot if a larger ad size is selected.

Currently, when we find the smallest ad size for a particular slot, it is [hard-coded](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/components/ArticleContainer.tsx#L146), rather than derived from the list of possible ad-sizes. This means it is susceptible to be incorrect in the future if the list of ad-sizes for a slot changes. For example, the smallest ad size on mobile articles in the first inline slot is the Outstream size at 197px tall. If this ad size was removed, we could instead reserve space for the next smallest ad size, the MPU at 250px.