### PR TITLE
Align tsconfigs

### DIFF
--- a/tsconfig.core.json
+++ b/tsconfig.core.json
@@ -1,11 +1,7 @@
 {
 	"compilerOptions": {
-		"baseUrl": "src",
 		"declaration": true,
-		"noEmit": false,
-		"noUncheckedIndexedAccess": true,
-		"outDir": "dist",
-		"rootDir": "src"
+		"noEmit": false
 	},
 	"extends": "./tsconfig.json",
 	"include": ["src/core", "src/types"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
 		"moduleResolution": "node",
 		"noEmit": true,
 		"noUnusedLocals": true,
+		"outDir": "dist",
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"strict": true,


### PR DESCRIPTION
## What does this change?

Since merging `commercial-core` into this repo and aligning the `tsconfig` rules we can now remove duplicate rules from `tsconfig.core.json` uses to compile the core output.