### PR TITLE
Improve consentless first visit detection

### DIFF
--- a/.changeset/spotty-carrots-change.md
+++ b/.changeset/spotty-carrots-change.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Improve consentless "firstvisit" targeting

--- a/src/core/event-timer.ts
+++ b/src/core/event-timer.ts
@@ -270,4 +270,4 @@ const _ = {
 	trackedSlots,
 };
 
-export { EventTimer, _ };
+export { EventTimer, _, supportsPerformanceAPI };

--- a/src/core/targeting/build-page-targeting.spec.ts
+++ b/src/core/targeting/build-page-targeting.spec.ts
@@ -1063,7 +1063,7 @@ describe('Build Page Targeting', () => {
 		).toBe('f');
 	});
 
-	it('should set firstvisit to false referrer is the guardian and navigation type is not navigate', () => {
+	it('should set firstvisit to false if referrer is the guardian and navigation type is not navigate', () => {
 		jest.spyOn(window, 'performance', 'get').mockReturnValue({
 			getEntriesByType: () => [
 				{

--- a/src/core/targeting/build-page-targeting.spec.ts
+++ b/src/core/targeting/build-page-targeting.spec.ts
@@ -1090,6 +1090,33 @@ describe('Build Page Targeting', () => {
 		).toBe('f');
 	});
 
+	it('should set firstvisit to true if referrer is not the guardian and navigation type is navigate', () => {
+		jest.spyOn(window, 'performance', 'get').mockReturnValue({
+			getEntriesByType: () => [
+				{
+					type: 'navigate',
+				},
+			],
+			mark: () => {
+				//
+			},
+		} as unknown as Performance);
+		jest.spyOn(document, 'referrer', 'get').mockReturnValue(
+			'https://google.com/',
+		);
+		jest.spyOn(window, 'location', 'get').mockReturnValue({
+			hostname: 'theguardian.com',
+		} as unknown as Location);
+		expect(
+			buildPageTargeting({
+				adFree: false,
+				clientSideParticipations: {},
+				consentState: emptyConsent,
+				isSignedIn: true,
+			}).firstvisit,
+		).toBe('t');
+	});
+
 	it('should not set firstvisit if consent is allowed', () => {
 		jest.spyOn(document, 'referrer', 'get').mockReturnValue('');
 		jest.spyOn(window, 'location', 'get').mockReturnValue({

--- a/src/core/targeting/build-page-targeting.spec.ts
+++ b/src/core/targeting/build-page-targeting.spec.ts
@@ -968,7 +968,10 @@ describe('Build Page Targeting', () => {
 		});
 	});
 
-	it('should set firstvisit to true if this is the users first visit to the page', () => {
+	it('should set firstvisit to true if referrer is empty and navigation api is missing', () => {
+		jest.spyOn(window, 'performance', 'get').mockReturnValue(
+			undefined as unknown as Performance,
+		);
 		jest.spyOn(document, 'referrer', 'get').mockReturnValue('');
 		jest.spyOn(window, 'location', 'get').mockReturnValue({
 			hostname: 'theguardian.com',
@@ -983,7 +986,94 @@ describe('Build Page Targeting', () => {
 		).toBe('t');
 	});
 
-	it("should set firstvisit to false if this isn't the users first visit to the page", () => {
+	it('should set firstvisit to true if referrer is empty and navigation type is navigate', () => {
+		jest.spyOn(window, 'performance', 'get').mockReturnValue({
+			getEntriesByType: () => [
+				{
+					type: 'navigate',
+				},
+			],
+			mark: () => {
+				//
+			},
+		} as unknown as Performance);
+		jest.spyOn(document, 'referrer', 'get').mockReturnValue('');
+		jest.spyOn(window, 'location', 'get').mockReturnValue({
+			hostname: 'theguardian.com',
+		} as unknown as Location);
+		expect(
+			buildPageTargeting({
+				adFree: false,
+				clientSideParticipations: {},
+				consentState: emptyConsent,
+				isSignedIn: true,
+			}).firstvisit,
+		).toBe('t');
+	});
+
+	it('should set firstvisit to false if referrer is empty and navigation type is not navigate', () => {
+		jest.spyOn(window, 'performance', 'get').mockReturnValue({
+			getEntriesByType: () => [
+				{
+					type: 'reload',
+				},
+			],
+			mark: () => {
+				//
+			},
+		} as unknown as Performance);
+		jest.spyOn(document, 'referrer', 'get').mockReturnValue('');
+		jest.spyOn(window, 'location', 'get').mockReturnValue({
+			hostname: 'theguardian.com',
+		} as unknown as Location);
+		expect(
+			buildPageTargeting({
+				adFree: false,
+				clientSideParticipations: {},
+				consentState: emptyConsent,
+				isSignedIn: true,
+			}).firstvisit,
+		).toBe('f');
+	});
+
+	it('should set firstvisit to false if referrer is the guardian and navigation type is navigate', () => {
+		jest.spyOn(window, 'performance', 'get').mockReturnValue({
+			getEntriesByType: () => [
+				{
+					type: 'navigate',
+				},
+			],
+			mark: () => {
+				//
+			},
+		} as unknown as Performance);
+		jest.spyOn(document, 'referrer', 'get').mockReturnValue(
+			'https://theguardian.com/uk',
+		);
+		jest.spyOn(window, 'location', 'get').mockReturnValue({
+			hostname: 'theguardian.com',
+		} as unknown as Location);
+		expect(
+			buildPageTargeting({
+				adFree: false,
+				clientSideParticipations: {},
+				consentState: emptyConsent,
+				isSignedIn: true,
+			}).firstvisit,
+		).toBe('f');
+	});
+
+	it('should set firstvisit to false referrer is the guardian and navigation type is not navigate', () => {
+		jest.spyOn(window, 'performance', 'get').mockReturnValue({
+			getEntriesByType: () => [
+				{
+					type: 'reload',
+				},
+			],
+			mark: () => {
+				//
+			},
+		} as unknown as Performance);
 		jest.spyOn(document, 'referrer', 'get').mockReturnValue(
 			'https://theguardian.com/uk',
 		);

--- a/src/core/targeting/build-page-targeting.ts
+++ b/src/core/targeting/build-page-targeting.ts
@@ -85,15 +85,15 @@ const referrerMatchesHost = (referrer: string): boolean => {
 		return false;
 	}
 	const referrerUrl = new URL(referrer);
-	return referrerUrl.hostname !== window.location.hostname;
+	return referrerUrl.hostname === window.location.hostname;
 };
 
 // A consentless friendly way of determining if this is the users first visit to the page
 const isFirstVisit = (referrer: string): boolean => {
 	if (!supportsPerformanceAPI()) {
-		return referrer === '' && !referrerMatchesHost(referrer);
+		return !referrerMatchesHost(referrer);
 	}
-	if (getLastNavigationType() === 'navigate' && referrer === '') {
+	if (getLastNavigationType() === 'navigate' && !referrerMatchesHost(referrer)) {
 		return true;
 	}
 	return false;

--- a/src/core/targeting/build-page-targeting.ts
+++ b/src/core/targeting/build-page-targeting.ts
@@ -90,7 +90,6 @@ const referrerMatchesHost = (referrer: string): boolean => {
 
 // A consentless friendly way of determining if this is the users first visit to the page
 const isFirstVisit = (referrer: string): boolean => {
-	console.log('supportsPerformanceAPI', supportsPerformanceAPI());
 	if (!supportsPerformanceAPI()) {
 		return referrer === '' && !referrerMatchesHost(referrer);
 	}
@@ -174,8 +173,6 @@ const buildPageTargeting = ({
 
 	if (!consentState.canTarget) {
 		consentlessTargeting.firstvisit = isFirstVisit(referrer) ? 't' : 'f';
-
-		console.log('consentlessTargeting', consentlessTargeting);
 	}
 
 	const pageTargets: PageTargeting = {

--- a/src/core/targeting/build-page-targeting.ts
+++ b/src/core/targeting/build-page-targeting.ts
@@ -93,7 +93,10 @@ const isFirstVisit = (referrer: string): boolean => {
 	if (!supportsPerformanceAPI()) {
 		return !referrerMatchesHost(referrer);
 	}
-	if (getLastNavigationType() === 'navigate' && !referrerMatchesHost(referrer)) {
+	if (
+		getLastNavigationType() === 'navigate' &&
+		!referrerMatchesHost(referrer)
+	) {
 		return true;
 	}
 	return false;

--- a/src/core/targeting/build-page-targeting.ts
+++ b/src/core/targeting/build-page-targeting.ts
@@ -90,16 +90,11 @@ const referrerMatchesHost = (referrer: string): boolean => {
 
 // A consentless friendly way of determining if this is the users first visit to the page
 const isFirstVisit = (referrer: string): boolean => {
-	if (!supportsPerformanceAPI()) {
-		return !referrerMatchesHost(referrer);
+	if (supportsPerformanceAPI() && getLastNavigationType() !== 'navigate') {
+		return false;
 	}
-	if (
-		getLastNavigationType() === 'navigate' &&
-		!referrerMatchesHost(referrer)
-	) {
-		return true;
-	}
-	return false;
+
+	return !referrerMatchesHost(referrer);
 };
 
 type BuildPageTargetingParams = {

--- a/src/core/targeting/build-page-targeting.ts
+++ b/src/core/targeting/build-page-targeting.ts
@@ -3,6 +3,7 @@ import { cmp } from '@guardian/consent-management-platform';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import type { CountryCode } from '@guardian/libs';
 import { getCookie, isString } from '@guardian/libs';
+import { supportsPerformanceAPI } from 'core/event-timer';
 import { getLocale } from '../lib/get-locale';
 import type { False, True } from '../types';
 import type { ContentTargeting } from './content';
@@ -70,13 +71,33 @@ const filterValues = (pageTargets: Record<string, unknown>) => {
 	return filtered;
 };
 
+const getLastNavigationType = (): NavigationTimingType | undefined => {
+	if (!supportsPerformanceAPI()) {
+		return undefined;
+	}
+	const navigationEvents = performance.getEntriesByType('navigation');
+	const lastNavigationEvent = navigationEvents[navigationEvents.length - 1];
+	return lastNavigationEvent?.type;
+};
+
+const referrerMatchesHost = (referrer: string): boolean => {
+	if (!referrer) {
+		return false;
+	}
+	const referrerUrl = new URL(referrer);
+	return referrerUrl.hostname !== window.location.hostname;
+};
+
 // A consentless friendly way of determining if this is the users first visit to the page
 const isFirstVisit = (referrer: string): boolean => {
-	if (!referrer) {
+	console.log('supportsPerformanceAPI', supportsPerformanceAPI());
+	if (!supportsPerformanceAPI()) {
+		return referrer === '' && !referrerMatchesHost(referrer);
+	}
+	if (getLastNavigationType() === 'navigate' && referrer === '') {
 		return true;
 	}
-	const referrerUrl = new URL(document.referrer);
-	return referrerUrl.hostname !== window.location.hostname;
+	return false;
 };
 
 type BuildPageTargetingParams = {
@@ -153,6 +174,8 @@ const buildPageTargeting = ({
 
 	if (!consentState.canTarget) {
 		consentlessTargeting.firstvisit = isFirstVisit(referrer) ? 't' : 'f';
+
+		console.log('consentlessTargeting', consentlessTargeting);
 	}
 
 	const pageTargets: PageTargeting = {

--- a/tsconfig.core.json
+++ b/tsconfig.core.json
@@ -5,7 +5,7 @@
 		"noEmit": false,
 		"noUncheckedIndexedAccess": true,
 		"outDir": "dist",
-		"rootDir": "src"
+		"typeRoots": ["./node_modules/@types", "./node_modules/web-vitals/dist"]
 	},
 	"extends": "./tsconfig.json",
 	"include": ["src/core", "src/types"],


### PR DESCRIPTION
## What does this change?
Use the performance API to determine the type of navigation so that we can better deduce if this is the users first visit.

[The performance API's navigation events let us distinguish the navigation type
](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/type#value)

Only if the referrer is empty and the navigation type is `navigate` can we assume this is the users first visit, otherwise they have refreshed or clicked the back/forwards button.

## Why?

So we can target ads without consent only on their "first visit" to the site.
