### PR TITLE
Use relative import path between core modules

### DIFF
--- a/.changeset/lovely-vans-help.md
+++ b/.changeset/lovely-vans-help.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+fix import issue with frontend

--- a/src/core/targeting/build-page-targeting.ts
+++ b/src/core/targeting/build-page-targeting.ts
@@ -3,7 +3,7 @@ import { cmp } from '@guardian/consent-management-platform';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import type { CountryCode } from '@guardian/libs';
 import { getCookie, isString } from '@guardian/libs';
-import { supportsPerformanceAPI } from 'core/event-timer';
+import { supportsPerformanceAPI } from '../event-timer';
 import { getLocale } from '../lib/get-locale';
 import type { False, True } from '../types';
 import type { ContentTargeting } from './content';

--- a/tsconfig.core.json
+++ b/tsconfig.core.json
@@ -8,6 +8,7 @@
 		"typeRoots": ["./node_modules/@types", "./node_modules/web-vitals/dist"]
 	},
 	"extends": "./tsconfig.json",
+	"rootDir": "src",
 	"include": ["src/core", "src/types"],
 	"exclude": ["**/*.spec.*", "**/*.test.*"]
 }


### PR DESCRIPTION
## What does this change?
Use relative import, not doing this has led to a strange failure in frontend https://github.com/guardian/frontend/actions/runs/7478681099/job/20354162665?pr=26808