### PR TITLE
Fix Playwright CI for PageSkins on tablet test

### DIFF
--- a/playwright/tests/pageskin.spec.ts
+++ b/playwright/tests/pageskin.spec.ts
@@ -53,13 +53,6 @@ test.describe('pageskin on uk front', () => {
 	});
 
 	small.forEach(({ breakpoint, width, height }) => {
-		if (breakpoint === 'tablet') {
-			/**
-			 * TODO e2e flakey test
-			 * The test for tablet always passes locally but always fails on CI
-			 */
-			return;
-		}
 		test(`Test pageskin front on ${breakpoint} should NOT display the pageskin and NOT use single request mode`, async ({
 			page,
 		}: {


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

This PR removes the conditional statement that excluded Pageskins on tablet test. 

## Why?
