### PR TITLE
Refactor Improve Digital unit tests

### DIFF
--- a/src/header-bidding/prebid/bid-config.spec.ts
+++ b/src/header-bidding/prebid/bid-config.spec.ts
@@ -11,7 +11,6 @@ import {
 import type { HeaderBiddingSize, PrebidBidder } from '../prebid-types';
 import {
 	containsBillboard as containsBillboard_,
-	containsBillboardNotLeaderboard as containsBillboardNotLeaderboard_,
 	containsDmpu as containsDmpu_,
 	containsLeaderboard as containsLeaderboard_,
 	containsLeaderboardOrBillboard as containsLeaderboardOrBillboard_,
@@ -31,10 +30,6 @@ import {
 	stripMobileSuffix as stripMobileSuffix_,
 } from '../utils';
 import { _, bids } from './bid-config';
-import {
-	getImprovePlacementId,
-	getImproveSkinPlacementId,
-} from './improve-digital';
 
 const mockPageTargeting = {} as unknown as PageTargeting;
 
@@ -60,8 +55,6 @@ jest.mock('lib/build-page-targeting', () => ({
 
 jest.mock('../utils');
 const containsBillboard = containsBillboard_ as jest.Mock;
-const containsBillboardNotLeaderboard =
-	containsBillboardNotLeaderboard_ as jest.Mock;
 const containsDmpu = containsDmpu_ as jest.Mock;
 const containsLeaderboard = containsLeaderboard_ as jest.Mock;
 const containsLeaderboardOrBillboard =
@@ -123,208 +116,6 @@ const resetConfig = () => {
 	window.guardian.config.page.section = 'Magic';
 	window.guardian.config.page.isDev = false;
 };
-
-describe('getImprovePlacementId', () => {
-	beforeEach(() => {
-		resetConfig();
-	});
-
-	afterEach(() => {
-		jest.resetAllMocks();
-	});
-
-	const generateTestIds = () => {
-		const prebidSizes: HeaderBiddingSize[][] = [
-			[createAdSize(300, 250)],
-			[createAdSize(300, 600)],
-			[createAdSize(970, 250)],
-			[createAdSize(728, 90)],
-			[createAdSize(1, 2)],
-		];
-
-		return prebidSizes.map((size) => getImprovePlacementId(size));
-	};
-
-	test('should return -1 if no cases match', () => {
-		expect(getImprovePlacementId([createAdSize(1, 2)])).toBe(-1);
-	});
-
-	test('should give the expected values when there is a billboard but NOT a leaderboard', () => {
-		isInUk.mockReturnValue(true);
-		getBreakpointKey.mockReturnValue('D');
-		containsBillboardNotLeaderboard.mockReturnValueOnce(true);
-		containsMpuOrDmpu.mockReturnValueOnce(false);
-		containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-
-		expect(getImprovePlacementId([])).toEqual(22987847);
-	});
-
-	test('should give the expected values when there is a leaderboard but NOT a billboard', () => {
-		isInUk.mockReturnValue(true);
-		getBreakpointKey.mockReturnValue('D');
-		containsBillboardNotLeaderboard.mockReturnValueOnce(false);
-		containsMpuOrDmpu.mockReturnValueOnce(false);
-		containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-
-		expect(getImprovePlacementId([])).toEqual(1116397);
-	});
-
-	test('should give the expected values when there is a billboard AND a leaderboard', () => {
-		isInUk.mockReturnValue(true);
-		getBreakpointKey.mockReturnValue('D');
-		containsBillboardNotLeaderboard.mockReturnValueOnce(false);
-		containsMpuOrDmpu.mockReturnValueOnce(false);
-		containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-
-		expect(getImprovePlacementId([])).toEqual(1116397);
-	});
-
-	test('should return the expected values when geolocated in UK and on desktop device', () => {
-		isInUk.mockReturnValue(true);
-		getBreakpointKey.mockReturnValue('D');
-		containsMpuOrDmpu.mockReturnValueOnce(true);
-		containsMpuOrDmpu.mockReturnValueOnce(true);
-		containsMpuOrDmpu.mockReturnValue(false);
-		containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-		containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-		containsLeaderboardOrBillboard.mockReturnValue(false);
-		expect(generateTestIds()).toEqual([
-			1116396, 1116396, 1116397, 1116397, -1,
-		]);
-	});
-
-	test('should return the expected values when geolocated in UK and on tablet device', () => {
-		isInUk.mockReturnValue(true);
-		getBreakpointKey.mockReturnValue('T');
-		containsMpuOrDmpu.mockReturnValueOnce(true);
-		containsMpuOrDmpu.mockReturnValueOnce(true);
-		containsMpuOrDmpu.mockReturnValue(false);
-		containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-		containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-		containsLeaderboardOrBillboard.mockReturnValue(false);
-		expect(generateTestIds()).toEqual([
-			1116398, 1116398, 1116399, 1116399, -1,
-		]);
-	});
-
-	test('should return the expected values when geolocated in UK and on mobile device', () => {
-		isInUk.mockReturnValue(true);
-		getBreakpointKey.mockReturnValue('M');
-		containsMpuOrDmpu.mockReturnValueOnce(true);
-		containsMpuOrDmpu.mockReturnValueOnce(true);
-		containsMpuOrDmpu.mockReturnValue(false);
-		containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-		containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-		containsLeaderboardOrBillboard.mockReturnValue(false);
-		expect(generateTestIds()).toEqual([1116400, 1116400, -1, -1, -1]);
-	});
-
-	test('should return the expected values when geolocated in ROW region and on desktop device', () => {
-		isInRow.mockReturnValue(true);
-		getBreakpointKey.mockReturnValue('D');
-		containsMpuOrDmpu.mockReturnValueOnce(true);
-		containsMpuOrDmpu.mockReturnValueOnce(true);
-		containsMpuOrDmpu.mockReturnValue(false);
-		containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-		containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-		containsLeaderboardOrBillboard.mockReturnValue(false);
-		expect(generateTestIds()).toEqual([
-			1116420, 1116420, 1116421, 1116421, -1,
-		]);
-	});
-
-	test('should return the expected values when not geolocated in ROW region and on tablet device', () => {
-		isInRow.mockReturnValue(true);
-		getBreakpointKey.mockReturnValue('T');
-		containsMpuOrDmpu.mockReturnValueOnce(true);
-		containsMpuOrDmpu.mockReturnValueOnce(true);
-		containsMpuOrDmpu.mockReturnValue(false);
-		containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-		containsLeaderboardOrBillboard.mockReturnValueOnce(true);
-		containsLeaderboardOrBillboard.mockReturnValue(false);
-		expect(generateTestIds()).toEqual([
-			1116422, 1116422, 1116423, 1116423, -1,
-		]);
-	});
-
-	test('should return the expected values when geolocated in ROW region and on mobile device', () => {
-		isInRow.mockReturnValue(true);
-		getBreakpointKey.mockReturnValue('M');
-		containsMpuOrDmpu.mockReturnValueOnce(true);
-		containsMpuOrDmpu.mockReturnValueOnce(true);
-		containsMpuOrDmpu.mockReturnValue(false);
-		expect(generateTestIds()).toEqual([1116424, 1116424, -1, -1, -1]);
-	});
-
-	test('should return -1 if geolocated in US or AU regions', () => {
-		isInUsOrCa.mockReturnValue(true);
-		expect(generateTestIds()).toEqual([-1, -1, -1, -1, -1]);
-		isInAuOrNz.mockReturnValue(true);
-		expect(generateTestIds()).toEqual([-1, -1, -1, -1, -1]);
-	});
-});
-
-describe('getImproveSkinPlacementId', () => {
-	beforeEach(() => {
-		resetConfig();
-		getBreakpointKey.mockReturnValue('D');
-	});
-
-	afterEach(() => {
-		jest.resetAllMocks();
-	});
-
-	const ID_UK = 22526482;
-	const ID_ROW = 22526483;
-
-	test(`should return ${ID_UK} if in the UK`, () => {
-		isInUk.mockReturnValue(true);
-		expect(getImproveSkinPlacementId()).toBe(ID_UK);
-	});
-
-	test(`should return ${ID_UK} when geolocated in UK and on desktop device`, () => {
-		isInUk.mockReturnValue(true);
-		getBreakpointKey.mockReturnValue('D');
-		expect(getImproveSkinPlacementId()).toEqual(ID_UK);
-	});
-
-	test('should return -1 when geolocated in UK and on tablet device', () => {
-		isInUk.mockReturnValue(true);
-		getBreakpointKey.mockReturnValue('T');
-		expect(getImproveSkinPlacementId()).toEqual(-1);
-	});
-
-	test('should return -1 values when geolocated in UK and on mobile device', () => {
-		isInUk.mockReturnValue(true);
-		getBreakpointKey.mockReturnValue('M');
-		expect(getImproveSkinPlacementId()).toEqual(-1);
-	});
-
-	test(`should return ${ID_ROW} when geolocated in ROW region and on desktop device`, () => {
-		isInRow.mockReturnValue(true);
-		getBreakpointKey.mockReturnValue('D');
-		expect(getImproveSkinPlacementId()).toEqual(ID_ROW);
-	});
-
-	test('should return -1 when not geolocated in ROW region and on tablet device', () => {
-		isInRow.mockReturnValue(true);
-		getBreakpointKey.mockReturnValue('T');
-		expect(getImproveSkinPlacementId()).toEqual(-1);
-	});
-
-	test('should return -1 when geolocated in ROW region and on mobile device', () => {
-		isInRow.mockReturnValue(true);
-		getBreakpointKey.mockReturnValue('M');
-		expect(getImproveSkinPlacementId()).toEqual(-1);
-	});
-
-	test('should return -1 if geolocated in US or AU regions', () => {
-		isInUsOrCa.mockReturnValue(true);
-		expect(getImproveSkinPlacementId()).toEqual(-1);
-		isInAuOrNz.mockReturnValue(true);
-		expect(getImproveSkinPlacementId()).toEqual(-1);
-	});
-});
 
 describe('getTrustXAdUnitId', () => {
 	beforeEach(() => {
@@ -758,10 +549,6 @@ describe('getXaxisPlacementId', () => {
 		];
 		return prebidSizes.map(getXaxisPlacementId);
 	};
-
-	test('should return -1 if no cases match', () => {
-		expect(getImprovePlacementId([createAdSize(1, 2)])).toBe(-1);
-	});
 
 	test('should return the expected values for desktop device', () => {
 		getBreakpointKey.mockReturnValue('D');

--- a/src/header-bidding/prebid/improve-digital.spec.ts
+++ b/src/header-bidding/prebid/improve-digital.spec.ts
@@ -1,0 +1,233 @@
+import { createAdSize } from 'core';
+import {
+	isInAuOrNz as isInAuOrNz_,
+	isInRow as isInRow_,
+	isInUk as isInUk_,
+	isInUsOrCa as isInUsOrCa_,
+} from 'utils/geo-utils';
+import { getBreakpointKey as getBreakpointKey_ } from '../utils';
+import {
+	getImprovePlacementId,
+	getImproveSkinPlacementId,
+} from './improve-digital';
+
+const getBreakpointKey = getBreakpointKey_ as jest.Mock;
+const isInAuOrNz = isInAuOrNz_ as jest.Mock;
+const isInRow = isInRow_ as jest.Mock;
+const isInUk = isInUk_ as jest.Mock;
+const isInUsOrCa = isInUsOrCa_ as jest.Mock;
+
+jest.mock('experiments/ab', () => ({
+	isInVariantSynchronous: jest.fn(),
+}));
+jest.mock('utils/geo-utils');
+
+jest.mock('../utils', () => ({
+	...jest.requireActual('../utils'),
+	getBreakpointKey: jest.fn(),
+}));
+
+describe('getImprovePlacementId', () => {
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	test.each([
+		{ sizes: [createAdSize(970, 250)], expectedId: 22987847 },
+		{ sizes: [createAdSize(728, 90)], expectedId: 1116397 },
+		{
+			sizes: [createAdSize(728, 90), createAdSize(970, 250)],
+			expectedId: 1116397,
+		},
+		{ sizes: [createAdSize(300, 250)], expectedId: 1116396 },
+		{ sizes: [createAdSize(300, 600)], expectedId: 1116396 },
+		{ sizes: [createAdSize(1, 2)], expectedId: -1 },
+	])(
+		'in UK on desktop case %p gives correct placement id',
+		({ sizes, expectedId }) => {
+			isInUk.mockReturnValue(true);
+			getBreakpointKey.mockReturnValueOnce('D');
+			expect(getImprovePlacementId(sizes)).toBe(expectedId);
+		},
+	);
+
+	test.each([
+		{ sizes: [createAdSize(970, 250)], expectedId: 1116399 },
+		{ sizes: [createAdSize(728, 90)], expectedId: 1116399 },
+		{
+			sizes: [createAdSize(728, 90), createAdSize(970, 250)],
+			expectedId: 1116399,
+		},
+		{ sizes: [createAdSize(300, 250)], expectedId: 1116398 },
+		{ sizes: [createAdSize(300, 600)], expectedId: 1116398 },
+		{ sizes: [createAdSize(1, 2)], expectedId: -1 },
+	])(
+		'in UK and on tablet %p returns correct placement id',
+		({ sizes, expectedId }) => {
+			isInUk.mockReturnValue(true);
+			getBreakpointKey.mockReturnValueOnce('T');
+			expect(getImprovePlacementId(sizes)).toBe(expectedId);
+		},
+	);
+
+	test.each([
+		{ sizes: [createAdSize(970, 250)], expectedId: -1 },
+		{ sizes: [createAdSize(728, 90)], expectedId: -1 },
+		{
+			sizes: [createAdSize(728, 90), createAdSize(970, 250)],
+			expectedId: -1,
+		},
+		{ sizes: [createAdSize(300, 250)], expectedId: 1116400 },
+		{ sizes: [createAdSize(300, 600)], expectedId: 1116400 },
+		{ sizes: [createAdSize(1, 2)], expectedId: -1 },
+	])(
+		'in UK and on mobile %p returns correct placement id',
+		({ sizes, expectedId }) => {
+			isInUk.mockReturnValue(true);
+			getBreakpointKey.mockReturnValueOnce('M');
+			expect(getImprovePlacementId(sizes)).toBe(expectedId);
+		},
+	);
+
+	test.each([
+		{ sizes: [createAdSize(970, 250)], expectedId: 1116421 },
+		{ sizes: [createAdSize(728, 90)], expectedId: 1116421 },
+		{
+			sizes: [createAdSize(728, 90), createAdSize(970, 250)],
+			expectedId: 1116421,
+		},
+		{ sizes: [createAdSize(300, 250)], expectedId: 1116420 },
+		{ sizes: [createAdSize(300, 600)], expectedId: 1116420 },
+		{ sizes: [createAdSize(1, 2)], expectedId: -1 },
+	])(
+		'in ROW and on desktop %p returns correct placement id',
+		({ sizes, expectedId }) => {
+			isInRow.mockReturnValue(true);
+			getBreakpointKey.mockReturnValueOnce('D');
+			expect(getImprovePlacementId(sizes)).toBe(expectedId);
+		},
+	);
+
+	test.each([
+		{ sizes: [createAdSize(970, 250)], expectedId: 1116423 },
+		{ sizes: [createAdSize(728, 90)], expectedId: 1116423 },
+		{
+			sizes: [createAdSize(728, 90), createAdSize(970, 250)],
+			expectedId: 1116423,
+		},
+		{ sizes: [createAdSize(300, 250)], expectedId: 1116422 },
+		{ sizes: [createAdSize(300, 600)], expectedId: 1116422 },
+		{ sizes: [createAdSize(1, 2)], expectedId: -1 },
+	])(
+		'in ROW and on tablet %p returns correct placement id',
+		({ sizes, expectedId }) => {
+			isInRow.mockReturnValue(true);
+			getBreakpointKey.mockReturnValueOnce('T');
+			expect(getImprovePlacementId(sizes)).toBe(expectedId);
+		},
+	);
+
+	test.each([
+		{ sizes: [createAdSize(970, 250)], expectedId: -1 },
+		{ sizes: [createAdSize(728, 90)], expectedId: -1 },
+		{
+			sizes: [createAdSize(728, 90), createAdSize(970, 250)],
+			expectedId: -1,
+		},
+		{ sizes: [createAdSize(300, 250)], expectedId: 1116424 },
+		{ sizes: [createAdSize(300, 600)], expectedId: 1116424 },
+		{ sizes: [createAdSize(1, 2)], expectedId: -1 },
+	])(
+		'in ROW and on mobile %p returns correct placement id',
+		({ sizes, expectedId }) => {
+			isInRow.mockReturnValue(true);
+			getBreakpointKey.mockReturnValueOnce('M');
+			expect(getImprovePlacementId(sizes)).toBe(expectedId);
+		},
+	);
+
+	test.each([
+		[[createAdSize(970, 250)]],
+		[[createAdSize(728, 90)]],
+		[[createAdSize(728, 90), createAdSize(970, 250)]],
+		[[createAdSize(300, 250)]],
+		[[createAdSize(300, 600)]],
+		[[createAdSize(1, 2)]],
+	])('in US returns placement id -1', (sizes) => {
+		isInUsOrCa.mockReturnValue(true);
+		expect(getImprovePlacementId(sizes)).toBe(-1);
+	});
+
+	test.each([
+		[[createAdSize(970, 250)]],
+		[[createAdSize(728, 90)]],
+		[[createAdSize(728, 90), createAdSize(970, 250)]],
+		[[createAdSize(300, 250)]],
+		[[createAdSize(300, 600)]],
+		[[createAdSize(1, 2)]],
+	])('in AUS returns placement id -1', (sizes) => {
+		isInAuOrNz.mockReturnValue(true);
+		expect(getImprovePlacementId(sizes)).toBe(-1);
+	});
+});
+
+describe('getImproveSkinPlacementId', () => {
+	beforeEach(() => {
+		getBreakpointKey.mockReturnValue('D');
+	});
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	const ID_UK = 22526482;
+	const ID_ROW = 22526483;
+
+	test(`should return ${ID_UK} if in the UK`, () => {
+		isInUk.mockReturnValue(true);
+		expect(getImproveSkinPlacementId()).toBe(ID_UK);
+	});
+
+	test(`should return ${ID_UK} when geolocated in UK and on desktop device`, () => {
+		isInUk.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('D');
+		expect(getImproveSkinPlacementId()).toEqual(ID_UK);
+	});
+
+	test('should return -1 when geolocated in UK and on tablet device', () => {
+		isInUk.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('T');
+		expect(getImproveSkinPlacementId()).toEqual(-1);
+	});
+
+	test('should return -1 values when geolocated in UK and on mobile device', () => {
+		isInUk.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('M');
+		expect(getImproveSkinPlacementId()).toEqual(-1);
+	});
+
+	test(`should return ${ID_ROW} when geolocated in ROW region and on desktop device`, () => {
+		isInRow.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('D');
+		expect(getImproveSkinPlacementId()).toEqual(ID_ROW);
+	});
+
+	test('should return -1 when geolocated in ROW region and on tablet device', () => {
+		isInRow.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('T');
+		expect(getImproveSkinPlacementId()).toEqual(-1);
+	});
+
+	test('should return -1 when geolocated in ROW region and on mobile device', () => {
+		isInRow.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('M');
+		expect(getImproveSkinPlacementId()).toEqual(-1);
+	});
+
+	test('should return -1 if geolocated in US or AU regions', () => {
+		isInUsOrCa.mockReturnValue(true);
+		expect(getImproveSkinPlacementId()).toEqual(-1);
+		isInAuOrNz.mockReturnValue(true);
+		expect(getImproveSkinPlacementId()).toEqual(-1);
+	});
+});


### PR DESCRIPTION
## What does this change?

- Split the Improve Digital placement ID unit tests out into a separate functions.
- Use table-driven tests via `test.each`.
- Only mock region / breakpoint, and avoid mocking checking the sizes (these functions are pure anyway!).

## Why?

This should make it easier to contribute to the tests moving forward.
