### PR TITLE
Replace `ophan-tracker-js` with `@guardian/ophan-tracker-js`

### DIFF
--- a/.changeset/hungry-rivers-relate.md
+++ b/.changeset/hungry-rivers-relate.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Replace ophan-tracker-js with @guardian/ophan-tracker-js

--- a/package.json
+++ b/package.json
@@ -105,10 +105,10 @@
 	},
 	"dependencies": {
 		"@changesets/cli": "^2.26.2",
+		"@guardian/ophan-tracker-js": "2.0.4",
 		"@octokit/core": "^4.0.5",
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",
-		"ophan-tracker-js": "^2.0.1",
 		"prebid.js": "guardian/prebid.js#ee7f43c7c85a5245bbe51920cfed18818866ea7b",
 		"process": "^0.11.10",
 		"raven-js": "^3.27.2",

--- a/src/ad-verification/prepare-ad-verification.spec.ts
+++ b/src/ad-verification/prepare-ad-verification.spec.ts
@@ -5,7 +5,7 @@ const validIds = ['slot-a', 'slot-2'];
 const mockVariantSynchronous = jest.fn<boolean, unknown[]>();
 const mockLog = jest.fn<void, unknown[]>();
 
-jest.mock('ophan-tracker-js', () => null);
+jest.mock('@guardian/ophan-tracker-js', () => null);
 jest.mock('@guardian/libs', () => ({
 	storage: {
 		local: {

--- a/src/dfp/Advert.spec.ts
+++ b/src/dfp/Advert.spec.ts
@@ -8,7 +8,7 @@ jest.mock('dfp/init-slot-ias', () => ({
 	initSlotIas: jest.fn(() => Promise.resolve()),
 }));
 
-jest.mock('ophan-tracker-js', () => null);
+jest.mock('@guardian/ophan-tracker-js', () => null);
 
 jest.mock('core/ad-sizes', () => {
 	const adSizes: typeof AdSizesType = jest.requireActual('core/ad-sizes');

--- a/src/experiments/ab-ophan.ts
+++ b/src/experiments/ab-ophan.ts
@@ -1,5 +1,5 @@
 import type { ABTest, Runnable, Variant } from '@guardian/ab-core';
-import ophan from 'ophan-tracker-js';
+import ophan from '@guardian/ophan-tracker-js';
 import { noop } from 'utils/noop';
 import { reportError } from 'utils/report-error';
 

--- a/src/init/consented/liveblog-adverts.spec.ts
+++ b/src/init/consented/liveblog-adverts.spec.ts
@@ -13,7 +13,7 @@ jest.mock('utils/report-error', () => ({
 jest.mock('header-bidding/prebid/prebid', () => ({
 	requestBids: jest.fn(),
 }));
-jest.mock('ophan-tracker-js', () => null);
+jest.mock('@guardian/ophan-tracker-js', () => null);
 jest.mock('utils/mediator');
 jest.mock('spacefinder/space-filler', () => ({
 	spaceFiller: {

--- a/src/init/consented/prepare-googletag.spec.ts
+++ b/src/init/consented/prepare-googletag.spec.ts
@@ -68,7 +68,7 @@ jest.mock('identity/api', () => ({
 	getGoogleTagId: jest.fn().mockResolvedValue('test-id-string'),
 	getUrl: jest.fn(),
 }));
-jest.mock('ophan-tracker-js', () => null);
+jest.mock('@guardian/ophan-tracker-js', () => null);
 jest.mock('analytics/beacon', () => void {});
 
 jest.mock('detect/detect-breakpoint', () => ({

--- a/src/init/consented/third-party-tags.spec.ts
+++ b/src/init/consented/third-party-tags.spec.ts
@@ -93,7 +93,7 @@ afterEach(() => {
 	document.body.innerHTML = '';
 });
 
-jest.mock('ophan-tracker-js', () => null);
+jest.mock('@guardian/ophan-tracker-js', () => null);
 
 jest.mock('lib/commercial-features', () => ({
 	commercialFeatures: {

--- a/src/types/modules.d.ts
+++ b/src/types/modules.d.ts
@@ -12,7 +12,7 @@ declare module '*.svg' {
 	export default content;
 }
 
-declare module 'ophan-tracker-js' {
+declare module '@guardian/ophan-tracker-js' {
 	const ophan: Ophan;
 	// eslint-disable-next-line import/no-default-export -- that’s the ophan way
 	export default ophan;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,6 +1787,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.6.4.tgz#13787065e5c58b884944c5c71d6e324c7f2e566a"
   integrity sha512-oN+xN7FBuVKLCbbjvAMdWjgWqOtvR38acnqwAKsjUDkFsBzRWU/pueDSEGTCTTVSFcRdCKOsWnop+Vwh59P47g==
 
+"@guardian/ophan-tracker-js@2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@guardian/ophan-tracker-js/-/ophan-tracker-js-2.0.4.tgz#899cf3b3d91d403fb5afb6842b258fff1c286c60"
+  integrity sha512-kwUNUSfnL8SQwzTlVzInYh7a6VSMFy3zEq2A6Hm7cmKSbl8D7ed03y7ANqquViFuPffRZRQ0IrkJHSbMnsRmrA==
+
 "@guardian/prettier@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-4.0.0.tgz#1ad1d7d079194937bfd0107789dde7b0fb84fa11"
@@ -6658,11 +6663,6 @@ opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
-
-ophan-tracker-js@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-2.0.1.tgz#568c9a8c127f511d4dc19e9d3421cc88e04ea910"
-  integrity sha512-HXH0rjZlLeV9ri4V9Q0t0AaD5Q3ue4o+YMCuBsov6cWLPWcWBiARHtSRlpY6fJD+/iUIEiSPsrlfPIJUz7inYA==
 
 optionator@^0.8.1:
   version "0.8.3"


### PR DESCRIPTION
## What does this change?

Replace `ophan-tracker-js` with `@guardian/ophan-tracker-js`

## Why?

`ophan-tracker-js` is deprecated and we should replace with `@guardian/ophan-tracker-js`.

v2.0.4 will also bring in this fix to how Ophan constructs its requests: https://github.com/guardian/ophan/pull/5624
