### PR TITLE
Enable inserting new inline ad slots when new blocks are created on liveblogs

### DIFF
--- a/.changeset/quick-ligers-fix.md
+++ b/.changeset/quick-ligers-fix.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+when inserting inline ad slots server-side on liveblog pages, create the event listener to insert ad slots when more blocks are added to the page

--- a/playwright/fixtures/pages/blogs.ts
+++ b/playwright/fixtures/pages/blogs.ts
@@ -15,11 +15,11 @@ const blogs: GuPage[] = [
 	{
 		path: getTestUrl({
 			stage,
-			path: '/football/live/2023/aug/08/carabao-cup-first-round-wrexham-v-wigan-gillingham-v-southampton-live',
+			path: '/business/live/2023/nov/22/sam-altman-openai-return-jeremy-hunt-autumn-statement-tax-cuts-business-live',
 			type: 'liveblog',
 		}),
 		name: 'ad-limit',
-		expectedMinInlineSlotsOnDesktop: 5,
+		expectedMinInlineSlotsOnDesktop: 4,
 	},
 	{
 		path: getTestUrl({

--- a/playwright/lib/util.ts
+++ b/playwright/lib/util.ts
@@ -192,7 +192,15 @@ const waitForIsland = async (page: Page, island: string) => {
 	await hyrdatedIslandLocator.waitFor({ state: 'visible', timeout: 120000 });
 };
 
+const countLiveblogInlineSlots = async (page: Page, isMobile: boolean) => {
+	const mobileSuffix = isMobile ? '--mobile' : '';
+	const locator = `#liveblog-body .ad-slot--liveblog-inline${mobileSuffix}`;
+
+	return await page.locator(locator).count();
+};
+
 export {
+	countLiveblogInlineSlots,
 	fakeLogOut,
 	getStage,
 	getTestUrl,

--- a/playwright/tests/parallel-3/liveblog-live-update.spec.ts
+++ b/playwright/tests/parallel-3/liveblog-live-update.spec.ts
@@ -3,6 +3,7 @@ import { breakpoints } from '../../fixtures/breakpoints';
 import { blogs } from '../../fixtures/pages';
 import { cmpAcceptAll } from '../../lib/cmp';
 import { loadPage } from '../../lib/load-page';
+import { countLiveblogInlineSlots } from '../../lib/util';
 
 /**
  * TODO serial e2e tests
@@ -35,12 +36,11 @@ test.describe.serial('Liveblog live updates', () => {
 					.locator('.ad-slot--inline1')
 					.waitFor({ state: 'attached' });
 
-				// count the initial inline slots
-				const startSlotCount = await page
-					.locator('#liveblog-body .ad-slot--liveblog-inline')
-					.count();
-
-				console.log(`start slot count is ${startSlotCount}`);
+				const isMobile = breakpoint === 'mobile';
+				const startSlotCount = await countLiveblogInlineSlots(
+					page,
+					isMobile,
+				);
 
 				await page.evaluate(() => {
 					// @ts-expect-error -- browser land
@@ -65,7 +65,6 @@ test.describe.serial('Liveblog live updates', () => {
 
 				// new inline slot locator is the start slot count + 1
 				// except mobile where top-above-nav is also an inline
-				const isMobile = breakpoint === 'mobile';
 				const newInlineSlotLocator = `#liveblog-body .ad-slot--inline${
 					startSlotCount + (isMobile ? 0 : 1)
 				}`;
@@ -75,12 +74,10 @@ test.describe.serial('Liveblog live updates', () => {
 					.locator(newInlineSlotLocator)
 					.waitFor({ state: 'attached' });
 
-				// count the inline slots
-				const endSlotCount = await page
-					.locator('#liveblog-body .ad-slot--liveblog-inline')
-					.count();
-
-				console.log(`end slot count is ${endSlotCount}`);
+				const endSlotCount = await countLiveblogInlineSlots(
+					page,
+					isMobile,
+				);
 
 				expect(endSlotCount).toBeGreaterThan(startSlotCount);
 			});

--- a/src/spacefinder/liveblog-adverts.spec.ts
+++ b/src/spacefinder/liveblog-adverts.spec.ts
@@ -107,48 +107,4 @@ describe('Liveblog Dynamic Adverts', () => {
 			).toBe(14);
 		});
 	});
-
-	it('should insert ad slots if in the server-side ad slot test CONTROL group', async () => {
-		window.guardian.config.tests = window.guardian.config.tests ?? {};
-		window.guardian.config.tests.serverSideLiveblogInlineAdsControl =
-			'control';
-
-		const block1 = document.querySelector<HTMLElement>('.x1');
-		const block2 = document.querySelector<HTMLElement>('.x12');
-		if (block1 === null || block2 === null) {
-			throw Error();
-		}
-
-		spaceFillerStub.mockImplementationOnce(
-			createFillSpaceMock([block1, block2]),
-		);
-
-		await init().then(() => {
-			expect(
-				document.querySelector('.js-liveblog-body')?.children.length,
-			).toBe(14);
-		});
-	});
-
-	it('should NOT insert ad slots if in the server-side ad slot test VARIANT group', async () => {
-		window.guardian.config.tests = window.guardian.config.tests ?? {};
-		window.guardian.config.tests.serverSideLiveblogInlineAdsVariant =
-			'variant';
-
-		const block1 = document.querySelector<HTMLElement>('.x1');
-		const block2 = document.querySelector<HTMLElement>('.x12');
-		if (block1 === null || block2 === null) {
-			throw Error();
-		}
-
-		spaceFillerStub.mockImplementationOnce(
-			createFillSpaceMock([block1, block2]),
-		);
-
-		await init().then(() => {
-			expect(
-				document.querySelector('.js-liveblog-body')?.children.length,
-			).toBe(12);
-		});
-	});
 });

--- a/src/spacefinder/liveblog-adverts.ts
+++ b/src/spacefinder/liveblog-adverts.ts
@@ -147,13 +147,13 @@ const stopListening = () => {
 
 const getPreviousContentBlock = (element: HTMLElement): HTMLElement | null => {
 	const prevElement = element.previousSibling;
-	if (prevElement === null) return null;
+	if (!(prevElement instanceof HTMLElement)) return null;
 
-	if ((prevElement as HTMLElement).classList.contains('block')) {
-		return prevElement as HTMLElement;
+	if (prevElement.classList.contains('block')) {
+		return prevElement;
 	}
 
-	return getPreviousContentBlock(prevElement as HTMLElement);
+	return getPreviousContentBlock(prevElement);
 };
 
 const insertMoreAds = () => {
@@ -173,10 +173,7 @@ const insertMoreAds = () => {
 				firstSlot = undefined;
 			} else {
 				const nearestContentBlock = getPreviousContentBlock(topAdvert);
-				firstSlot =
-					nearestContentBlock !== null
-						? nearestContentBlock
-						: undefined;
+				firstSlot = nearestContentBlock ?? undefined;
 			}
 		} else {
 			const el = document.querySelector(

--- a/src/spacefinder/liveblog-adverts.ts
+++ b/src/spacefinder/liveblog-adverts.ts
@@ -31,34 +31,28 @@ const AD_SPACE_MULTIPLIER = 2;
 
 let AD_COUNTER = 0;
 let WINDOWHEIGHT: number;
+let IS_SERVER_SIDE_MODE = false;
 let firstSlot: HTMLElement | undefined;
 
-const getWindowHeight = (doc = document) => {
-	if (doc.documentElement.clientHeight) {
-		return doc.documentElement.clientHeight;
-	}
-	return 0; // #? zero, or throw an error?
-};
-
-const getSpaceFillerRules = (
-	windowHeight: number,
-	shouldUpdate = false,
-): SpacefinderRules => {
+const getSpaceFillerRules = (shouldUpdate: boolean): SpacefinderRules => {
 	let prevSlot: SpacefinderItem | undefined;
 
 	const isEnoughSpaceBetweenSlots = (
 		prevSlot: SpacefinderItem,
 		slot: SpacefinderItem,
-	) => Math.abs(slot.top - prevSlot.top) > windowHeight * AD_SPACE_MULTIPLIER;
+	) => Math.abs(slot.top - prevSlot.top) > WINDOWHEIGHT * AD_SPACE_MULTIPLIER;
 
 	const filterSlot = (slot: SpacefinderItem) => {
 		if (!prevSlot) {
 			prevSlot = slot;
 			return !shouldUpdate;
-		} else if (isEnoughSpaceBetweenSlots(prevSlot, slot)) {
+		}
+
+		if (isEnoughSpaceBetweenSlots(prevSlot, slot)) {
 			prevSlot = slot;
 			return true;
 		}
+
 		return false;
 	};
 
@@ -77,22 +71,26 @@ const getSpaceFillerRules = (
 };
 
 const getSlotName = (isMobile: boolean, slotCounter: number): string => {
-	if (isMobile && slotCounter === 0) {
-		return 'top-above-nav';
-	} else if (isMobile) {
-		return `inline${slotCounter}`;
+	if (isMobile) {
+		return slotCounter === 0 ? 'top-above-nav' : `inline${slotCounter}`;
 	}
+
 	return `inline${slotCounter + 1}`;
 };
 
 const insertAdAtPara = (para: Node) => {
 	const isMobile = getCurrentBreakpoint() === 'mobile';
 	const container: HTMLElement = document.createElement('div');
-	container.className = `ad-slot-container`;
+
+	let className = `ad-slot-container`;
+	if (IS_SERVER_SIDE_MODE) {
+		className += ` ad-slot-${isMobile ? 'mobile' : 'desktop'}`;
+	}
+	container.className = className;
 
 	const ad = createAdSlot('inline', {
 		name: getSlotName(isMobile, AD_COUNTER),
-		classes: 'liveblog-inline',
+		classes: `liveblog-inline${isMobile ? '--mobile' : ''}`,
 	});
 
 	container.appendChild(ad);
@@ -134,7 +132,7 @@ const insertAds: SpacefinderWriter = async (paras) => {
 const onUpdate = () => {
 	// eslint-disable-next-line no-use-before-define -- circular reference
 	stopListening();
-	const rules = getSpaceFillerRules(WINDOWHEIGHT, true);
+	const rules = getSpaceFillerRules(true);
 	// eslint-disable-next-line no-use-before-define -- circular reference
 	void fill(rules);
 };
@@ -147,24 +145,60 @@ const stopListening = () => {
 	document.removeEventListener('liveblog:blocks-updated', onUpdate);
 };
 
-const fill = (rules: SpacefinderRules) => {
-	const options: SpacefinderOptions = { pass: 'inline1' };
+const getPreviousContentBlock = (element: HTMLElement): HTMLElement | null => {
+	const prevElement = element.previousSibling;
+	if (prevElement === null) return null;
 
-	return spaceFiller.fillSpace(rules, insertAds, options).then(() => {
-		if (AD_COUNTER < MAX_ADS) {
+	if ((prevElement as HTMLElement).classList.contains('block')) {
+		return prevElement as HTMLElement;
+	}
+
+	return getPreviousContentBlock(prevElement as HTMLElement);
+};
+
+const insertMoreAds = () => {
+	const isMobile = getCurrentBreakpoint() === 'mobile';
+
+	let adContainerClass = '.ad-slot-container';
+	if (IS_SERVER_SIDE_MODE) {
+		adContainerClass += `.ad-slot-${isMobile ? 'mobile' : 'desktop'}`;
+	}
+
+	if (AD_COUNTER < MAX_ADS) {
+		if (IS_SERVER_SIDE_MODE) {
+			const topAdvert: HTMLElement | null = document.querySelector(
+				`.js-liveblog-body > ${adContainerClass}`,
+			);
+			if (topAdvert === null) {
+				firstSlot = undefined;
+			} else {
+				const nearestContentBlock = getPreviousContentBlock(topAdvert);
+				firstSlot =
+					nearestContentBlock !== null
+						? nearestContentBlock
+						: undefined;
+			}
+		} else {
 			const el = document.querySelector(
-				`${rules.bodySelector} > .ad-slot-container`,
+				`.js-liveblog-body > ${adContainerClass}`,
 			);
 			if (el && el.previousSibling instanceof HTMLElement) {
 				firstSlot = el.previousSibling;
 			} else {
 				firstSlot = undefined;
 			}
-			startListening();
-		} else {
-			firstSlot = undefined;
 		}
-	});
+
+		startListening();
+	} else {
+		firstSlot = undefined;
+	}
+};
+
+const fill = (rules: SpacefinderRules) => {
+	const options: SpacefinderOptions = { pass: 'inline1' };
+
+	return spaceFiller.fillSpace(rules, insertAds, options).then(insertMoreAds);
 };
 
 /**
@@ -175,23 +209,42 @@ export const init = (): Promise<void> => {
 		return Promise.resolve();
 	}
 
-	const isServerSideAdsMode =
-		window.guardian.config.tests?.serverSideLiveblogInlineAdsVariant ===
-		'variant';
-	if (isServerSideAdsMode) {
+	const isMobile = getCurrentBreakpoint() === 'mobile';
+
+	// Temporary measure to identify whether we're in server-side inline ad insertion mode.
+	// Client-side ad insertion functionality will be removed very soon.
+	const numMobileAdsInServerSideMode = document.querySelectorAll(
+		'.ad-slot-container.ad-slot-mobile',
+	).length;
+	IS_SERVER_SIDE_MODE = numMobileAdsInServerSideMode > 0;
+
+	console.log('numMobileAdsInServerSideMode', numMobileAdsInServerSideMode);
+	console.log('IS_SERVER_SIDE_MODE', IS_SERVER_SIDE_MODE);
+
+	if (IS_SERVER_SIDE_MODE) {
 		log(
 			'commercial',
 			'Server side inline ads mode. No client-side inline ad slots inserted',
 		);
-		return Promise.resolve();
+		const selector = `.ad-slot-container.ad-slot-${
+			isMobile ? 'mobile' : 'desktop'
+		}`;
+
+		AD_COUNTER = document.querySelectorAll(selector).length;
+
+		return fastdom
+			.measure(() => {
+				WINDOWHEIGHT = document.documentElement.clientHeight;
+				return WINDOWHEIGHT;
+			})
+			.then(insertMoreAds);
 	}
 
 	return fastdom
 		.measure(() => {
-			WINDOWHEIGHT = getWindowHeight();
-			return WINDOWHEIGHT;
+			WINDOWHEIGHT = document.documentElement.clientHeight;
 		})
-		.then(getSpaceFillerRules)
+		.then(() => getSpaceFillerRules(false))
 		.then(fill);
 };
 

--- a/src/spacefinder/liveblog-adverts.ts
+++ b/src/spacefinder/liveblog-adverts.ts
@@ -218,9 +218,6 @@ export const init = (): Promise<void> => {
 	).length;
 	IS_SERVER_SIDE_MODE = numMobileAdsInServerSideMode > 0;
 
-	console.log('numMobileAdsInServerSideMode', numMobileAdsInServerSideMode);
-	console.log('IS_SERVER_SIDE_MODE', IS_SERVER_SIDE_MODE);
-
 	if (IS_SERVER_SIDE_MODE) {
 		log(
 			'commercial',


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

- On liveblog pages where inline ads are inserted server-side, this enables the functionality to insert more ads as new blocks are pushed to the page. This functionality currently exists when inserting inline ads client-side, but we are moving to a server-side strategy.

## Why?

- So that we can replicate the functionality of client-side inserted ad slots, allowing to make the switch to server-side inserted inline ad slots
