### PR TITLE
add logic for feature swtich

### DIFF
--- a/.changeset/proud-turkeys-drive.md
+++ b/.changeset/proud-turkeys-drive.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+ding feature switch logic

--- a/src/commercial.consentless.ts
+++ b/src/commercial.consentless.ts
@@ -23,7 +23,10 @@ const bootConsentless = async (
 
 	//this is added so that we can load the subscriber cookie for DCR pages and correctly hide ads
 
-	if (isDotcomRendering) {
+	if (
+		isDotcomRendering &&
+		window.guardian.config.switches.userFeaturesDcr !== true
+	) {
 		const userFeatures = await import(
 			/* webpackChunkName: "dcr" */
 			'lib/user-features'

--- a/src/standalone.commercial.ts
+++ b/src/standalone.commercial.ts
@@ -116,6 +116,10 @@ if (!commercialFeatures.adFree) {
 const loadDcrBundle = async (): Promise<void> => {
 	if (!isDotcomRendering) return;
 
+	if (window.guardian.config.switches.userFeaturesDcr === true) {
+		return;
+	}
+
 	const userFeatures = await import(
 		/* webpackChunkName: "dcr" */
 		'lib/user-features'


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?
This PR aims to provide a test to check whether the feature switch for `userFeaturesDcr` is set to true.

This is to enable us to test the Feature switch in the Frontend switchboard, depending on its value, it will force user-features module to be loaded from the desired code base (`dcr` or `commercial`)
## Why?
