### PR TITLE
Move fill slot listener to standalone

### DIFF
--- a/.changeset/strange-penguins-tickle.md
+++ b/.changeset/strange-penguins-tickle.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Move fill ad slot listener to commercial.standalone

--- a/src/init/consented/fill-slot-listener.ts
+++ b/src/init/consented/fill-slot-listener.ts
@@ -1,6 +1,6 @@
 import type { SizeMapping } from 'core';
-import { dfpEnv } from './dfp-env';
-import { fillDynamicAdSlot } from './fill-dynamic-advert-slot';
+import { dfpEnv } from '../../dfp/dfp-env';
+import { fillDynamicAdSlot } from '../../dfp/fill-dynamic-advert-slot';
 
 type ExternalSlotCustomEvent = CustomEvent<{
 	slotId: string;
@@ -27,20 +27,28 @@ const isCustomEvent = (event: Event): event is CustomEvent => {
  * These events will not be received from a restricted iframe such, such as a
  * cross-origin or safeframe iframe.
  */
-export const createSlotFillListener = () => {
+const createSlotFillListener = () => {
 	document.addEventListener('gu.commercial.slot.fill', (event: Event) => {
-		if (isCustomEvent(event)) {
-			const { slotId, additionalSizes } = (<ExternalSlotCustomEvent>event)
-				.detail;
+		window.googletag.cmd.push(() => {
+			if (isCustomEvent(event)) {
+				const { slotId, additionalSizes } = (<ExternalSlotCustomEvent>(
+					event
+				)).detail;
 
-			if (dfpEnv.adverts.has(slotId)) {
-				return;
-			}
+				if (dfpEnv.adverts.has(slotId)) {
+					return;
+				}
 
-			const slot = document.getElementById(slotId);
-			if (slot) {
-				void fillDynamicAdSlot(slot, false, additionalSizes);
+				const slot = document.getElementById(slotId);
+				if (slot) {
+					void fillDynamicAdSlot(slot, false, additionalSizes);
+				}
 			}
-		}
+		});
 	});
 };
+
+const initFillSlotListener = (): Promise<void> =>
+	Promise.resolve(createSlotFillListener());
+
+export { initFillSlotListener };

--- a/src/init/consented/prepare-googletag.ts
+++ b/src/init/consented/prepare-googletag.ts
@@ -12,7 +12,6 @@ import { commercialFeatures } from 'lib/commercial-features';
 import raven from 'lib/raven';
 import { init as initMeasureAdLoad } from 'messenger/measure-ad-load';
 import { reportError } from 'utils/report-error';
-import { createSlotFillListener } from '../../dfp/fill-slot-listener';
 import { fillStaticAdvertSlots } from '../../dfp/fill-static-advert-slots';
 import { onSlotLoad } from '../../dfp/on-slot-load';
 import { onSlotRender } from '../../dfp/on-slot-render';
@@ -129,7 +128,6 @@ export const init = (): Promise<void> => {
 						setPageTargeting(consentState, isSignedIn);
 					},
 					() => {
-						createSlotFillListener();
 						// Note: this function isn't synchronous like most buffered cmds, it's a promise. It's put in here to ensure
 						// it strictly follows preceding prepare-googletag work (and the module itself ensures dependencies are
 						// fulfilled), but don't assume this function is complete when queueing subsequent work using cmd.push

--- a/src/standalone.commercial.ts
+++ b/src/standalone.commercial.ts
@@ -26,6 +26,7 @@ import { init as initArticleBodyAdverts } from 'init/consented/article-body-adve
 import { initCommentAdverts } from 'init/consented/comment-adverts';
 import { initCommentsExpandedAdverts } from 'init/consented/comments-expanded-advert';
 import { init as initComscore } from 'init/consented/comscore';
+import { initFillSlotListener } from 'init/consented/fill-slot-listener';
 import { init as initHighMerch } from 'init/consented/high-merch';
 import { init as initIpsosMori } from 'init/consented/ipsos-mori';
 import { init as initLiveblogAdverts } from 'init/consented/liveblog-adverts';
@@ -90,6 +91,7 @@ if (!commercialFeatures.adFree) {
 		// The permutive lib however is loaded async with the third party tags
 		['cm-prepare-googletag', () => initPermutive().then(prepareGoogletag)],
 		['cm-prepare-a9', prepareA9],
+		['cm-prepare-fill-slot-listener', initFillSlotListener],
 	);
 	commercialExtraModules.push(
 		['cm-prepare-adverification', prepareAdVerification],


### PR DESCRIPTION
## What does this change?
Move the fill slot listener to be initialised in `standalone.commercial`

## Why?
We need the event listener to be added ASAP.

At the moment it's possible for the event to be sent before the listener has been setup.

The particular case where this is happening is the `article-end` slot. If the page is refreshed while it's in view, the slot is inserted after the fixed ad slots are initialised but before the fill-slot-listener has been setup, resulting in an empty slot.

Adding `window.googletag.cmd.push` will ensure the slot will only be filled if googletag loads.