### PR TITLE
Add mobile sticky to ROW 

### DIFF
--- a/.changeset/dry-terms-invite.md
+++ b/.changeset/dry-terms-invite.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Add mobile-sticky to ROW

--- a/src/header-bidding/utils.spec.ts
+++ b/src/header-bidding/utils.spec.ts
@@ -344,17 +344,26 @@ describe('Utils', () => {
 		});
 	});
 
-	const regions: CountryCode[] = ['US', 'CA', 'AU', 'NZ'];
+	const regionsTestCases: Array<{ region: CountryCode; expected: boolean }> =
+		[
+			{ region: 'US', expected: true },
+			{ region: 'CA', expected: true },
+			{ region: 'AU', expected: true },
+			{ region: 'NZ', expected: true },
+			{ region: 'GB', expected: false },
+			{ region: 'BE', expected: true },
+			{ region: 'EG', expected: true },
+		];
 
-	regions.forEach((region) => {
-		test(`should include mobile sticky if geolocation is ${region} and content is Article on mobiles`, () => {
+	test.each(regionsTestCases)(
+		`should include mobile sticky $expected if geolocation is $region and content is Article on mobiles`,
+		({ region, expected }) => {
 			window.guardian.config.page.contentType = 'Article';
-
 			getCountryCode.mockReturnValue(region);
 			matchesBreakpoints.mockReturnValue(true);
-			expect(shouldIncludeMobileSticky()).toBe(true);
-		});
-	});
+			expect(shouldIncludeMobileSticky()).toBe(expected);
+		},
+	);
 
 	test('shouldIncludeMobileSticky should be false if all conditions true except content type ', () => {
 		window.guardian.config.page.contentType = 'Network Front';

--- a/src/header-bidding/utils.ts
+++ b/src/header-bidding/utils.ts
@@ -199,7 +199,7 @@ export const shouldIncludeMobileSticky = once(
 			min: 'mobile',
 			max: 'mobileLandscape',
 		}) &&
-			(isInUsOrCa() || isInAuOrNz()) &&
+			!isInUk() &&
 			window.guardian.config.page.contentType === 'Article' &&
 			!window.guardian.config.page.isHosted),
 );


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

This PR adds the `mobile-sticky` slot to ROW.

Any questions on this format, chat to Alex Amoui @Amouzle 

## Why?

Increase inventory for the mobile sticky slot.
