### PR TITLE
add changeset for removing user features

### DIFF
--- a/.changeset/tidy-lizards-develop.md
+++ b/.changeset/tidy-lizards-develop.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+removes user-features module and related code as well as redundant refs to shady-pie in adblock-ask


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?
This PR adds a changeset for the PR `remove user-features module and related code`: https://github.com/guardian/commercial/pull/1173


## Why?
In order to release and bump the change in commercial appropriately