### PR TITLE
Change order of adding ad centering/rendered classes

### DIFF
--- a/.changeset/chilled-knives-tell.md
+++ b/.changeset/chilled-knives-tell.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Change order of ad rendering classes

--- a/src/lib/dfp/render-advert.ts
+++ b/src/lib/dfp/render-advert.ts
@@ -215,8 +215,8 @@ const renderAdvert = (
 
 			return callSizeCallback()
 				.then(() => renderAdvertLabel(advert.node))
-				.then(addRenderedClass)
 				.then(() => addContainerClass(advert.node, isRendered))
+				.then(addRenderedClass)
 				.then(() => isRendered);
 		})
 		.catch((err) => {


### PR DESCRIPTION
## Why?
This should prevent a momentary flicker of the uncentered ad