### PR TITLE
Enable Prebid for mobile sticky web in ROW

### DIFF
--- a/.changeset/nasty-bikes-melt.md
+++ b/.changeset/nasty-bikes-melt.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Add placement IDs to Prebid mobile-sticky

--- a/src/header-bidding/prebid/appnexus.ts
+++ b/src/header-bidding/prebid/appnexus.ts
@@ -42,8 +42,7 @@ const getAppNexusDirectPlacementId = (sizes: HeaderBiddingSize[]): string => {
 	}
 
 	if (isInRow() && containsMobileSticky(sizes)) {
-			return '31512573';
-		}
+		return '31512573';
 	}
 
 	const defaultPlacementId = '9251752';

--- a/src/header-bidding/prebid/appnexus.ts
+++ b/src/header-bidding/prebid/appnexus.ts
@@ -41,8 +41,7 @@ const getAppNexusDirectPlacementId = (sizes: HeaderBiddingSize[]): string => {
 		return '11016434';
 	}
 
-	if (isInRow()) {
-		if (containsMobileSticky(sizes)) {
+	if (isInRow() && containsMobileSticky(sizes)) {
 			return '31512573';
 		}
 	}

--- a/src/header-bidding/prebid/appnexus.ts
+++ b/src/header-bidding/prebid/appnexus.ts
@@ -1,11 +1,12 @@
 import type { PageTargeting } from 'core/targeting/build-page-targeting';
 import { buildAppNexusTargetingObject } from 'lib/build-page-targeting';
-import { isInAuOrNz } from 'utils/geo-utils';
+import { isInAuOrNz, isInRow } from 'utils/geo-utils';
 import type { HeaderBiddingSize } from '../prebid-types';
 import {
 	containsBillboardNotLeaderboard,
 	containsLeaderboard,
 	containsLeaderboardOrBillboard,
+	containsMobileSticky,
 	containsMpu,
 	containsMpuOrDmpu,
 	getBreakpointKey,
@@ -38,6 +39,12 @@ const getAppNexusInvCode = (sizes: HeaderBiddingSize[]): string | undefined => {
 const getAppNexusDirectPlacementId = (sizes: HeaderBiddingSize[]): string => {
 	if (isInAuOrNz()) {
 		return '11016434';
+	}
+
+	if (isInRow()) {
+		if (containsMobileSticky(sizes)) {
+			return '31512573';
+		}
 	}
 
 	const defaultPlacementId = '9251752';

--- a/src/header-bidding/prebid/bid-config.spec.ts
+++ b/src/header-bidding/prebid/bid-config.spec.ts
@@ -6,6 +6,7 @@ import {
 	isInAuOrNz as isInAuOrNz_,
 	isInRow as isInRow_,
 	isInUk as isInUk_,
+	isInUsa as isInUsa_,
 	isInUsOrCa as isInUsOrCa_,
 } from 'utils/geo-utils';
 import type { HeaderBiddingSize, PrebidBidder } from '../prebid-types';
@@ -45,6 +46,7 @@ const {
 	getXaxisPlacementId,
 	getTrustXAdUnitId,
 	indexExchangeBidders,
+	getOzonePlacementId,
 } = _;
 
 jest.mock('lib/build-page-targeting', () => ({
@@ -80,6 +82,7 @@ const isInAuOrNz = isInAuOrNz_ as jest.Mock;
 const isInRow = isInRow_ as jest.Mock;
 const isInUk = isInUk_ as jest.Mock;
 const isInUsOrCa = isInUsOrCa_ as jest.Mock;
+const isInUsa = isInUsa_ as jest.Mock;
 
 jest.mock('experiments/ab', () => ({
 	isInVariantSynchronous: jest.fn(),
@@ -343,13 +346,11 @@ describe('bids', () => {
 			[createAdSize(728, 90)],
 			mockPageTargeting,
 		)[2];
-		if (typeof openXBid !== 'undefined') {
-			expect(openXBid.params).toEqual({
-				customParams: 'someAppNexusTargetingObject',
-				delDomain: 'guardian-d.openx.net',
-				unit: '540279541',
-			});
-		}
+		expect(openXBid?.params).toEqual({
+			customParams: 'someAppNexusTargetingObject',
+			delDomain: 'guardian-d.openx.net',
+			unit: '540279541',
+		});
 	});
 
 	test('should use correct parameters in OpenX bids geolocated in US', () => {
@@ -360,13 +361,11 @@ describe('bids', () => {
 			[createAdSize(728, 90)],
 			mockPageTargeting,
 		)[2];
-		if (typeof openXBid !== 'undefined') {
-			expect(openXBid.params).toEqual({
-				customParams: 'someAppNexusTargetingObject',
-				delDomain: 'guardian-us-d.openx.net',
-				unit: '540279544',
-			});
-		}
+		expect(openXBid?.params).toEqual({
+			customParams: 'someAppNexusTargetingObject',
+			delDomain: 'guardian-us-d.openx.net',
+			unit: '540279544',
+		});
 	});
 
 	test('should use correct parameters in OpenX bids geolocated in AU', () => {
@@ -377,16 +376,14 @@ describe('bids', () => {
 			[createAdSize(728, 90)],
 			mockPageTargeting,
 		)[2];
-		if (typeof openXBid !== 'undefined') {
-			expect(openXBid.params).toEqual({
-				customParams: 'someAppNexusTargetingObject',
-				delDomain: 'guardian-aus-d.openx.net',
-				unit: '540279542',
-			});
-		}
+		expect(openXBid?.params).toEqual({
+			customParams: 'someAppNexusTargetingObject',
+			delDomain: 'guardian-aus-d.openx.net',
+			unit: '540279542',
+		});
 	});
 
-	test('should use correct parameters in OpenX bids geolocated in FR', () => {
+	test('should use correct parameters in OpenX bids geolocated in FR for top-above-nav', () => {
 		shouldIncludeOpenx.mockReturnValue(true);
 		isInRow.mockReturnValue(true);
 		const openXBid = bids(
@@ -394,13 +391,26 @@ describe('bids', () => {
 			[createAdSize(728, 90)],
 			mockPageTargeting,
 		)[2];
-		if (typeof openXBid !== 'undefined') {
-			expect(openXBid.params).toEqual({
-				customParams: 'someAppNexusTargetingObject',
-				delDomain: 'guardian-d.openx.net',
-				unit: '540279541',
-			});
-		}
+		expect(openXBid?.params).toEqual({
+			customParams: 'someAppNexusTargetingObject',
+			delDomain: 'guardian-d.openx.net',
+			unit: '540279541',
+		});
+	});
+	test('should use correct parameters in OpenX bids geolocated in FR for mobile-sticky', () => {
+		shouldIncludeOpenx.mockReturnValue(true);
+		isInRow.mockReturnValue(true);
+		containsMobileSticky.mockReturnValue(true);
+		const openXBid = bids(
+			'dfp-ad--mobile-sticky',
+			[createAdSize(320, 50)],
+			mockPageTargeting,
+		)[2];
+		expect(openXBid?.params).toEqual({
+			customParams: 'someAppNexusTargetingObject',
+			delDomain: 'guardian-d.openx.net',
+			unit: '560429384',
+		});
 	});
 });
 
@@ -570,5 +580,25 @@ describe('getXaxisPlacementId', () => {
 		expect(generateTestIds()).toEqual([
 			20943669, 20943669, 20943670, 20943670, 20943670,
 		]);
+	});
+});
+
+describe('getOzonePlacementId', () => {
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	test('should return correct placementID for mobile-sticky in US', () => {
+		isInUsa.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('M');
+		containsMobileSticky.mockReturnValue(true);
+		expect(getOzonePlacementId([createAdSize(320, 50)])).toBe('3500014217');
+	});
+
+	test('should return correct placementID for mobile-sticky in ROW', () => {
+		isInRow.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('M');
+		containsMobileSticky.mockReturnValue(true);
+		expect(getOzonePlacementId([createAdSize(320, 50)])).toBe('1500000260');
 	});
 });

--- a/src/header-bidding/prebid/bid-config.ts
+++ b/src/header-bidding/prebid/bid-config.ts
@@ -599,4 +599,5 @@ export const _ = {
 	getXaxisPlacementId,
 	getTrustXAdUnitId,
 	indexExchangeBidders,
+	getOzonePlacementId,
 };

--- a/src/header-bidding/prebid/improve-digital.spec.ts
+++ b/src/header-bidding/prebid/improve-digital.spec.ts
@@ -80,6 +80,7 @@ describe('getImprovePlacementId', () => {
 		{ sizes: [createAdSize(300, 250)], expectedId: 1116400 },
 		{ sizes: [createAdSize(300, 600)], expectedId: 1116400 },
 		{ sizes: [createAdSize(1, 2)], expectedId: -1 },
+		{ sizes: [createAdSize(320, 50)], expectedId: -1 },
 	])(
 		'in UK and on mobile %p returns correct placement id',
 		({ sizes, expectedId }) => {
@@ -137,6 +138,7 @@ describe('getImprovePlacementId', () => {
 		{ sizes: [createAdSize(300, 250)], expectedId: 1116424 },
 		{ sizes: [createAdSize(300, 600)], expectedId: 1116424 },
 		{ sizes: [createAdSize(1, 2)], expectedId: -1 },
+		{ sizes: [createAdSize(320, 50)], expectedId: 23060750 },
 	])(
 		'in ROW and on mobile %p returns correct placement id',
 		({ sizes, expectedId }) => {
@@ -153,6 +155,7 @@ describe('getImprovePlacementId', () => {
 		[[createAdSize(300, 250)]],
 		[[createAdSize(300, 600)]],
 		[[createAdSize(1, 2)]],
+		[[createAdSize(320, 50)]],
 	])('in US returns placement id -1', (sizes) => {
 		isInUsOrCa.mockReturnValue(true);
 		expect(getImprovePlacementId(sizes)).toBe(-1);
@@ -165,6 +168,7 @@ describe('getImprovePlacementId', () => {
 		[[createAdSize(300, 250)]],
 		[[createAdSize(300, 600)]],
 		[[createAdSize(1, 2)]],
+		[[createAdSize(320, 50)]],
 	])('in AUS returns placement id -1', (sizes) => {
 		isInAuOrNz.mockReturnValue(true);
 		expect(getImprovePlacementId(sizes)).toBe(-1);

--- a/src/header-bidding/prebid/improve-digital.ts
+++ b/src/header-bidding/prebid/improve-digital.ts
@@ -3,6 +3,7 @@ import type { HeaderBiddingSize } from '../prebid-types';
 import {
 	containsBillboardNotLeaderboard,
 	containsLeaderboardOrBillboard,
+	containsMobileSticky,
 	containsMpuOrDmpu,
 	getBreakpointKey,
 	stripMobileSuffix,
@@ -42,6 +43,7 @@ const getImprovePlacementId = (sizes: HeaderBiddingSize[]): number => {
 				return -1;
 		}
 	}
+
 	if (isInRow()) {
 		switch (getBreakpointKey()) {
 			case 'D': // Desktop
@@ -55,6 +57,9 @@ const getImprovePlacementId = (sizes: HeaderBiddingSize[]): number => {
 			case 'M': // Mobile
 				if (containsMpuOrDmpu(sizes)) {
 					return 1116424;
+				}
+				if (containsMobileSticky(sizes)) {
+					return 23060750;
 				}
 				return -1;
 			case 'T': // Tablet


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

This PR enables Prebid for mobile-sticky in ROW and add the correct placement IDs for each Prebid vendor. We also refactored the unit tests and added few more to test mobile-sticky in Ozone, Ozone US, Improve, OpenX. 

In the future we should add more tests for Ozone and AppNexus.

## Why?

A follow up work #1187
