### PR TITLE
Fix issue with unintended zoom on interscrollers

### DIFF
--- a/.changeset/honest-rivers-drive.md
+++ b/.changeset/honest-rivers-drive.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Fix interscroller zoom issue

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -84,7 +84,6 @@ const createParent = (
 
 			if (scrollType === 'interscroller') {
 				background.style.height = '100vh';
-				background.style.height = '100svh';
 			}
 		}
 	}

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -81,6 +81,10 @@ const createParent = (
 
 			background.style.inset = '0';
 			background.style.transition = 'background 100ms ease';
+
+			if (scrollType === 'interscroller') {
+				background.style.height = '100vh';
+			}
 		}
 	}
 

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -84,6 +84,7 @@ const createParent = (
 
 			if (scrollType === 'interscroller') {
 				background.style.height = '100vh';
+				background.style.height = '100svh';
 			}
 		}
 	}


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

- Sets the height of the background to `100vh`

## Why?

- There is unintended zoom on mobile devices when changing scrolling direction, when the viewport changes dimensions depending on which direction the user is scrolling. This is often when the address bar pops up/down when the user scrolls up. The background interscroller image covers the screen, so when the viewport aspect ratio changes, the image can look zoomed in/out
- `vh` (same as `lvh`. Less explicit, but [better supported](https://caniuse.com/viewport-unit-variants)) was preferred over `svh`, because with the latter there can be some white space below the ad image when the viewport is at its tallest: 
<img width="178" alt="Screenshot 2024-02-06 at 11 44 34" src="https://github.com/guardian/commercial/assets/9574885/340186dc-1fef-47c9-b6f2-b8f39667ac5d">

## Notes

- The image still "jumps" up and down slightly when changing scroll direction. This PR does not attempt to fix this bug.

## Screenshots

| Before | After |
| - | - |
| ![before] | ![after] |

[before]: https://github.com/guardian/commercial/assets/9574885/7d34bd04-cfc3-404e-b087-91c8375bfd10
[after]: https://github.com/guardian/commercial/assets/9574885/ecd61afa-d878-493b-b6af-8ab76dccb8c4
