### PR TITLE
Let playwright figure out sharding/parallelism

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1, 2, 3, 4, 5]
+        group: [1/5, 2/5, 3/5, 4/5, 5/5]
     steps:
       # Commercial
       - name: Checkout
@@ -64,7 +64,7 @@ jobs:
         working-directory: ./commercial
 
       - name: Run Playwright
-        run: yarn playwright test parallel-${{ matrix.group }}
+        run: yarn playwright test --shard=${{ matrix.group }}
         working-directory: ./commercial
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1/5, 2/5, 3/5, 4/5, 5/5]
+        group: [1, 2, 3, 4, 5]
     steps:
       # Commercial
       - name: Checkout
@@ -64,12 +64,12 @@ jobs:
         working-directory: ./commercial
 
       - name: Run Playwright
-        run: yarn playwright test --shard=${{ matrix.group }}
+        run: yarn playwright test --shard=${{ matrix.group }}/5
         working-directory: ./commercial
 
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.group }}
           path: ./commercial/playwright-report
           retention-days: 5

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -70,6 +70,6 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: playwright-report-${{ matrix.group }}
+          name: playwright-report
           path: ./commercial/playwright-report
           retention-days: 5

--- a/playwright/tests/article-inline-slots.spec.ts
+++ b/playwright/tests/article-inline-slots.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test';
-import { breakpoints } from '../../fixtures/breakpoints';
-import { articles } from '../../fixtures/pages';
-import { cmpAcceptAll } from '../../lib/cmp';
-import { loadPage } from '../../lib/load-page';
+import { breakpoints } from '../fixtures/breakpoints';
+import { articles } from '../fixtures/pages';
+import { cmpAcceptAll } from '../lib/cmp';
+import { loadPage } from '../lib/load-page';
 
 const pages = articles.filter(({ name }) => name === 'inlineSlots');
 

--- a/playwright/tests/consent.spec.ts
+++ b/playwright/tests/consent.spec.ts
@@ -1,16 +1,16 @@
 import type { Page } from '@playwright/test';
 import { expect, test } from '@playwright/test';
-import { articles } from '../../fixtures/pages';
-import type { GuPage } from '../../fixtures/pages/Page';
-import { cmpAcceptAll, cmpReconsent, cmpRejectAll } from '../../lib/cmp';
-import { loadPage } from '../../lib/load-page';
+import { articles } from '../fixtures/pages';
+import type { GuPage } from '../fixtures/pages/Page';
+import { cmpAcceptAll, cmpReconsent, cmpRejectAll } from '../lib/cmp';
+import { loadPage } from '../lib/load-page';
 import {
 	fakeLogOut,
 	getStage,
 	getTestUrl,
 	setupFakeLogin,
 	waitForSlot,
-} from '../../lib/util';
+} from '../lib/util';
 
 const { path } = articles[0] as unknown as GuPage;
 

--- a/playwright/tests/front-inline-slots.spec.ts
+++ b/playwright/tests/front-inline-slots.spec.ts
@@ -1,8 +1,8 @@
 import { test } from '@playwright/test';
-import { fronts, tagFronts } from '../../fixtures/pages';
-import { cmpAcceptAll } from '../../lib/cmp';
-import { loadPage } from '../../lib/load-page';
-import { waitForSlot } from '../../lib/util';
+import { fronts, tagFronts } from '../fixtures/pages';
+import { cmpAcceptAll } from '../lib/cmp';
+import { loadPage } from '../lib/load-page';
+import { waitForSlot } from '../lib/util';
 
 test.describe('Slots and iframes load on fronts pages', () => {
 	fronts.forEach(({ path }) => {

--- a/playwright/tests/googletag-switch.spec.ts
+++ b/playwright/tests/googletag-switch.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@playwright/test';
-import { cmpAcceptAll } from '../../lib/cmp';
-import { loadPage } from '../../lib/load-page';
-import { getStage, getTestUrl, waitForSlot } from '../../lib/util';
+import { cmpAcceptAll } from '../lib/cmp';
+import { loadPage } from '../lib/load-page';
+import { getStage, getTestUrl, waitForSlot } from '../lib/util';
 
 test.describe('shouldLoadGoogletagSwitch', () => {
 	test('ad slot should be filled when switch is true', async ({ page }) => {

--- a/playwright/tests/liveblog-ad-limit.spec.ts
+++ b/playwright/tests/liveblog-ad-limit.spec.ts
@@ -1,11 +1,11 @@
 import type { Page } from '@playwright/test';
 import { expect, test } from '@playwright/test';
-import type { BreakpointSizes } from '../../fixtures/breakpoints';
-import { breakpoints } from '../../fixtures/breakpoints';
-import { blogs } from '../../fixtures/pages';
-import { cmpAcceptAll } from '../../lib/cmp';
-import { loadPage } from '../../lib/load-page';
-import { countLiveblogInlineSlots } from '../../lib/util';
+import type { BreakpointSizes } from '../fixtures/breakpoints';
+import { breakpoints } from '../fixtures/breakpoints';
+import { blogs } from '../fixtures/pages';
+import { cmpAcceptAll } from '../lib/cmp';
+import { loadPage } from '../lib/load-page';
+import { countLiveblogInlineSlots } from '../lib/util';
 
 /**
  * TODO serial e2e tests

--- a/playwright/tests/liveblog-inline-slots.spec.ts
+++ b/playwright/tests/liveblog-inline-slots.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { breakpoints } from '../../fixtures/breakpoints';
-import { blogs } from '../../fixtures/pages';
-import { cmpAcceptAll } from '../../lib/cmp';
-import { loadPage } from '../../lib/load-page';
-import { countLiveblogInlineSlots } from '../../lib/util';
+import { breakpoints } from '../fixtures/breakpoints';
+import { blogs } from '../fixtures/pages';
+import { cmpAcceptAll } from '../lib/cmp';
+import { loadPage } from '../lib/load-page';
+import { countLiveblogInlineSlots } from '../lib/util';
 
 const blogPages = blogs.filter(
 	(page) =>

--- a/playwright/tests/liveblog-live-update.spec.ts
+++ b/playwright/tests/liveblog-live-update.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { breakpoints } from '../../fixtures/breakpoints';
-import { blogs } from '../../fixtures/pages';
-import { cmpAcceptAll } from '../../lib/cmp';
-import { loadPage } from '../../lib/load-page';
-import { countLiveblogInlineSlots } from '../../lib/util';
+import { breakpoints } from '../fixtures/breakpoints';
+import { blogs } from '../fixtures/pages';
+import { cmpAcceptAll } from '../lib/cmp';
+import { loadPage } from '../lib/load-page';
+import { countLiveblogInlineSlots } from '../lib/util';
 
 /**
  * TODO serial e2e tests

--- a/playwright/tests/merchandising-high.spec.ts
+++ b/playwright/tests/merchandising-high.spec.ts
@@ -1,15 +1,15 @@
 import { test } from '@playwright/test';
 import { isDefined } from 'core/types';
-import { breakpoints } from '../../fixtures/breakpoints';
-import { articles, blogs } from '../../fixtures/pages';
-import type { GuPage } from '../../fixtures/pages/Page';
-import { cmpAcceptAll } from '../../lib/cmp';
-import { loadPage } from '../../lib/load-page';
-import { waitForSlot } from '../../lib/util';
+import { breakpoints } from '../fixtures/breakpoints';
+import { articles, blogs } from '../fixtures/pages';
+import type { GuPage } from '../fixtures/pages/Page';
+import { cmpAcceptAll } from '../lib/cmp';
+import { loadPage } from '../lib/load-page';
+import { waitForSlot } from '../lib/util';
 
 const pages = [articles[0], blogs[0]].filter<GuPage>(isDefined);
 
-test.describe('merchandising slot', () => {
+test.describe('merchandising high slot', () => {
 	pages.forEach(({ path }, index) => {
 		breakpoints.forEach(({ breakpoint, width, height }) => {
 			test(`Test page ${index} has slot and iframe at breakpoint ${breakpoint}`, async ({
@@ -23,7 +23,7 @@ test.describe('merchandising slot', () => {
 				await loadPage(page, path);
 				await cmpAcceptAll(page);
 
-				await waitForSlot(page, 'merchandising');
+				await waitForSlot(page, 'merchandising-high');
 			});
 		});
 	});

--- a/playwright/tests/merchandising.spec.ts
+++ b/playwright/tests/merchandising.spec.ts
@@ -1,15 +1,15 @@
 import { test } from '@playwright/test';
 import { isDefined } from 'core/types';
-import { breakpoints } from '../../fixtures/breakpoints';
-import { articles, blogs } from '../../fixtures/pages';
-import type { GuPage } from '../../fixtures/pages/Page';
-import { cmpAcceptAll } from '../../lib/cmp';
-import { loadPage } from '../../lib/load-page';
-import { waitForSlot } from '../../lib/util';
+import { breakpoints } from '../fixtures/breakpoints';
+import { articles, blogs } from '../fixtures/pages';
+import type { GuPage } from '../fixtures/pages/Page';
+import { cmpAcceptAll } from '../lib/cmp';
+import { loadPage } from '../lib/load-page';
+import { waitForSlot } from '../lib/util';
 
 const pages = [articles[0], blogs[0]].filter<GuPage>(isDefined);
 
-test.describe('merchandising high slot', () => {
+test.describe('merchandising slot', () => {
 	pages.forEach(({ path }, index) => {
 		breakpoints.forEach(({ breakpoint, width, height }) => {
 			test(`Test page ${index} has slot and iframe at breakpoint ${breakpoint}`, async ({
@@ -23,7 +23,7 @@ test.describe('merchandising high slot', () => {
 				await loadPage(page, path);
 				await cmpAcceptAll(page);
 
-				await waitForSlot(page, 'merchandising-high');
+				await waitForSlot(page, 'merchandising');
 			});
 		});
 	});

--- a/playwright/tests/mostpop.spec.ts
+++ b/playwright/tests/mostpop.spec.ts
@@ -1,11 +1,11 @@
 import { test } from '@playwright/test';
 import { isDefined } from 'core/types';
-import { testAtBreakpoints } from '../../fixtures/breakpoints';
-import { articles, blogs } from '../../fixtures/pages';
-import type { GuPage } from '../../fixtures/pages/Page';
-import { cmpAcceptAll } from '../../lib/cmp';
-import { loadPage } from '../../lib/load-page';
-import { waitForSlot } from '../../lib/util';
+import { testAtBreakpoints } from '../fixtures/breakpoints';
+import { articles, blogs } from '../fixtures/pages';
+import type { GuPage } from '../fixtures/pages/Page';
+import { cmpAcceptAll } from '../lib/cmp';
+import { loadPage } from '../lib/load-page';
+import { waitForSlot } from '../lib/util';
 
 const pages = [articles[0], blogs[0]].filter<GuPage>(isDefined);
 

--- a/playwright/tests/pageskin.spec.ts
+++ b/playwright/tests/pageskin.spec.ts
@@ -1,11 +1,11 @@
 import type { Page } from '@playwright/test';
 import { expect, test } from '@playwright/test';
-import { breakpoints } from '../../fixtures/breakpoints';
-import { frontWithPageSkin } from '../../fixtures/pages';
-import { cmpAcceptAll } from '../../lib/cmp';
-import { assertHeader, waitForGAMResponseForSlot } from '../../lib/gam';
-import { loadPage } from '../../lib/load-page';
-import { waitForSlot } from '../../lib/util';
+import { breakpoints } from '../fixtures/breakpoints';
+import { frontWithPageSkin } from '../fixtures/pages';
+import { cmpAcceptAll } from '../lib/cmp';
+import { assertHeader, waitForGAMResponseForSlot } from '../lib/gam';
+import { loadPage } from '../lib/load-page';
+import { waitForSlot } from '../lib/util';
 
 const large = breakpoints.filter(
 	({ breakpoint }) => breakpoint === 'desktop' || breakpoint === 'wide',

--- a/playwright/tests/right-slot.spec.ts
+++ b/playwright/tests/right-slot.spec.ts
@@ -1,9 +1,9 @@
 import { breakpoints } from '@guardian/source-foundations';
 import { test } from '@playwright/test';
-import { allPages } from '../../fixtures/pages';
-import { cmpAcceptAll } from '../../lib/cmp';
-import { loadPage } from '../../lib/load-page';
-import { waitForSlot } from '../../lib/util';
+import { allPages } from '../fixtures/pages';
+import { cmpAcceptAll } from '../lib/cmp';
+import { loadPage } from '../lib/load-page';
+import { waitForSlot } from '../lib/util';
 
 test.describe('right slot', () => {
 	[...allPages].forEach(({ path }, index) => {

--- a/playwright/tests/sponsor-logo.spec.ts
+++ b/playwright/tests/sponsor-logo.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@playwright/test';
-import { cmpAcceptAll } from '../../lib/cmp';
-import { loadPage } from '../../lib/load-page';
-import { getStage, getTestUrl, waitForSlot } from '../../lib/util';
+import { cmpAcceptAll } from '../lib/cmp';
+import { loadPage } from '../lib/load-page';
+import { getStage, getTestUrl, waitForSlot } from '../lib/util';
 
 test.describe('sponsorshipLogo', () => {
 	test('sponsor logo ad is correctly filled in thrasher fixture', async ({

--- a/playwright/tests/targeting.spec.ts
+++ b/playwright/tests/targeting.spec.ts
@@ -1,16 +1,16 @@
 import type { Request } from '@playwright/test';
 import { expect, test } from '@playwright/test';
-import { allPages, articles } from '../../fixtures/pages';
-import type { GuPage } from '../../fixtures/pages/Page';
-import { bidderURLs, wins } from '../../fixtures/prebid';
-import { cmpAcceptAll } from '../../lib/cmp';
+import { allPages, articles } from '../fixtures/pages';
+import type { GuPage } from '../fixtures/pages/Page';
+import { bidderURLs, wins } from '../fixtures/prebid';
+import { cmpAcceptAll } from '../lib/cmp';
 import {
 	assertRequestParameter,
 	gamUrl,
 	getEncodedParamsFromRequest,
 	waitForGAMRequestForSlot,
-} from '../../lib/gam';
-import { loadPage } from '../../lib/load-page';
+} from '../lib/gam';
+import { loadPage } from '../lib/load-page';
 
 const article = articles[0] as unknown as GuPage;
 

--- a/playwright/tests/top-above-nav.spec.ts
+++ b/playwright/tests/top-above-nav.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test';
-import { allPages } from '../../fixtures/pages';
-import { cmpAcceptAll } from '../../lib/cmp';
-import { loadPage } from '../../lib/load-page';
-import { waitForSlot } from '../../lib/util';
+import { allPages } from '../fixtures/pages';
+import { cmpAcceptAll } from '../lib/cmp';
+import { loadPage } from '../lib/load-page';
+import { waitForSlot } from '../lib/util';
 
 test.describe('top-above-nav slot', () => {
 	[...allPages].forEach(({ path }, index) => {


### PR DESCRIPTION
## What does this change?
Use playwright [sharding](https://playwright.dev/docs/test-sharding) to automatically assign tests to the CI workers

## Why?
Micro improvement in run time and no need for the `parallel-{x}` directories
