### PR TITLE
More commercial metrics

### DIFF
--- a/.changeset/dull-jeans-reply.md
+++ b/.changeset/dull-jeans-reply.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+More commercial metrics

--- a/src/core/event-timer.ts
+++ b/src/core/event-timer.ts
@@ -27,7 +27,12 @@ const trackedSlots = ['top-above-nav', 'inline1', 'inline2'] as const;
 type TrackedSlot = (typeof trackedSlots)[number];
 
 // marks that we want to save as commercial metrics
-const slotMarks = ['slotReady', 'adRenderStart', 'adOnPage'] as const;
+const slotMarks = [
+	'slotReady',
+	'adRenderStart',
+	'adOnPage',
+	'viewable',
+] as const;
 
 type SlotMark = (typeof slotMarks)[number];
 

--- a/src/core/event-timer.ts
+++ b/src/core/event-timer.ts
@@ -22,7 +22,13 @@ interface EventTimerProperties {
 }
 
 // Events will be logged using the performance API for all slots, but only these slots will be tracked as commercial metrics and sent to the data lake
-const trackedSlots = ['top-above-nav', 'inline1', 'inline2'] as const;
+const trackedSlots = [
+	'top-above-nav',
+	'inline1',
+	'inline2',
+	'fronts-banner-1',
+	'fronts-banner-2',
+] as const;
 
 type TrackedSlot = (typeof trackedSlots)[number];
 
@@ -30,6 +36,7 @@ type TrackedSlot = (typeof trackedSlots)[number];
 const slotMarks = [
 	'slotReady',
 	'adRenderStart',
+	'prebidStart',
 	'adOnPage',
 	'viewable',
 ] as const;

--- a/src/dfp/on-slot-viewable.ts
+++ b/src/dfp/on-slot-viewable.ts
@@ -1,4 +1,5 @@
 import { log } from '@guardian/libs';
+import { EventTimer } from 'core';
 import { outstreamSizes } from 'core/ad-sizes';
 import { AD_LABEL_HEIGHT } from 'core/constants/ad-label-height';
 import fastdom from 'lib/fastdom-promise';
@@ -121,12 +122,11 @@ const onSlotViewableFunction = (): ((
 ) => void) => {
 	const queryParams = getUrlVars();
 
-	if (queryParams.adrefresh !== 'false') {
-		return setSlotAdRefresh;
-	}
-
-	return () => {
-		/* */
+	return (event: googletag.events.ImpressionViewableEvent) => {
+		EventTimer.get().mark('viewable', event.slot.getTargeting('slot')[0]);
+		if (queryParams.adrefresh !== 'false') {
+			setSlotAdRefresh(event);
+		}
 	};
 };
 


### PR DESCRIPTION
## What does this change?
Add a few more marks to commercial metrics
- viewable
- prebidStart

also track metrics for the first 2 fronts-banners

## Why?
`viewable` - don't know why we don't have this to be honest! Records the timestamp when the slot became viewable
`prebidStart` - because we may [separate running prebid for slots from fetching the ad](https://github.com/guardian/commercial/pull/1057), this could be useful for determining if prebid is running sufficiently in advance.
