### PR TITLE
collapse merchandise ad slots on viewport resize

### DIFF
--- a/.changeset/itchy-hats-share.md
+++ b/.changeset/itchy-hats-share.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+hides merch slot if billboard sized ad and viewport is phablet or smaller

--- a/src/dfp/render-advert.ts
+++ b/src/dfp/render-advert.ts
@@ -200,7 +200,7 @@ const renderAdvert = (
 						advert.node.dataset.name === 'merchandising-high'
 					) {
 						void advert.updateExtraSlotClasses(
-							'ad-slot--merchandising-hide-below-desktop',
+							'ad-slot--collapse-below-desktop',
 						);
 					}
 					const sizeCallback = sizeCallbacks[advert.size.toString()];

--- a/src/dfp/render-advert.ts
+++ b/src/dfp/render-advert.ts
@@ -95,7 +95,9 @@ sizeCallbacks[adSizes.billboard.toString()] = (advert: Advert) => {
 		advert.node.dataset.name === 'merchandising' ||
 		advert.node.dataset.name === 'merchandising-high'
 	) {
-		advert.node.classList.add('ad-slot--merchandising-billboard');
+		return advert.updateExtraSlotClasses(
+			'ad-slot--merchandising-billboard',
+		);
 	}
 	return Promise.resolve();
 };

--- a/src/dfp/render-advert.ts
+++ b/src/dfp/render-advert.ts
@@ -90,18 +90,6 @@ sizeCallbacks[adSizes.outstreamMobile.toString()] = (advert: Advert) =>
 sizeCallbacks[adSizes.googleCard.toString()] = (advert: Advert) =>
 	advert.updateExtraSlotClasses('ad-slot--gc');
 
-sizeCallbacks[adSizes.billboard.toString()] = (advert: Advert) => {
-	if (
-		advert.node.dataset.name === 'merchandising' ||
-		advert.node.dataset.name === 'merchandising-high'
-	) {
-		return advert.updateExtraSlotClasses(
-			'ad-slot--merchandising-billboard',
-		);
-	}
-	return Promise.resolve();
-};
-
 /**
  * Out of page adverts - creatives that aren't directly shown on the page - need to be hidden,
  * and their containers closed up.
@@ -206,7 +194,15 @@ const renderAdvert = (
 					 * subsequent ad refreshes as they may not be prebid ads.
 					 * */
 					advert.hasPrebidSize = false;
-
+					if (
+						(advert.size !== 'fluid' &&
+							advert.node.dataset.name === 'merchandising') ||
+						advert.node.dataset.name === 'merchandising-high'
+					) {
+						void advert.updateExtraSlotClasses(
+							'ad-slot--merchandising-hide-below-desktop',
+						);
+					}
 					const sizeCallback = sizeCallbacks[advert.size.toString()];
 					return Promise.resolve(
 						sizeCallback !== undefined

--- a/src/dfp/render-advert.ts
+++ b/src/dfp/render-advert.ts
@@ -90,6 +90,16 @@ sizeCallbacks[adSizes.outstreamMobile.toString()] = (advert: Advert) =>
 sizeCallbacks[adSizes.googleCard.toString()] = (advert: Advert) =>
 	advert.updateExtraSlotClasses('ad-slot--gc');
 
+sizeCallbacks[adSizes.billboard.toString()] = (advert: Advert) => {
+	if (
+		advert.node.dataset.name === 'merchandising' ||
+		advert.node.dataset.name === 'merchandising-high'
+	) {
+		advert.node.classList.add('ad-slot--merchandising-billboard');
+	}
+	return Promise.resolve();
+};
+
 /**
  * Out of page adverts - creatives that aren't directly shown on the page - need to be hidden,
  * and their containers closed up.


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?
Currently when a user changes the viewport size from desktop to tablet or phone size, the merch slots still contain the `billboard` ad size which gets cut off.

This PR should collapse the `merchandise` and `merchandise-high` slot when the viewport is resized and therefore if billboard ad no longer fits in viewport.

This PR adds an callback which adds a class to `dfp-ad--merchandising` element for thje `merchandising` and `merchandising-high` ad slots.
This class is conditionally added on the premise that the adSize is `billboard` (970x250)

As a result of testing in CODE we discovered that some ads were larger than `billboard` ad like 1300x250.
As a result the aproach was to include non `fluid` ads as well.
## Why?
This is essential so that code in `dotcom-rendering` can detect this class and in turn apply appropriate `adSlotCollapseStyles`. See PR: https://github.com/guardian/dotcom-rendering/pull/9930

Tested in CODE with beta release:

Merchandising slot
<img width="1000" alt="Screenshot 2023-12-14 at 17 32 29" src="https://github.com/guardian/commercial/assets/49187886/3006b9aa-d9b0-4f3e-a766-cfe5acf28567">

merchandising-high slot
<img width="1073" alt="Screenshot 2023-12-14 at 17 41 42" src="https://github.com/guardian/commercial/assets/49187886/7ab9b0ca-e3fd-42cc-b4d0-32aeb0c76b37">

| Before     | After      |
| ----------- | ---------- |
| <img width="300" alt="Screenshot 2023-12-18 at 11 17 06" src="https://github.com/guardian/dotcom-rendering/assets/49187886/bfcc6233-8426-4894-aad7-12679a833953"> | <img width="300" alt="Screenshot 2023-12-18 at 11 23 35" src="https://github.com/guardian/dotcom-rendering/assets/49187886/5ea95f54-9a2c-496e-a890-4f296a85a3f2">|
