### PR TITLE
Unify centring slots in container to a single class

### DIFF
--- a/.changeset/olive-meals-travel.md
+++ b/.changeset/olive-meals-travel.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Unify ad centring

--- a/src/lib/dfp/render-advert-label.ts
+++ b/src/lib/dfp/render-advert-label.ts
@@ -109,6 +109,7 @@ const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<Promise<void>> => {
 			return fastdom.mutate(() => {
 				adSlotNode.setAttribute('data-label-show', 'true');
 				adSlotNode.setAttribute('ad-label-text', adLabelContent);
+				// Remove this once new `ad-slot-container--centred-slot` class is in place
 				if (
 					adSlotNode.parentElement?.classList.contains(
 						'ad-slot-container',
@@ -120,6 +121,7 @@ const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<Promise<void>> => {
 						'true',
 					);
 				}
+				// \Remove this
 
 				if (shouldRenderCloseButton(adSlotNode)) {
 					adSlotNode.insertBefore(

--- a/src/lib/dfp/render-advert-label.ts
+++ b/src/lib/dfp/render-advert-label.ts
@@ -109,7 +109,7 @@ const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<Promise<void>> => {
 			return fastdom.mutate(() => {
 				adSlotNode.setAttribute('data-label-show', 'true');
 				adSlotNode.setAttribute('ad-label-text', adLabelContent);
-				// Remove this once new `ad-slot-container--centred-slot` class is in place
+				// Remove this once new `ad-slot-container--centre-slot` class is in place
 				if (
 					adSlotNode.parentElement?.classList.contains(
 						'ad-slot-container',

--- a/src/lib/dfp/render-advert.ts
+++ b/src/lib/dfp/render-advert.ts
@@ -185,9 +185,35 @@ const renderAdvert = (
 					  })
 					: Promise.resolve();
 
+			const centredAdSlots = [
+				'dfp-ad--top-above-nav',
+				'dfp-ad--merchandising-high',
+				'dfp-ad--merchandising',
+			];
+
+			/* Center certain slots in their containers, this is class is added dynamically to avoid rendering quirks with the ad label, and variable width ads.
+			 */
+			const addContainerCenterClass = () => {
+				if (
+					isRendered &&
+					advert.node.parentElement?.classList.contains(
+						'ad-slot-container',
+					) &&
+					centredAdSlots.includes(advert.node.id)
+				) {
+					return fastdom.mutate(() => {
+						advert.node.parentElement?.classList.add(
+							'ad-slot-container--centred-slot',
+						);
+					});
+				}
+				return Promise.resolve();
+			};
+
 			return callSizeCallback()
 				.then(() => renderAdvertLabel(advert.node))
 				.then(addRenderedClass)
+				.then(addContainerCenterClass)
 				.then(() => isRendered);
 		})
 		.catch((err) => {

--- a/src/lib/dfp/render-advert.ts
+++ b/src/lib/dfp/render-advert.ts
@@ -185,25 +185,25 @@ const renderAdvert = (
 					  })
 					: Promise.resolve();
 
-			const centredAdSlots = [
+			const centreAdSlots = [
 				'dfp-ad--top-above-nav',
 				'dfp-ad--merchandising-high',
 				'dfp-ad--merchandising',
 			];
 
-			/* Center certain slots in their containers, this is class is added dynamically to avoid rendering quirks with the ad label, and variable width ads.
+			/* Centre certain slots in their containers, this is class is added dynamically to avoid rendering quirks with the ad label, and variable width ads.
 			 */
-			const addContainerCenterClass = () => {
+			const addContainerCentreClass = () => {
 				if (
 					isRendered &&
 					advert.node.parentElement?.classList.contains(
 						'ad-slot-container',
 					) &&
-					centredAdSlots.includes(advert.node.id)
+					centreAdSlots.includes(advert.node.id)
 				) {
 					return fastdom.mutate(() => {
 						advert.node.parentElement?.classList.add(
-							'ad-slot-container--centred-slot',
+							'ad-slot-container--centre-slot',
 						);
 					});
 				}
@@ -213,7 +213,7 @@ const renderAdvert = (
 			return callSizeCallback()
 				.then(() => renderAdvertLabel(advert.node))
 				.then(addRenderedClass)
-				.then(addContainerCenterClass)
+				.then(addContainerCentreClass)
 				.then(() => isRendered);
 		})
 		.catch((err) => {

--- a/src/lib/dfp/render-advert.ts
+++ b/src/lib/dfp/render-advert.ts
@@ -155,17 +155,14 @@ const addContainerClass = (adSlotNode: HTMLElement, isRendered: boolean) => {
 	];
 	return fastdom
 		.measure(() => {
-			if (
+			return (
 				isRendered &&
 				!adSlotNode.classList.contains('ad-slot--fluid') &&
 				adSlotNode.parentElement?.classList.contains(
 					'ad-slot-container',
 				) &&
 				centreAdSlots.includes(adSlotNode.id)
-			) {
-				return true;
-			}
-			return false;
+			);
 		})
 		.then((shouldCentre) => {
 			if (shouldCentre) {

--- a/src/lib/dfp/render-advert.ts
+++ b/src/lib/dfp/render-advert.ts
@@ -146,7 +146,7 @@ const addContentClass = (adSlotNode: HTMLElement) => {
 	}
 };
 
-/* Centre certain slots in their containers, this is class is added dynamically to avoid rendering quirks with the ad label, and variable width ads. */
+/* Centre certain slots in their containers, this class is added dynamically to avoid rendering quirks with the ad label, and variable width ads. */
 const addContainerClass = (adSlotNode: HTMLElement, isRendered: boolean) => {
 	const centreAdSlots = [
 		'dfp-ad--top-above-nav',

--- a/src/lib/dfp/render-advert.ts
+++ b/src/lib/dfp/render-advert.ts
@@ -194,20 +194,30 @@ const renderAdvert = (
 			/* Centre certain slots in their containers, this is class is added dynamically to avoid rendering quirks with the ad label, and variable width ads.
 			 */
 			const addContainerCentreClass = () => {
-				if (
-					isRendered &&
-					advert.node.parentElement?.classList.contains(
-						'ad-slot-container',
-					) &&
-					centreAdSlots.includes(advert.node.id)
-				) {
-					return fastdom.mutate(() => {
-						advert.node.parentElement?.classList.add(
-							'ad-slot-container--centre-slot',
-						);
+				return fastdom
+					.measure(() => {
+						if (
+							isRendered &&
+							!advert.node.classList.contains('ad-slot--fluid') &&
+							advert.node.parentElement?.classList.contains(
+								'ad-slot-container',
+							) &&
+							centreAdSlots.includes(advert.node.id)
+						) {
+							return true;
+						}
+						return false;
+					})
+					.then((isCentre) => {
+						if (isCentre) {
+							return fastdom.mutate(() => {
+								advert.node.parentElement?.classList.add(
+									'ad-slot-container--centre-slot',
+								);
+							});
+						}
+						return Promise.resolve();
 					});
-				}
-				return Promise.resolve();
 			};
 
 			return callSizeCallback()

--- a/src/lib/dfp/render-advert.ts
+++ b/src/lib/dfp/render-advert.ts
@@ -146,7 +146,7 @@ const addContentClass = (adSlotNode: HTMLElement) => {
 	}
 };
 
-/* Centre certain slots in their containers, this class is added dynamically to avoid rendering quirks with the ad label, and variable width ads. */
+/* Centre certain slots in their containers, this class is added dynamically to avoid rendering quirks with the ad label and variable width ads. */
 const addContainerClass = (adSlotNode: HTMLElement, isRendered: boolean) => {
 	const centreAdSlots = [
 		'dfp-ad--top-above-nav',
@@ -154,16 +154,15 @@ const addContainerClass = (adSlotNode: HTMLElement, isRendered: boolean) => {
 		'dfp-ad--merchandising',
 	];
 	return fastdom
-		.measure(() => {
-			return (
+		.measure(
+			() =>
 				isRendered &&
 				!adSlotNode.classList.contains('ad-slot--fluid') &&
 				adSlotNode.parentElement?.classList.contains(
 					'ad-slot-container',
 				) &&
-				centreAdSlots.includes(adSlotNode.id)
-			);
-		})
+				centreAdSlots.includes(adSlotNode.id),
+		)
 		.then((shouldCentre) => {
 			if (shouldCentre) {
 				return fastdom.mutate(() => {

--- a/src/lib/high-merch.ts
+++ b/src/lib/high-merch.ts
@@ -17,7 +17,7 @@ export const init = (): Promise<void> => {
 		const container = wrapSlotInContainer(slot, {
 			className: 'fc-container fc-container--commercial',
 		});
-		// Remove this once new `ad-slot-container--center-slot` class is in place
+		// Remove this once new `ad-slot-container--centre-slot` class is in place
 		container.style.display = 'flex';
 		container.style.justifyContent = 'center';
 		// \Remove this

--- a/src/lib/high-merch.ts
+++ b/src/lib/high-merch.ts
@@ -17,8 +17,10 @@ export const init = (): Promise<void> => {
 		const container = wrapSlotInContainer(slot, {
 			className: 'fc-container fc-container--commercial',
 		});
+		// Remove this once new `ad-slot-container--center-slot` class is in place
 		container.style.display = 'flex';
 		container.style.justifyContent = 'center';
+		// \Remove this
 		return fastdom.mutate(() => {
 			if (anchor?.parentNode) {
 				anchor.parentNode.insertBefore(container, anchor);


### PR DESCRIPTION
## What does this change?
Add `ad-slot-container--centre-slot` class to replace the `top-above-nav-ad-rendered` attribute. Which will be removed later so this can release across DCR and Frontend gracefully.

Move the code out of the `render-advert-label` module as it's not to do with labels, it was just there to benefit from the check for fluid.

## Why?
So we can reuse the centring style semantically for other slots like merchandising.

Also changing to a class name, as this is just used to apply a css style.

This is to fix the centring issues when ads are displayed in merch slots ([details and screenshots in the Frontend PR](https://github.com/guardian/frontend/pull/26694))