### PR TITLE
Extend expiry for mpuWhenNoEpic AB test to set back live

### DIFF
--- a/.changeset/big-kiwis-live.md
+++ b/.changeset/big-kiwis-live.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Extend expiry to make mpuWhenNoEpic live again after unblocking Teads

--- a/src/experiments/tests/mpu-when-no-epic.ts
+++ b/src/experiments/tests/mpu-when-no-epic.ts
@@ -4,7 +4,7 @@ export const mpuWhenNoEpic: ABTest = {
 	id: 'MpuWhenNoEpic',
 	author: '@commercial-dev',
 	start: '2023-11-22',
-	expiry: '2024-01-31',
+	expiry: '2024-02-29',
 	audience: 10 / 100,
 	audienceOffset: 5 / 100,
 	audienceCriteria: '',


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

This PR is a part of the `mpuWhenNoEpic` AB test work which started in #1157. We first ran the tests for a week without Teads which was a blocked work for some time because it required external changes (Teads team) but now the work has been done and we will set the tests back live for a week. 

## Why?

Testing if Teads in `article-end` MPU would increase the revenue towards our Advertising.
