### PR TITLE
Extend IMA AB test

### DIFF
--- a/src/experiments/tests/integrate-ima.ts
+++ b/src/experiments/tests/integrate-ima.ts
@@ -4,7 +4,7 @@ import { noop } from 'utils/noop';
 export const integrateIma: ABTest = {
 	id: 'IntegrateIma',
 	start: '2022-07-14',
-	expiry: '2023-04-04',
+	expiry: '2024-02-28',
 	author: 'Zeke Hunter-Green',
 	description:
 		'Test the commercial impact of replacing YouTube ads with Interactive Media Ads on first-party videos',


### PR DESCRIPTION
## What does this change?

Extend the IMA AB test until end of Feb 2024.
