### PR TITLE
Only apply the mostpop test at desired breakpoints

### DIFF
--- a/playwright/fixtures/breakpoints.ts
+++ b/playwright/fixtures/breakpoints.ts
@@ -11,7 +11,7 @@ type BreakpointSizes = {
 	height: number;
 };
 
-const breakpointsToTest: Array<keyof BreakpointKeys> = [
+const allBreakpoints: Array<keyof BreakpointKeys> = [
 	'mobile',
 	'tablet',
 	'desktop',
@@ -25,10 +25,17 @@ const heights = {
 	wide: 1100,
 } as const;
 
-const breakpointSizes: BreakpointSizes[] = breakpointsToTest.map((b) => ({
-	breakpoint: b,
-	width: breakpoints[b],
-	height: heights[b],
-}));
+const testAtBreakpoints = (breakpointsToTest: Array<keyof BreakpointKeys>) =>
+	breakpointsToTest.map((b) => ({
+		breakpoint: b,
+		width: breakpoints[b],
+		height: heights[b],
+	}));
 
-export { breakpointSizes as breakpoints, type BreakpointSizes };
+const breakpointSizes: BreakpointSizes[] = testAtBreakpoints(allBreakpoints);
+
+export {
+	breakpointSizes as breakpoints,
+	testAtBreakpoints,
+	type BreakpointSizes,
+};

--- a/playwright/tests/parallel-5/mostpop.spec.ts
+++ b/playwright/tests/parallel-5/mostpop.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test';
 import { isDefined } from 'core/types';
-import { breakpoints } from '../../fixtures/breakpoints';
+import { testAtBreakpoints } from '../../fixtures/breakpoints';
 import { articles, blogs } from '../../fixtures/pages';
 import type { GuPage } from '../../fixtures/pages/Page';
 import { cmpAcceptAll } from '../../lib/cmp';
@@ -11,20 +11,26 @@ const pages = [articles[0], blogs[0]].filter<GuPage>(isDefined);
 
 test.describe('mostpop slot', () => {
 	pages.forEach(({ path }, index) => {
-		breakpoints.forEach(({ breakpoint, width, height }) => {
-			test(`Test page ${index} has slot and iframe at breakpoint ${breakpoint}`, async ({
-				page,
-			}) => {
-				await page.setViewportSize({
-					width,
-					height,
+		/**
+		 * Since the introduction of non-house advertising in the merchandising slot,
+		 * we now hide the most pop slot until the tablet breakpoint
+		 */
+		testAtBreakpoints(['tablet', 'desktop', 'wide']).forEach(
+			({ breakpoint, width, height }) => {
+				test(`Test page ${index} has slot and iframe at breakpoint ${breakpoint}`, async ({
+					page,
+				}) => {
+					await page.setViewportSize({
+						width,
+						height,
+					});
+
+					await loadPage(page, path);
+					await cmpAcceptAll(page);
+
+					await waitForSlot(page, 'mostpop');
 				});
-
-				await loadPage(page, path);
-				await cmpAcceptAll(page);
-
-				await waitForSlot(page, 'mostpop');
-			});
-		});
+			},
+		);
 	});
 });


### PR DESCRIPTION
## What does this change?

Only apply the `mostpop` PlayWright test from tablet and above.

## Why?

We recently made a change that hide the `mostpop` slot until the tablet breakpoint (PR). This caused these tests in Commercial to (rightly) fail.
