### PR TITLE
Update peer dependencies causing conflicts in DCR

### DIFF
--- a/.changeset/late-pumas-camp.md
+++ b/.changeset/late-pumas-camp.md
@@ -1,5 +1,5 @@
 ---
-'@guardian/commercial': patch
+'@guardian/commercial': major
 ---
 
 update peer deps

--- a/.changeset/late-pumas-camp.md
+++ b/.changeset/late-pumas-camp.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+update peer deps

--- a/package.json
+++ b/package.json
@@ -130,13 +130,13 @@
 		"access": "public"
 	},
 	"peerDependencies": {
-		"@guardian/ab-core": "^5.0.0",
+		"@guardian/ab-core": "^7.0.1",
 		"@guardian/consent-management-platform": "^13.7.1",
-		"@guardian/core-web-vitals": "^5.1.0",
+		"@guardian/core-web-vitals": "^6.0.0",
 		"@guardian/identity-auth": "^1.0.0",
 		"@guardian/identity-auth-frontend": "^1.0.0",
-		"@guardian/libs": "^15.6.4",
-		"@guardian/source-foundations": "^13.0.0",
+		"@guardian/libs": "^16.0.0",
+		"@guardian/source-foundations": "^14.1.2",
 		"@guardian/support-dotcom-components": "^1.0.7"
 	},
 	"browserslist": [


### PR DESCRIPTION
## What does this change?

This updates various internal peer dependencies to request their latest version.

## Why?

WebEx are seeking to enforce met peer dependencies in DCR and this clears a blocker for them https://github.com/guardian/dotcom-rendering/issues/10204