### PR TITLE
Launch Kargo to 99% of users

### DIFF
--- a/.changeset/nervous-flies-divide.md
+++ b/.changeset/nervous-flies-divide.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Launch Kargo

--- a/src/experiments/tests/prebid-kargo.ts
+++ b/src/experiments/tests/prebid-kargo.ts
@@ -3,9 +3,9 @@ import type { ABTest } from '@guardian/ab-core';
 export const prebidKargo: ABTest = {
 	id: 'PrebidKargo',
 	author: '@commercial-dev',
-	start: '2023-08-10',
-	expiry: '2023-09-29',
-	audience: 0 / 100,
+	start: '2023-12-05',
+	expiry: '2024-02-29',
+	audience: 2 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: 'USA only',
 	successMeasure: '',

--- a/src/header-bidding/utils.ts
+++ b/src/header-bidding/utils.ts
@@ -190,7 +190,7 @@ export const shouldIncludeCriteo = (): boolean => !isInAuOrNz();
 export const shouldIncludeSmart = (): boolean => isInUk() || isInRow();
 
 export const shouldIncludeKargo = (): boolean =>
-	isInUsa() && isInVariantSynchronous(prebidKargo, 'variant');
+	isInUsa() && !isInVariantSynchronous(prebidKargo, 'variant');
 
 export const shouldIncludeMobileSticky = once(
 	(): boolean =>


### PR DESCRIPTION
## What does this change?
Extend the test created in #1005 to add Kargo as a prebid bidder in the US.

Invert the check for running kargo to be when *not* in the test.

## Why?

Wewe now want to launch the change for the majority of users and hold back 1% of our audience to compare revenue.
