### PR TITLE
Add Index site id for `320x50` size ads

### DIFF
--- a/src/lib/header-bidding/prebid/bid-config.spec.ts
+++ b/src/lib/header-bidding/prebid/bid-config.spec.ts
@@ -46,7 +46,7 @@ const getBidders = () =>
 	).map((bid) => bid.bidder);
 
 const {
-	getIndexSiteId,
+	getIndexSiteIdFromConfig,
 	getXaxisPlacementId,
 	getTrustXAdUnitId,
 	indexExchangeBidders,
@@ -414,8 +414,8 @@ describe('getIndexSiteId', () => {
 	test('should return an empty string if pbIndexSites is empty', () => {
 		window.guardian.config.page.pbIndexSites = [];
 		getBreakpointKey.mockReturnValue('D');
-		expect(getIndexSiteId()).toBe('');
-		expect(getIndexSiteId().length).toBe(0);
+		expect(getIndexSiteIdFromConfig()).toBe('');
+		expect(getIndexSiteIdFromConfig().length).toBe(0);
 	});
 
 	test('should find the correct ID for the breakpoint', () => {
@@ -428,7 +428,7 @@ describe('getIndexSiteId', () => {
 		const results = [];
 		for (let i = 0; i < breakpoints.length; i += 1) {
 			getBreakpointKey.mockReturnValue(breakpoints[i]);
-			results.push(getIndexSiteId());
+			results.push(getIndexSiteIdFromConfig());
 		}
 		expect(results).toEqual([
 			'234567',

--- a/src/lib/header-bidding/prebid/bid-config.spec.ts
+++ b/src/lib/header-bidding/prebid/bid-config.spec.ts
@@ -634,7 +634,7 @@ describe('triplelift adapter', () => {
 		containsLeaderboard.mockReturnValueOnce(true);
 		containsMpu.mockReturnValueOnce(false);
 		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValueOnce(false);
+		containsMobileSticky.mockReturnValue(false);
 		isInUsOrCa.mockReturnValue(true);
 		const tripleLiftBids = bids(
 			'dfp-ad--top-above-nav',
@@ -650,7 +650,7 @@ describe('triplelift adapter', () => {
 		containsLeaderboard.mockReturnValueOnce(true);
 		containsMpu.mockReturnValueOnce(false);
 		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValueOnce(false);
+		containsMobileSticky.mockReturnValue(false);
 		isInAuOrNz.mockReturnValue(true);
 		const tripleLiftBids = bids(
 			'dfp-ad--top-above-nav',
@@ -666,7 +666,7 @@ describe('triplelift adapter', () => {
 		containsLeaderboard.mockReturnValueOnce(false);
 		containsMpu.mockReturnValueOnce(true);
 		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValueOnce(false);
+		containsMobileSticky.mockReturnValue(false);
 		isInUsOrCa.mockReturnValue(true);
 
 		const tripleLiftBids = bids(
@@ -683,7 +683,7 @@ describe('triplelift adapter', () => {
 		containsLeaderboard.mockReturnValueOnce(false);
 		containsMpu.mockReturnValueOnce(true);
 		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValueOnce(false);
+		containsMobileSticky.mockReturnValue(false);
 		isInAuOrNz.mockReturnValue(true);
 
 		const tripleLiftBids = bids(
@@ -700,7 +700,7 @@ describe('triplelift adapter', () => {
 		containsLeaderboard.mockReturnValueOnce(false);
 		containsMpu.mockReturnValueOnce(false);
 		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValueOnce(true);
+		containsMobileSticky.mockReturnValue(true);
 		isInUsOrCa.mockReturnValue(true);
 
 		const tripleLiftBids = bids(
@@ -717,7 +717,7 @@ describe('triplelift adapter', () => {
 		containsLeaderboard.mockReturnValueOnce(false);
 		containsMpu.mockReturnValueOnce(false);
 		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValueOnce(true);
+		containsMobileSticky.mockReturnValue(true);
 		isInAuOrNz.mockReturnValue(true);
 
 		const tripleLiftBids = bids(


### PR DESCRIPTION
## What does this change?

This PR adds a new `siteId` to be used with the mobile-sticky ads by Index. We add this site id to Index's bid params when we detect the slot supports the mobile-sticky size.

In order to accommodate this, I did a small amount of refactoring to break out the way we pick a site id into two separate functions.

![Screenshot 2023-11-15 at 12 01 59](https://github.com/guardian/commercial/assets/8000415/2be0b5c6-3e5f-4037-bdcd-e4e25081e9e2)


## Why?

So that Index can bid on this new inventory.
