### PR TITLE
Add Ozone and AppNexus prebid unit tests for placementID

### DIFF
--- a/src/header-bidding/prebid/appnexus.spec.ts
+++ b/src/header-bidding/prebid/appnexus.spec.ts
@@ -6,6 +6,7 @@ import {
 	isInUsa as isInUsa_,
 } from 'utils/geo-utils';
 import {
+	containsBillboard as containsBillboard_,
 	containsBillboardNotLeaderboard as containsBillboardNotLeaderboard_,
 	containsDmpu as containsDmpu_,
 	containsLeaderboard as containsLeaderboard_,
@@ -18,6 +19,7 @@ import {
 import { getAppNexusDirectPlacementId } from './appnexus';
 
 jest.mock('../utils');
+const containsBillboard = containsBillboard_ as jest.Mock;
 const containsBillboardNotLeaderboard =
 	containsBillboardNotLeaderboard_ as jest.Mock;
 const containsDmpu = containsDmpu_ as jest.Mock;
@@ -77,7 +79,7 @@ describe('getAppNexusDirectPlacementId', () => {
 		resetConfig();
 	});
 
-	test('should return correct placementID for any existing biding sizes in Australia or New Zealand', () => {
+	test('should return correct placementID for any existing bidding sizes in Australia or New Zealand', () => {
 		isInAuOrNz.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('D');
 		containsMpu.mockReturnValue(true);
@@ -104,10 +106,8 @@ describe('getAppNexusDirectPlacementId', () => {
 		);
 	});
 
-	test('should return correct placementID for desktop billboard not leaderboad in UK, ROW and US', () => {
+	test('should return correct placementID for desktop billboard not leaderboad in UK', () => {
 		isInUk.mockReturnValue(true);
-		isInRow.mockReturnValue(true);
-		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('D');
 		containsBillboardNotLeaderboard.mockReturnValue(true);
 		expect(getAppNexusDirectPlacementId([createAdSize(970, 250)])).toBe(
@@ -115,10 +115,8 @@ describe('getAppNexusDirectPlacementId', () => {
 		);
 	});
 
-	test('should return correct placementID for desktop mpu or dmpu in UK, ROW and US', () => {
+	test('should return correct placementID for desktop mpu or dmpu in UK', () => {
 		isInUk.mockReturnValue(true);
-		isInRow.mockReturnValue(true);
-		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('D');
 		containsMpuOrDmpu.mockReturnValue(true);
 		expect(getAppNexusDirectPlacementId([createAdSize(300, 600)])).toBe(
@@ -129,10 +127,8 @@ describe('getAppNexusDirectPlacementId', () => {
 		);
 	});
 
-	test('should return correct placementID for desktop billboard or leaderboard in UK, ROW and US', () => {
-		isInUk.mockReturnValue(true);
+	test('should return correct placementID for desktop billboard or leaderboard in ROW', () => {
 		isInRow.mockReturnValue(true);
-		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('D');
 		containsLeaderboardOrBillboard.mockReturnValue(true);
 		expect(getAppNexusDirectPlacementId([createAdSize(970, 250)])).toBe(
@@ -143,21 +139,21 @@ describe('getAppNexusDirectPlacementId', () => {
 		);
 	});
 
-	test('should return correct placementID for desktop leaderboard in UK, ROW and US', () => {
-		isInUk.mockReturnValue(true);
+	test('should return correct placementID for desktop leaderboard in ROW', () => {
 		isInRow.mockReturnValue(true);
-		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('D');
+		containsBillboard.mockReturnValue(false);
 		containsLeaderboard.mockReturnValue(true);
+		containsLeaderboardOrBillboard.mockReturnValue(
+			containsBillboard() || containsLeaderboard(),
+		);
 		expect(getAppNexusDirectPlacementId([createAdSize(728, 90)])).toBe(
-			'9251752',
+			'9926678',
 		);
 	});
 
-	test('should return correct placementID for tablet mpu in UK, ROW and US', () => {
+	test('should return correct placementID for tablet mpu in UK', () => {
 		isInUk.mockReturnValue(true);
-		isInRow.mockReturnValue(true);
-		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('T');
 		containsMpu.mockReturnValue(true);
 		expect(getAppNexusDirectPlacementId([createAdSize(300, 250)])).toBe(
@@ -165,10 +161,8 @@ describe('getAppNexusDirectPlacementId', () => {
 		);
 	});
 
-	test('should return correct placementID for tablet leaderboard in UK, ROW and US', () => {
+	test('should return correct placementID for tablet leaderboard in UK', () => {
 		isInUk.mockReturnValue(true);
-		isInRow.mockReturnValue(true);
-		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('T');
 		containsLeaderboard.mockReturnValue(true);
 		expect(getAppNexusDirectPlacementId([createAdSize(728, 90)])).toBe(
@@ -176,10 +170,8 @@ describe('getAppNexusDirectPlacementId', () => {
 		);
 	});
 
-	test('should return correct placementID for tablet dmpu in UK, ROW and US', () => {
+	test('should return correct placementID for tablet dmpu in UK', () => {
 		isInUk.mockReturnValue(true);
-		isInRow.mockReturnValue(true);
-		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('T');
 		containsDmpu.mockReturnValue(true);
 		expect(getAppNexusDirectPlacementId([createAdSize(300, 600)])).toBe(
@@ -187,10 +179,8 @@ describe('getAppNexusDirectPlacementId', () => {
 		);
 	});
 
-	test('should return correct placementID for mobile mpu in UK, ROW and US', () => {
+	test('should return correct placementID for mobile mpu in UK', () => {
 		isInUk.mockReturnValue(true);
-		isInRow.mockReturnValue(true);
-		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
 		expect(getAppNexusDirectPlacementId([createAdSize(300, 250)])).toBe(

--- a/src/header-bidding/prebid/appnexus.spec.ts
+++ b/src/header-bidding/prebid/appnexus.spec.ts
@@ -1,0 +1,209 @@
+import { createAdSize } from 'core/ad-sizes';
+import {
+	isInAuOrNz as isInAuOrNz_,
+	isInRow as isInRow_,
+	isInUk as isInUk_,
+	isInUsa as isInUsa_,
+} from 'utils/geo-utils';
+import {
+	containsBillboardNotLeaderboard as containsBillboardNotLeaderboard_,
+	containsDmpu as containsDmpu_,
+	containsLeaderboard as containsLeaderboard_,
+	containsLeaderboardOrBillboard as containsLeaderboardOrBillboard_,
+	containsMobileSticky as containsMobileSticky_,
+	containsMpu as containsMpu_,
+	containsMpuOrDmpu as containsMpuOrDmpu_,
+	getBreakpointKey as getBreakpointKey_,
+} from '../utils';
+import { getAppNexusDirectPlacementId } from './appnexus';
+
+jest.mock('../utils');
+const containsBillboardNotLeaderboard =
+	containsBillboardNotLeaderboard_ as jest.Mock;
+const containsDmpu = containsDmpu_ as jest.Mock;
+const containsLeaderboard = containsLeaderboard_ as jest.Mock;
+const containsLeaderboardOrBillboard =
+	containsLeaderboardOrBillboard_ as jest.Mock;
+const containsMobileSticky = containsMobileSticky_ as jest.Mock;
+const containsMpu = containsMpu_ as jest.Mock;
+const containsMpuOrDmpu = containsMpuOrDmpu_ as jest.Mock;
+const getBreakpointKey = getBreakpointKey_ as jest.Mock;
+
+jest.mock('utils/geo-utils');
+const isInAuOrNz = isInAuOrNz_ as jest.Mock;
+const isInRow = isInRow_ as jest.Mock;
+const isInUk = isInUk_ as jest.Mock;
+const isInUsa = isInUsa_ as jest.Mock;
+
+jest.mock('experiments/ab', () => ({
+	isInVariantSynchronous: jest.fn(),
+}));
+
+jest.mock('lib/cookies', () => ({
+	getCookie: jest.fn(),
+}));
+
+const resetConfig = () => {
+	window.guardian.ophan = {
+		pageViewId: 'pvid',
+		viewId: 'v_id',
+		record: () => {
+			// do nothing;
+		},
+		setEventEmitter: null,
+		trackComponentAttention: null,
+	};
+	window.guardian.config.switches = {
+		prebidAppnexus: true,
+		prebidAppnexusInvcode: true,
+		prebidOpenx: true,
+		prebidImproveDigital: true,
+		prebidIndexExchange: true,
+		prebidSonobi: true,
+		prebidTrustx: true,
+		prebidXaxis: true,
+		prebidAdYouLike: true,
+		prebidTriplelift: true,
+		prebidCriteo: true,
+	};
+	window.guardian.config.page.contentType = 'Article';
+	window.guardian.config.page.section = 'Magic';
+	window.guardian.config.page.isDev = false;
+};
+
+describe('getAppNexusDirectPlacementId', () => {
+	afterEach(() => {
+		jest.resetAllMocks();
+		resetConfig();
+	});
+
+	test('should return correct placementID for any existing biding sizes in Australia or New Zealand', () => {
+		isInAuOrNz.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('D');
+		containsMpu.mockReturnValue(true);
+		expect(getAppNexusDirectPlacementId([createAdSize(300, 250)])).toBe(
+			'11016434',
+		);
+	});
+
+	test('should return correct placementID for mobile-sticky and in ROW', () => {
+		isInRow.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('M');
+		containsMobileSticky.mockReturnValue(true);
+		expect(getAppNexusDirectPlacementId([createAdSize(320, 50)])).toBe(
+			'31512573',
+		);
+	});
+
+	test('should return correct placementID for ad sizes not in the conditional statement and not mobile-sticky in ROW', () => {
+		isInRow.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('D');
+		containsDmpu.mockReturnValue(true);
+		expect(getAppNexusDirectPlacementId([createAdSize(300, 600)])).toBe(
+			'9251752',
+		);
+	});
+
+	test('should return correct placementID for desktop billboard not leaderboad in UK, ROW and US', () => {
+		isInUk.mockReturnValue(true);
+		isInRow.mockReturnValue(true);
+		isInUsa.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('D');
+		containsBillboardNotLeaderboard.mockReturnValue(true);
+		expect(getAppNexusDirectPlacementId([createAdSize(970, 250)])).toBe(
+			'30017511',
+		);
+	});
+
+	test('should return correct placementID for desktop mpu or dmpu in UK, ROW and US', () => {
+		isInUk.mockReturnValue(true);
+		isInRow.mockReturnValue(true);
+		isInUsa.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('D');
+		containsMpuOrDmpu.mockReturnValue(true);
+		expect(getAppNexusDirectPlacementId([createAdSize(300, 600)])).toBe(
+			'9251752',
+		);
+		expect(getAppNexusDirectPlacementId([createAdSize(300, 250)])).toBe(
+			'9251752',
+		);
+	});
+
+	test('should return correct placementID for desktop billboard or leaderboard in UK, ROW and US', () => {
+		isInUk.mockReturnValue(true);
+		isInRow.mockReturnValue(true);
+		isInUsa.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('D');
+		containsLeaderboardOrBillboard.mockReturnValue(true);
+		expect(getAppNexusDirectPlacementId([createAdSize(970, 250)])).toBe(
+			'9926678',
+		);
+		expect(getAppNexusDirectPlacementId([createAdSize(728, 90)])).toBe(
+			'9926678',
+		);
+	});
+
+	test('should return correct placementID for desktop leaderboard in UK, ROW and US', () => {
+		isInUk.mockReturnValue(true);
+		isInRow.mockReturnValue(true);
+		isInUsa.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('D');
+		containsLeaderboard.mockReturnValue(true);
+		expect(getAppNexusDirectPlacementId([createAdSize(728, 90)])).toBe(
+			'9251752',
+		);
+	});
+
+	test('should return correct placementID for tablet mpu in UK, ROW and US', () => {
+		isInUk.mockReturnValue(true);
+		isInRow.mockReturnValue(true);
+		isInUsa.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('T');
+		containsMpu.mockReturnValue(true);
+		expect(getAppNexusDirectPlacementId([createAdSize(300, 250)])).toBe(
+			'4371641',
+		);
+	});
+
+	test('should return correct placementID for tablet leaderboard in UK, ROW and US', () => {
+		isInUk.mockReturnValue(true);
+		isInRow.mockReturnValue(true);
+		isInUsa.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('T');
+		containsLeaderboard.mockReturnValue(true);
+		expect(getAppNexusDirectPlacementId([createAdSize(728, 90)])).toBe(
+			'4371640',
+		);
+	});
+
+	test('should return correct placementID for tablet dmpu in UK, ROW and US', () => {
+		isInUk.mockReturnValue(true);
+		isInRow.mockReturnValue(true);
+		isInUsa.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('T');
+		containsDmpu.mockReturnValue(true);
+		expect(getAppNexusDirectPlacementId([createAdSize(300, 600)])).toBe(
+			'9251752',
+		);
+	});
+
+	test('should return correct placementID for mobile mpu in UK, ROW and US', () => {
+		isInUk.mockReturnValue(true);
+		isInRow.mockReturnValue(true);
+		isInUsa.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('M');
+		containsMpu.mockReturnValue(true);
+		expect(getAppNexusDirectPlacementId([createAdSize(300, 250)])).toBe(
+			'4298191',
+		);
+	});
+
+	test('should return correct placementID for mobile-sticky in US', () => {
+		isInUsa.mockReturnValue('true');
+		getBreakpointKey.mockReturnValue('M');
+		containsMobileSticky.mockReturnValue(true);
+		expect(getAppNexusDirectPlacementId([createAdSize(320, 50)])).toBe(
+			'9251752',
+		);
+	});
+});

--- a/src/header-bidding/prebid/appnexus.ts
+++ b/src/header-bidding/prebid/appnexus.ts
@@ -36,7 +36,9 @@ const getAppNexusInvCode = (sizes: HeaderBiddingSize[]): string | undefined => {
 	}
 };
 
-const getAppNexusDirectPlacementId = (sizes: HeaderBiddingSize[]): string => {
+export const getAppNexusDirectPlacementId = (
+	sizes: HeaderBiddingSize[],
+): string => {
 	if (isInAuOrNz()) {
 		return '11016434';
 	}
@@ -100,3 +102,5 @@ export const getAppNexusDirectBidParams = (
 		keywords: buildAppNexusTargetingObject(pageTargeting),
 	};
 };
+
+export const _ = { getAppNexusDirectPlacementId };

--- a/src/header-bidding/prebid/bid-config.spec.ts
+++ b/src/header-bidding/prebid/bid-config.spec.ts
@@ -588,6 +588,24 @@ describe('getOzonePlacementId', () => {
 		jest.resetAllMocks();
 	});
 
+	test('should return correct placementID for billboard in US when it is in desktop', () => {
+		isInUsa.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('D');
+		containsBillboard.mockReturnValue(true);
+		expect(getOzonePlacementId([createAdSize(970, 250)])).toBe(
+			'3500010912',
+		);
+	});
+
+	test('should return correct placementID for mpu in US when it is in desktop', () => {
+		isInUsa.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('D');
+		containsMpu.mockReturnValue(true);
+		expect(getOzonePlacementId([createAdSize(300, 250)])).toBe(
+			'3500010911',
+		);
+	});
+
 	test('should return correct placementID for mobile-sticky in US', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
@@ -595,10 +613,28 @@ describe('getOzonePlacementId', () => {
 		expect(getOzonePlacementId([createAdSize(320, 50)])).toBe('3500014217');
 	});
 
+	test('should return correct placementID in US if none of the conditions are met', () => {
+		isInUsa.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('M');
+		containsMpu.mockReturnValue(true);
+		expect(getOzonePlacementId([createAdSize(300, 250)])).toBe(
+			'1420436308',
+		);
+	});
+
 	test('should return correct placementID for mobile-sticky in ROW', () => {
 		isInRow.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMobileSticky.mockReturnValue(true);
 		expect(getOzonePlacementId([createAdSize(320, 50)])).toBe('1500000260');
+	});
+
+	test('should return correct placementID if none of the conditions are met', () => {
+		isInUk.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('T');
+		containsMpu.mockReturnValue(true);
+		expect(getOzonePlacementId([createAdSize(300, 250)])).toBe(
+			'0420420500',
+		);
 	});
 });


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

This PR adds more Ozone prebid unit tests and creates AppNexus prebid tests which was noted in a previous PR #1190.

All the added tests checks if `placementID` is correct based on region, breakpoint and ad size. 

## Why?

Covering more unit test cases.
