### PR TITLE
Playwright stability tweaks

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -56,7 +56,7 @@ jobs:
             ghcr.io/guardian/dotcom-rendering:main
 
       - name: Install Playwright Browsers
-        run: yarn playwright install --with-deps
+        run: yarn playwright install --with-deps chromium
         working-directory: ./commercial
 
       - name: Start Commercial server

--- a/playwright/fixtures/pages/articles.ts
+++ b/playwright/fixtures/pages/articles.ts
@@ -32,14 +32,6 @@ const articles: GuPage[] = [
 		}),
 		name: 'sensitive-content',
 	},
-	{
-		path: getTestUrl({
-			stage,
-			path: '/politics/2022/feb/10/keir-starmer-says-stop-the-war-coalition-gives-help-to-authoritarians-like-putin',
-			type: 'article',
-			adtest: 'comdev',
-		}),
-	},
 ];
 
 export { articles };

--- a/playwright/lib/load-page.ts
+++ b/playwright/lib/load-page.ts
@@ -21,6 +21,7 @@ const loadPage = async (page: Page, path: string, region = 'GB') => {
 	//
 	// Instead of aborting ophan change the waituntil to 'domcontentloaded'
 	// rather than 'load'. Monitor this to see if it works for our use cases.
+	console.log('Loading page', path);
 	await page.goto(path, { waitUntil: 'domcontentloaded' });
 };
 

--- a/playwright/lib/util.ts
+++ b/playwright/lib/util.ts
@@ -164,7 +164,7 @@ const clearCookie = async (context: BrowserContext, cookieName: string) => {
 const fakeLogOut = async (context: BrowserContext) =>
 	await clearCookie(context, 'GU_U');
 
-const waitForSlot = async (page: Page, slot: string) => {
+const waitForSlot = async (page: Page, slot: string, waitForIframe = true) => {
 	const slotId = `#dfp-ad--${slot}`;
 	// create a locator for the slot
 	const slotLocator = page.locator(slotId);
@@ -172,10 +172,13 @@ const waitForSlot = async (page: Page, slot: string) => {
 	await slotLocator.isVisible();
 	// scroll to it
 	await slotLocator.scrollIntoViewIfNeeded();
-	// iframe locator
-	const iframe = page.locator(`${slotId} iframe`);
-	// wait for the iframe
-	await iframe.waitFor({ state: 'visible', timeout: 120000 });
+
+	if (waitForIframe) {
+		// iframe locator
+		const iframe = page.locator(`${slotId} iframe`);
+		// wait for the iframe
+		await iframe.waitFor({ state: 'visible', timeout: 120000 });
+	}
 };
 
 const waitForIsland = async (page: Page, island: string) => {

--- a/playwright/tests/pageskin.spec.ts
+++ b/playwright/tests/pageskin.spec.ts
@@ -80,7 +80,7 @@ test.describe('pageskin on uk front', () => {
 			await cmpAcceptAll(page);
 
 			// need to wait for top-above-nav on mobile as it is out of view
-			await waitForSlot(page, slotWithPostfix);
+			await waitForSlot(page, slotWithPostfix, false);
 
 			const response = await gamResponsePromise;
 

--- a/playwright/tests/right-slot.spec.ts
+++ b/playwright/tests/right-slot.spec.ts
@@ -11,7 +11,7 @@ test.describe('right slot', () => {
 			// viewport width has to be >= 1300px for the right column to appear on liveblogs
 			await page.setViewportSize({
 				width: breakpoints['wide'],
-				height: 200,
+				height: 800,
 			});
 
 			await loadPage(page, path);

--- a/src/dfp/empty-advert.ts
+++ b/src/dfp/empty-advert.ts
@@ -1,3 +1,4 @@
+import { log } from '@guardian/libs';
 import fastdom from 'fastdom';
 import type { Advert } from './Advert';
 import { dfpEnv } from './dfp-env';
@@ -18,6 +19,7 @@ const removeAd = (advert: Advert) => {
 };
 
 const emptyAdvert = (advert: Advert): void => {
+	log('commercial', `Removing empty advert: ${advert.id}`);
 	fastdom.mutate(() => {
 		window.googletag.destroySlots([advert.slot]);
 		removeAd(advert);

--- a/src/lib/remove-slots.ts
+++ b/src/lib/remove-slots.ts
@@ -23,7 +23,7 @@ const filterDisabledNodes = (nodes: Element[]) => nodes.filter(isDisabled);
 const removeNodes = (nodes: Element[]): Promise<void> =>
 	fastdom.mutate(() =>
 		nodes.forEach((node) => {
-			log('commercial', `Removing ad slot ${node.id}`);
+			log('commercial', `Removing ad slot: ${node.id}`);
 			node.remove();
 		}),
 	);


### PR DESCRIPTION
## What does this change?

Some minor tweaks to improve Playwright test stability:

- add logging to help diagnose when ad slots are not fulfilled. This is an indication that we are not requesting an adtest and therefore requesting real ads from GAM which may not fulfill (h/t @Jakeii )

- remove the opt-out specific article and adtest from the articles list

- from the opt-out UI the adtest has been changed from `comdev` to `fixed-puppies-ci`. This makes it easier to ensure we are using the default adtest across gam and opt-out tests

- don' wait for the top-above-nav slot in the page-skin tablet and mobile tests as the pageskin adtest will not appply (> desktop) and so it goes out to regular GAM ads and may not fulfill

- perf tweak to only install Chromium browsers on CI as that is all we test against



