### PR TITLE
Updates to the Spacefinder debugger

### DIFF
--- a/docs/spacefinder/readme.md
+++ b/docs/spacefinder/readme.md
@@ -86,6 +86,6 @@ On desktop, the first inline ad sits inside the body of the article copy. All su
 
 ## Debugging
 
-Adding `sfdebug=1` to the URL shows information about `inline1` ads. Adding `sfdebug=2` shows information about the other inline slots.
+Adding `?sfdebug` to the URL opens the Spacefinder debugger control panel. The panel contains buttons to show the data for the different times that Spacefinder runs to find space for an ad. You can click these buttons to see the data for that run.
 
 Further reading: https://github.com/guardian/frontend/pull/24618

--- a/playwright/tests/spacefinder-debugger.spec.ts
+++ b/playwright/tests/spacefinder-debugger.spec.ts
@@ -1,0 +1,24 @@
+import { test } from '@playwright/test';
+import { articles } from '../fixtures/pages';
+import type { GuPage } from '../fixtures/pages/Page';
+import { cmpAcceptAll } from '../lib/cmp';
+import { loadPage } from '../lib/load-page';
+
+const { path } = articles[0] as unknown as GuPage;
+const pathWithDebug = path + '?sfdebug';
+
+test.describe('Spacefinder debugger', () => {
+	test(`Check that Spacefinder debug control panel loads when '?sfdebug' is added to the URL`, async ({
+		page,
+	}) => {
+		await loadPage(page, path);
+
+		await cmpAcceptAll(page);
+
+		await loadPage(page, pathWithDebug);
+
+		const debuggerPanelLocator = page.locator('sfdebug-panel');
+
+		await debuggerPanelLocator.isVisible();
+	});
+});

--- a/src/init/consented/article-body-adverts.ts
+++ b/src/init/consented/article-body-adverts.ts
@@ -286,7 +286,7 @@ const addDesktopInline2PlusAds = (): Promise<boolean> => {
 	return spaceFiller.fillSpace(rules, insertAds, {
 		waitForImages: true,
 		waitForInteractives: true,
-		pass: 'inline2',
+		pass: 'subsequent-inlines',
 	});
 };
 

--- a/src/spacefinder/spacefinder-debug-tools.ts
+++ b/src/spacefinder/spacefinder-debug-tools.ts
@@ -391,6 +391,16 @@ const addDebugPanel = (): void => {
 	document.body.appendChild(style);
 };
 
+const selectFirstPass = (): void => {
+	const controls = document.querySelector('#sfdebug-panel .controls');
+	if (
+		controls?.hasChildNodes &&
+		controls.firstElementChild?.tagName === 'INPUT'
+	) {
+		(controls.firstElementChild as HTMLInputElement).click();
+	}
+};
+
 const init = (
 	exclusions: SpacefinderExclusions = {},
 	winners: SpacefinderItem[],
@@ -402,6 +412,7 @@ const init = (
 	addDebugPanel();
 	annotate(exclusions, winners, rules, pass);
 	addPassToDebugPanel(pass);
+	selectFirstPass();
 };
 
 export { init };

--- a/src/spacefinder/spacefinder.ts
+++ b/src/spacefinder/spacefinder.ts
@@ -51,7 +51,7 @@ type SpacefinderRules = {
 
 type SpacefinderWriter = (paras: HTMLElement[]) => Promise<void>;
 
-type SpacefinderPass = 'inline1' | 'inline2' | 'im' | 'carrot';
+type SpacefinderPass = 'inline1' | 'subsequent-inlines' | 'im' | 'carrot';
 
 type SpacefinderOptions = {
 	waitForImages?: boolean;


### PR DESCRIPTION
## What does this change?
This PR makes a couple of small changes to the Spacefinder debugger:

- Renames `inline2` to `subsequent-inlines` to reflect that the button means all inlines after inline1, not just inline2
- Selects the first button in the Spacefinder control panel by default, so that we have the annotation appearing on the page and it doesn't appear blank
- Updates the documentation to reflect the fact that your URL only needs to contain `?sfdebug` - there's no difference between using `?sfdebug=1` or `?sfdebug=2` any more

## Why?
At the moment, when you load a page with `?sfdebug` in your URL, only the ad slots are highlighted by default, not the paragraphs, so the functionality of the debugger isn't immediately clear without clicking on a button on the control panel.

The name of inline2 was also misleading - it might make you think it only referred to the Spacefinder process for inline2 - not all inline adverts afterwards. Hopefully these small changes improve the user-friendliness of the the Spacefinder debugger.