### PR TITLE
Increase percentage for prebid kargo test to 4%

### DIFF
--- a/.changeset/lazy-items-tickle.md
+++ b/.changeset/lazy-items-tickle.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Bump prebid Kargo test to 4%

--- a/src/experiments/tests/prebid-kargo.ts
+++ b/src/experiments/tests/prebid-kargo.ts
@@ -5,7 +5,7 @@ export const prebidKargo: ABTest = {
 	author: '@commercial-dev',
 	start: '2023-12-05',
 	expiry: '2024-02-29',
-	audience: 2 / 100,
+	audience: 4 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: 'USA only',
 	successMeasure: '',


### PR DESCRIPTION
## Why?
We're not getting the data volume we expected, increasing the test to 4% should help!