### PR TITLE
remove feature swtch logic for user-features module

### DIFF
--- a/src/commercial.consentless.ts
+++ b/src/commercial.consentless.ts
@@ -23,18 +23,6 @@ const bootConsentless = async (
 
 	//this is added so that we can load the subscriber cookie for DCR pages and correctly hide ads
 
-	if (
-		isDotcomRendering &&
-		window.guardian.config.switches.userFeaturesDcr !== true
-	) {
-		const userFeatures = await import(
-			/* webpackChunkName: "dcr" */
-			'lib/user-features'
-		);
-
-		consentlessModuleList.push(userFeatures.refresh());
-	}
-
 	await Promise.all(consentlessModuleList);
 
 	// Since we're in single-request mode

--- a/src/commercial.consentless.ts
+++ b/src/commercial.consentless.ts
@@ -7,10 +7,7 @@ import { initConsentless } from './consentless/prepare-ootag';
 import { init as setAdTestCookie } from './lib/set-adtest-cookie';
 import { init as setAdTestInLabelsCookie } from './lib/set-adtest-in-labels-cookie';
 
-const bootConsentless = async (
-	consentState: ConsentState,
-	isDotcomRendering: boolean,
-): Promise<void> => {
+const bootConsentless = async (consentState: ConsentState): Promise<void> => {
 	const consentlessModuleList = [
 		setAdTestCookie(),
 		setAdTestInLabelsCookie(),
@@ -20,8 +17,6 @@ const bootConsentless = async (
 		initArticleInline(),
 		initLiveblogInline(),
 	];
-
-	//this is added so that we can load the subscriber cookie for DCR pages and correctly hide ads
 
 	await Promise.all(consentlessModuleList);
 

--- a/src/standalone.commercial.ts
+++ b/src/standalone.commercial.ts
@@ -50,8 +50,7 @@ import { catchErrorsWithContext } from 'utils/robust';
 
 type Modules = Array<[`${string}-${string}`, () => Promise<unknown>]>;
 
-const { isDotcomRendering, frontendAssetsFullURL, switches, page } =
-	window.guardian.config;
+const { frontendAssetsFullURL, switches, page } = window.guardian.config;
 
 const decideAssetsPath = () => {
 	if (process.env.OVERRIDE_BUNDLE_PATH) {
@@ -107,12 +106,6 @@ if (!commercialFeatures.adFree) {
 		['cm-redplanet', initRedplanet],
 	);
 }
-
-/**
- * Load modules specific to `dotcom-rendering`.
- * Not sure if this is needed. Currently no separate chunk is created
- * Introduced by @tomrf1
- */
 
 const loadModules = (modules: Modules, eventName: string) => {
 	const modulePromises: Array<Promise<unknown>> = [];
@@ -226,9 +219,7 @@ const chooseAdvertisingTag = async () => {
 		void import(
 			/* webpackChunkName: "consentless" */
 			'./commercial.consentless'
-		).then(({ bootConsentless }) =>
-			bootConsentless(consentState, isDotcomRendering),
-		);
+		).then(({ bootConsentless }) => bootConsentless(consentState));
 	} else {
 		bootCommercialWhenReady();
 	}

--- a/src/standalone.commercial.ts
+++ b/src/standalone.commercial.ts
@@ -113,21 +113,6 @@ if (!commercialFeatures.adFree) {
  * Not sure if this is needed. Currently no separate chunk is created
  * Introduced by @tomrf1
  */
-const loadDcrBundle = async (): Promise<void> => {
-	if (!isDotcomRendering) return;
-
-	if (window.guardian.config.switches.userFeaturesDcr === true) {
-		return;
-	}
-
-	const userFeatures = await import(
-		/* webpackChunkName: "dcr" */
-		'lib/user-features'
-	);
-
-	commercialExtraModules.push(['c-user-features', userFeatures.refresh]);
-	return;
-};
 
 const loadModules = (modules: Modules, eventName: string) => {
 	const modulePromises: Array<Promise<unknown>> = [];
@@ -203,8 +188,6 @@ const bootCommercial = async (): Promise<void> => {
 	};
 
 	try {
-		await loadDcrBundle();
-
 		const allModules: Array<Parameters<typeof loadModules>> = [
 			[commercialBaseModules, 'commercialBaseModulesLoaded'],
 			[commercialExtraModules, 'commercialExtraModulesLoaded'],


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?
This PR aims to remove logic which will conditionally load the user-features 



## Why?
We moved `user-features` to `dcr`: https://github.com/guardian/dotcom-rendering/pull/9362.
As a transitional process, we kept user-features in commercial and added a feature-switch in order to switch back if any issues.
We are now confident it is working as expected in `dcr` and loading appropriately with all cookies.