### PR TITLE
Use `@guardian/prebid.js@8.34.0` from npm

### DIFF
--- a/.changeset/curvy-zebras-travel.md
+++ b/.changeset/curvy-zebras-travel.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Upgrade to prebid.js@8.34.0 and use from npm

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
 	"dependencies": {
 		"@changesets/cli": "^2.26.2",
 		"@guardian/ophan-tracker-js": "2.0.4",
+		"@guardian/prebid.js": "8.24.0",
 		"@octokit/core": "^4.0.5",
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
 	"dependencies": {
 		"@changesets/cli": "^2.26.2",
 		"@guardian/ophan-tracker-js": "2.0.4",
-		"@guardian/prebid.js": "8.24.0",
+		"@guardian/prebid.js": "8.34.0",
 		"@octokit/core": "^4.0.5",
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
 		"@octokit/core": "^4.0.5",
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",
-		"prebid.js": "guardian/prebid.js#91cabf5cdfc3c01745f4b10e55044f95a9d7d1b4",
 		"process": "^0.11.10",
 		"raven-js": "^3.27.2",
 		"tslib": "^2.6.2",

--- a/scripts/bump_commercial.sh
+++ b/scripts/bump_commercial.sh
@@ -22,7 +22,7 @@ git checkout -b "$BRANCH_NAME"
 yarn upgrade "$REPO@$VERSION"
 
 # fix the flip flopping Prebid
-yarn cache clean prebid.js
+yarn cache clean @guardian/prebid.js
 yarn install --force
 
 git add package.json yarn.lock

--- a/src/init/consented/prepare-prebid.ts
+++ b/src/init/consented/prepare-prebid.ts
@@ -24,7 +24,7 @@ const loadPrebid = async (framework: Framework): Promise<void> => {
 	if (shouldLoadPrebid()) {
 		await import(
 			// @ts-expect-error -- there’s no types for Prebid.js
-			/* webpackChunkName: "Prebid.js" */ 'prebid.js/build/dist/prebid'
+			/* webpackChunkName: "Prebid.js" */ '@guardian/prebid.js/build/dist/prebid'
 		);
 		prebid.initialise(window, framework);
 	}

--- a/src/lib/header-bidding/prebid/prebid.spec.ts
+++ b/src/lib/header-bidding/prebid/prebid.spec.ts
@@ -24,7 +24,7 @@ const resetPrebid = () => {
 	// @ts-expect-error -- there’s no types for this
 	delete window.pbjsChunk;
 	jest.resetModules();
-	jest.requireActual('prebid.js/build/dist/prebid');
+	jest.requireActual('@guardian/prebid.js/build/dist/prebid');
 };
 
 describe('initialise', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1797,10 +1797,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ophan-tracker-js/-/ophan-tracker-js-2.0.4.tgz#899cf3b3d91d403fb5afb6842b258fff1c286c60"
   integrity sha512-kwUNUSfnL8SQwzTlVzInYh7a6VSMFy3zEq2A6Hm7cmKSbl8D7ed03y7ANqquViFuPffRZRQ0IrkJHSbMnsRmrA==
 
-"@guardian/prebid.js@8.24.0":
-  version "8.24.0"
-  resolved "https://registry.yarnpkg.com/@guardian/prebid.js/-/prebid.js-8.24.0.tgz#f987886ddc12fa8e833f5d7566fb57ce081ac7c1"
-  integrity sha512-ug0/r2kH3lPLFzmyPPfffE6E5k6CvN2XKguQErZTxK7T2bnepqUQ2qPCMXKWP4KDP1EljIedXOAxYvX2LrtVMg==
+"@guardian/prebid.js@8.34.0":
+  version "8.34.0"
+  resolved "https://registry.yarnpkg.com/@guardian/prebid.js/-/prebid.js-8.34.0.tgz#6ab69684d254e52c44a0fe58ad5fc334ee133953"
+  integrity sha512-DLH/EuWGsM6oZcMVm+qsuWhYPl+TE4nqkDzAVJRjOkiP3AHHOZ7AnQaGzF9Y9tG3EeFU/iJwqJ43JlIjDBOt1A==
   dependencies:
     "@babel/core" "^7.23.2"
     "@babel/plugin-transform-runtime" "^7.18.9"
@@ -1816,7 +1816,7 @@
     express "^4.15.4"
     fun-hooks "^0.9.9"
     just-clone "^1.0.2"
-    live-connect-js "^6.3.0"
+    live-connect-js "^6.3.4"
   optionalDependencies:
     fsevents "^2.3.2"
 
@@ -6177,17 +6177,17 @@ listr2@^5.0.7:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
-live-connect-common@^v3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/live-connect-common/-/live-connect-common-3.0.2.tgz#85111a551cf848d84e7560139ddf55dccba0d468"
-  integrity sha512-K3LNKd9CpREDJbXGdwKqPojjQaxd4G6c7OAD6Yzp3wsCWTH2hV8xNAbUksSOpOcVyyOT9ilteEFXIJQJrbODxQ==
+live-connect-common@^v3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/live-connect-common/-/live-connect-common-3.1.1.tgz#7d0474bce04d6c03fb7157abebd37b0deac437a6"
+  integrity sha512-sV0oUvJnaTN41f30hOo3wDjZL2y8TYu5BQKvlxmek7Agpe2AGGN/dsPA8i2sHkessRKpcTfrPjmpnG2bIxq7Gg==
 
-live-connect-js@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/live-connect-js/-/live-connect-js-6.3.0.tgz#032d6015969293774430872d4d22ca8bae8ff2c9"
-  integrity sha512-1SnXQZq9gxHIb0scXPX1Da1rQ0oY2sloMGgeRreTAwhCtdQEuip/IYwgOh3/ZeZ6yT6iG9FLb7+AjORC4pO46g==
+live-connect-js@^6.3.4:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/live-connect-js/-/live-connect-js-6.5.0.tgz#3731fd8a20d117235c843f5d14502961483accd9"
+  integrity sha512-gZOKtGjPjTf6JuUtA6OZgg8w/uEP2lEtlAKWSox+rTiTRmD4U6o28MB9WEgSJWlZWwUwmWu9dL8ByxBFbsWZyg==
   dependencies:
-    live-connect-common "^v3.0.2"
+    live-connect-common "^v3.1.1"
     tiny-hashes "1.0.1"
 
 load-json-file@^4.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,11 +1787,6 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-16.0.1.tgz#81214a701ef7159e8bdbba901af30bdaec901c28"
   integrity sha512-/pgkDwWu9xp4TAEx07LFu80XsJWIti0VHRxjRRV6vNCMIb44OktONXs5Lu9deoSXWNZh+VcyAEj8vFF2DRPdMA==
 
-"@guardian/libs@^15.6.4":
-  version "15.9.1"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.9.1.tgz#6846c9f0debb19d650f1775b21314a99ea80248d"
-  integrity sha512-Mns6Gc3MQacVxQ44Ei5HaVak3y9HYQF5kZ4lZGnacJfRdWAfW9K5K5rphf7mSgqkygOGoTs5TMQ3gO37MP8hbw==
-
 "@guardian/libs@^16.0.0":
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-16.0.0.tgz#35c567039f3a2a8440e3f0520b1bd9d275e6ad97"
@@ -6949,28 +6944,6 @@ playwright@1.40.1:
     playwright-core "1.40.1"
   optionalDependencies:
     fsevents "2.3.2"
-
-prebid.js@guardian/prebid.js#91cabf5cdfc3c01745f4b10e55044f95a9d7d1b4:
-  version "8.24.0"
-  resolved "https://codeload.github.com/guardian/prebid.js/tar.gz/91cabf5cdfc3c01745f4b10e55044f95a9d7d1b4"
-  dependencies:
-    "@babel/core" "^7.23.2"
-    "@babel/plugin-transform-runtime" "^7.18.9"
-    "@babel/preset-env" "^7.16.8"
-    "@babel/runtime" "^7.18.9"
-    "@guardian/libs" "^15.6.4"
-    core-js "^3.13.0"
-    core-js-pure "^3.13.0"
-    criteo-direct-rsa-validate "^1.1.0"
-    crypto-js "^4.2.0"
-    dlv "1.1.3"
-    dset "3.1.2"
-    express "^4.15.4"
-    fun-hooks "^0.9.9"
-    just-clone "^1.0.2"
-    live-connect-js "^6.3.0"
-  optionalDependencies:
-    fsevents "^2.3.2"
 
 preferred-pm@^3.0.0:
   version "3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,6 +1787,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-16.0.1.tgz#81214a701ef7159e8bdbba901af30bdaec901c28"
   integrity sha512-/pgkDwWu9xp4TAEx07LFu80XsJWIti0VHRxjRRV6vNCMIb44OktONXs5Lu9deoSXWNZh+VcyAEj8vFF2DRPdMA==
 
+"@guardian/libs@^15.6.4":
+  version "15.9.1"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-15.9.1.tgz#6846c9f0debb19d650f1775b21314a99ea80248d"
+  integrity sha512-Mns6Gc3MQacVxQ44Ei5HaVak3y9HYQF5kZ4lZGnacJfRdWAfW9K5K5rphf7mSgqkygOGoTs5TMQ3gO37MP8hbw==
+
 "@guardian/libs@^16.0.0":
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-16.0.0.tgz#35c567039f3a2a8440e3f0520b1bd9d275e6ad97"
@@ -1796,6 +1801,29 @@
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@guardian/ophan-tracker-js/-/ophan-tracker-js-2.0.4.tgz#899cf3b3d91d403fb5afb6842b258fff1c286c60"
   integrity sha512-kwUNUSfnL8SQwzTlVzInYh7a6VSMFy3zEq2A6Hm7cmKSbl8D7ed03y7ANqquViFuPffRZRQ0IrkJHSbMnsRmrA==
+
+"@guardian/prebid.js@8.24.0":
+  version "8.24.0"
+  resolved "https://registry.yarnpkg.com/@guardian/prebid.js/-/prebid.js-8.24.0.tgz#f987886ddc12fa8e833f5d7566fb57ce081ac7c1"
+  integrity sha512-ug0/r2kH3lPLFzmyPPfffE6E5k6CvN2XKguQErZTxK7T2bnepqUQ2qPCMXKWP4KDP1EljIedXOAxYvX2LrtVMg==
+  dependencies:
+    "@babel/core" "^7.23.2"
+    "@babel/plugin-transform-runtime" "^7.18.9"
+    "@babel/preset-env" "^7.16.8"
+    "@babel/runtime" "^7.18.9"
+    "@guardian/libs" "^16.0.0"
+    core-js "^3.13.0"
+    core-js-pure "^3.13.0"
+    criteo-direct-rsa-validate "^1.1.0"
+    crypto-js "^4.2.0"
+    dlv "1.1.3"
+    dset "3.1.2"
+    express "^4.15.4"
+    fun-hooks "^0.9.9"
+    just-clone "^1.0.2"
+    live-connect-js "^6.3.0"
+  optionalDependencies:
+    fsevents "^2.3.2"
 
 "@guardian/prettier@4.0.0":
   version "4.0.0"
@@ -6930,7 +6958,7 @@ prebid.js@guardian/prebid.js#91cabf5cdfc3c01745f4b10e55044f95a9d7d1b4:
     "@babel/plugin-transform-runtime" "^7.18.9"
     "@babel/preset-env" "^7.16.8"
     "@babel/runtime" "^7.18.9"
-    "@guardian/libs" "^16.0.0"
+    "@guardian/libs" "^15.6.4"
     core-js "^3.13.0"
     core-js-pure "^3.13.0"
     criteo-direct-rsa-validate "^1.1.0"


### PR DESCRIPTION
## What does this change?

Since https://github.com/guardian/Prebid.js/pull/145 we now publish our fork of prebid.js to npm:

https://www.npmjs.com/package/@guardian/prebid.js

We can now reference the version of `@guardian/prebid.js` from npm instead of attempting to reference a github commit which causes issues for yarn's cache, Snyk and Dependabot.

This also [bumps the version to 8.34.0](https://github.com/guardian/Prebid.js/pull/146) as a test of the new publishing flow.

Tested on CODE



