### PR TITLE
Update Prebid to resolve peer dependency mismatches with DCR

### DIFF
--- a/.changeset/neat-mayflies-glow.md
+++ b/.changeset/neat-mayflies-glow.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': major
+---
+
+Update Prebid to node 20, and update peer dependencies to match DCR

--- a/.changeset/neat-mayflies-glow.md
+++ b/.changeset/neat-mayflies-glow.md
@@ -2,4 +2,4 @@
 '@guardian/commercial': major
 ---
 
-Update Prebid to node 20, and update peer dependencies to match DCR
+Update Prebid to node 18, and update peer dependencies to match DCR

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
 		"@octokit/core": "^4.0.5",
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",
-		"prebid.js": "guardian/prebid.js#ee7f43c7c85a5245bbe51920cfed18818866ea7b",
+		"prebid.js": "guardian/prebid.js#23b621b364f4477710579ab6285e951a35cdad16",
 		"process": "^0.11.10",
 		"raven-js": "^3.27.2",
 		"tslib": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 		"ts-jest": "^29.0.5",
 		"ts-loader": "^9.4.2",
 		"type-fest": "^4.3.3",
-		"typescript": "^5.1.3",
+		"typescript": "^5.3.3",
 		"webpack": "^5.76.0",
 		"webpack-bundle-analyzer": "^4.7.0",
 		"webpack-cli": "^4.10.0",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
 		"@octokit/core": "^4.0.5",
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",
-		"prebid.js": "guardian/prebid.js#a69808b0a18d5a7bd01f389202a4cc0330a7d9f3",
+		"prebid.js": "guardian/prebid.js#c1065fc8533ef73470a5e834ea7e7edc00a3f73f",
 		"process": "^0.11.10",
 		"raven-js": "^3.27.2",
 		"tslib": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
 		"@octokit/core": "^4.0.5",
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",
-		"prebid.js": "guardian/prebid.js#23b621b364f4477710579ab6285e951a35cdad16",
+		"prebid.js": "guardian/prebid.js#a69808b0a18d5a7bd01f389202a4cc0330a7d9f3",
 		"process": "^0.11.10",
 		"raven-js": "^3.27.2",
 		"tslib": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
 		"@octokit/core": "^4.0.5",
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",
-		"prebid.js": "guardian/prebid.js#ei/update-node",
+		"prebid.js": "guardian/prebid.js#91cabf5cdfc3c01745f4b10e55044f95a9d7d1b4",
 		"process": "^0.11.10",
 		"raven-js": "^3.27.2",
 		"tslib": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
 		"@octokit/core": "^4.0.5",
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",
-		"prebid.js": "guardian/prebid.js#c1065fc8533ef73470a5e834ea7e7edc00a3f73f",
+		"prebid.js": "guardian/prebid.js#ei/update-node",
 		"process": "^0.11.10",
 		"raven-js": "^3.27.2",
 		"tslib": "^2.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6922,9 +6922,9 @@ playwright@1.40.1:
   optionalDependencies:
     fsevents "2.3.2"
 
-prebid.js@guardian/prebid.js#a69808b0a18d5a7bd01f389202a4cc0330a7d9f3:
+prebid.js@guardian/prebid.js#c1065fc8533ef73470a5e834ea7e7edc00a3f73f:
   version "8.24.0"
-  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/a69808b0a18d5a7bd01f389202a4cc0330a7d9f3"
+  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/c1065fc8533ef73470a5e834ea7e7edc00a3f73f"
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/plugin-transform-runtime" "^7.18.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1782,7 +1782,7 @@
   resolved "https://registry.yarnpkg.com/@guardian/identity-auth/-/identity-auth-1.0.0.tgz#ea8896a45d2aef9828e590cccdd858b5f46785d1"
   integrity sha512-JUkPai2Qnuq1quQ2rtvwWhLTtISqJBNe8XpxqbIr4jGaNWn5EL3kI1scAwq5PyNEg9135E7YXWTnjLNkm3ivoA==
 
-"@guardian/libs@15.6.4", "@guardian/libs@^15.6.4":
+"@guardian/libs@15.6.4":
   version "15.6.4"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.6.4.tgz#13787065e5c58b884944c5c71d6e324c7f2e566a"
   integrity sha512-oN+xN7FBuVKLCbbjvAMdWjgWqOtvR38acnqwAKsjUDkFsBzRWU/pueDSEGTCTTVSFcRdCKOsWnop+Vwh59P47g==
@@ -1791,6 +1791,11 @@
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@guardian/ophan-tracker-js/-/ophan-tracker-js-2.0.4.tgz#899cf3b3d91d403fb5afb6842b258fff1c286c60"
   integrity sha512-kwUNUSfnL8SQwzTlVzInYh7a6VSMFy3zEq2A6Hm7cmKSbl8D7ed03y7ANqquViFuPffRZRQ0IrkJHSbMnsRmrA==
+
+"@guardian/libs@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-16.0.0.tgz#35c567039f3a2a8440e3f0520b1bd9d275e6ad97"
+  integrity sha512-2i9cN6htXnvABIGhfqJGb9Bh/DdQOayUjb5ruqBGTiXEeDBHztctdVsi7+rPfMlwyPxQ+0qYLhM19f6J94vvhQ==
 
 "@guardian/prettier@4.0.0":
   version "4.0.0"
@@ -6917,15 +6922,15 @@ playwright@1.40.1:
   optionalDependencies:
     fsevents "2.3.2"
 
-prebid.js@guardian/prebid.js#23b621b364f4477710579ab6285e951a35cdad16:
+prebid.js@guardian/prebid.js#a69808b0a18d5a7bd01f389202a4cc0330a7d9f3:
   version "8.24.0"
-  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/23b621b364f4477710579ab6285e951a35cdad16"
+  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/a69808b0a18d5a7bd01f389202a4cc0330a7d9f3"
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/plugin-transform-runtime" "^7.18.9"
     "@babel/preset-env" "^7.16.8"
     "@babel/runtime" "^7.18.9"
-    "@guardian/libs" "^15.6.4"
+    "@guardian/libs" "^16.0.0"
     core-js "^3.13.0"
     core-js-pure "^3.13.0"
     criteo-direct-rsa-validate "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8237,10 +8237,10 @@ typescript-tuple@^2.2.1:
   dependencies:
     typescript-compare "^0.0.2"
 
-typescript@^5.1.3:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
-  integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
+typescript@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
+  integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
 typescript@~4.9.5:
   version "4.9.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6922,9 +6922,9 @@ playwright@1.40.1:
   optionalDependencies:
     fsevents "2.3.2"
 
-prebid.js@guardian/prebid.js#ei/update-node:
+prebid.js@guardian/prebid.js#91cabf5cdfc3c01745f4b10e55044f95a9d7d1b4:
   version "8.24.0"
-  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/c1065fc8533ef73470a5e834ea7e7edc00a3f73f"
+  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/91cabf5cdfc3c01745f4b10e55044f95a9d7d1b4"
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/plugin-transform-runtime" "^7.18.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6922,7 +6922,7 @@ playwright@1.40.1:
   optionalDependencies:
     fsevents "2.3.2"
 
-prebid.js@guardian/prebid.js#c1065fc8533ef73470a5e834ea7e7edc00a3f73f:
+prebid.js@guardian/prebid.js#ei/update-node:
   version "8.24.0"
   resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/c1065fc8533ef73470a5e834ea7e7edc00a3f73f"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6917,9 +6917,9 @@ playwright@1.40.1:
   optionalDependencies:
     fsevents "2.3.2"
 
-prebid.js@guardian/prebid.js#ee7f43c7c85a5245bbe51920cfed18818866ea7b:
+prebid.js@guardian/prebid.js#23b621b364f4477710579ab6285e951a35cdad16:
   version "8.24.0"
-  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/ee7f43c7c85a5245bbe51920cfed18818866ea7b"
+  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/23b621b364f4477710579ab6285e951a35cdad16"
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/plugin-transform-runtime" "^7.18.9"


### PR DESCRIPTION
## What does this change?
Updates Prebid to bring in the latest changes. This will resolve the peer dependency mismatches with dotcom-rendering.

This update has been tested on CODE to make sure that Prebid still runs as expected.