### PR TITLE
Remove ads-in-merch test

### DIFF
--- a/.changeset/fast-stingrays-punch.md
+++ b/.changeset/fast-stingrays-punch.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Removes adsInMerch AB test

--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -341,15 +341,20 @@ const slotSizeMappings = {
 			adSizes.empty,
 			adSizes.merchandisingHigh,
 			adSizes.fluid,
+			adSizes.mpu,
 		],
-		// The mobile mapping is given an additional size when filling the slot.
-		// We do not want this extra size applied to tablet, so we provide a
-		// mapping for tablet here.
 		tablet: [
 			adSizes.outOfPage,
 			adSizes.empty,
 			adSizes.merchandisingHigh,
 			adSizes.fluid,
+		],
+		desktop: [
+			adSizes.outOfPage,
+			adSizes.empty,
+			adSizes.merchandisingHigh,
+			adSizes.fluid,
+			adSizes.billboard,
 		],
 	},
 	'merchandising-high-lucky': {
@@ -361,15 +366,20 @@ const slotSizeMappings = {
 			adSizes.empty,
 			adSizes.merchandising,
 			adSizes.fluid,
+			adSizes.mpu,
 		],
-		// The mobile mapping is given an additional size when filling the slot.
-		// We do not want this extra size applied to tablet, so we provide a
-		// mapping for tablet here.
 		tablet: [
 			adSizes.outOfPage,
 			adSizes.empty,
 			adSizes.merchandising,
 			adSizes.fluid,
+		],
+		desktop: [
+			adSizes.outOfPage,
+			adSizes.empty,
+			adSizes.merchandising,
+			adSizes.fluid,
+			adSizes.billboard,
 		],
 	},
 	survey: {

--- a/src/dfp/ads-in-merchandising-test.ts
+++ b/src/dfp/ads-in-merchandising-test.ts
@@ -1,3 +1,0 @@
-export const includeAdsInMerch = () => {
-	return window.guardian.config.switches.adsInMerch === true;
-};

--- a/src/dfp/fill-static-advert-slots.ts
+++ b/src/dfp/fill-static-advert-slots.ts
@@ -4,7 +4,6 @@ import { adSizes, createAdSize } from 'core/ad-sizes';
 import { getCurrentBreakpoint } from 'detect/detect-breakpoint';
 import { commercialFeatures } from 'lib/commercial-features';
 import { removeDisabledSlots } from '../lib/remove-slots';
-import { includeAdsInMerch } from './ads-in-merchandising-test';
 import { createAdvert } from './create-advert';
 import { dfpEnv } from './dfp-env';
 import { displayAds } from './display-ads';
@@ -20,20 +19,15 @@ const decideAdditionalSizes = (adSlot: HTMLElement): SizeMapping => {
 		return {
 			desktop: [adSizes.billboard, createAdSize(900, 250)],
 		};
-	} else if (
-		(name === 'merchandising-high' || name === 'merchandising') &&
-		includeAdsInMerch()
-	) {
-		return {
-			mobile: [adSizes.mpu],
-			desktop: [adSizes.billboard],
-		};
-	} else if (contentType === 'LiveBlog' && name?.includes('inline')) {
+	}
+
+	if (contentType === 'LiveBlog' && name?.includes('inline')) {
 		return {
 			phablet: [adSizes.outstreamDesktop, adSizes.outstreamGoogleDesktop],
 			desktop: [adSizes.outstreamDesktop, adSizes.outstreamGoogleDesktop],
 		};
 	}
+
 	return {};
 };
 

--- a/src/header-bidding/slot-config.ts
+++ b/src/header-bidding/slot-config.ts
@@ -1,6 +1,5 @@
 import type { AdSize } from 'core/ad-sizes';
 import { adSizes, createAdSize } from 'core/ad-sizes';
-import { includeAdsInMerch } from 'dfp/ads-in-merchandising-test';
 import type { Advert } from 'dfp/Advert';
 import type {
 	HeaderBiddingSizeKey,
@@ -192,12 +191,12 @@ const getSlots = (): HeaderBiddingSizeMapping => {
 			tablet: isCrossword ? [adSizes.leaderboard] : [],
 		},
 		merchandising: {
-			mobile: includeAdsInMerch() ? [adSizes.mpu] : [],
-			desktop: includeAdsInMerch() ? [adSizes.billboard] : [],
+			mobile: [adSizes.mpu],
+			desktop: [adSizes.billboard],
 		},
 		'merchandising-high': {
-			mobile: includeAdsInMerch() ? [adSizes.mpu] : [],
-			desktop: includeAdsInMerch() ? [adSizes.billboard] : [],
+			mobile: [adSizes.mpu],
+			desktop: [adSizes.billboard],
 		},
 	};
 };


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

- Remove ads-in-merch AB test
- Moves all the sizes for both merch slots to `ad-sizes.ts`

## Why?

- It has been decided that we will keep showing ads in merch slots, allowing ads to compete with merchandising for the slot.