### PR TITLE
add class name to merch slot

### DIFF
--- a/src/dfp/render-advert.ts
+++ b/src/dfp/render-advert.ts
@@ -194,7 +194,15 @@ const renderAdvert = (
 					 * subsequent ad refreshes as they may not be prebid ads.
 					 * */
 					advert.hasPrebidSize = false;
-
+					if (
+						(advert.size !== 'fluid' &&
+							advert.node.dataset.name === 'merchandising') ||
+						advert.node.dataset.name === 'merchandising-high'
+					) {
+						void advert.updateExtraSlotClasses(
+							'ad-slot--collapse-below-desktop',
+						);
+					}
 					const sizeCallback = sizeCallbacks[advert.size.toString()];
 					return Promise.resolve(
 						sizeCallback !== undefined


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?
This is a simple PR to re-instate the revert : https://github.com/guardian/commercial/pull/1203/files



## Why?
As a result of some unwanted behaviour, merchandise as slot disappearing and therefore not presenting an MPU ad.