### PR TITLE
Explicitly set cookieDeprecationLabel targeting to 'empty'

### DIFF
--- a/.changeset/serious-lemons-kick.md
+++ b/.changeset/serious-lemons-kick.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Explicitly set cookieDeprecationLabel targeting to 'empty'

--- a/src/init/consented/prepare-googletag.ts
+++ b/src/init/consented/prepare-googletag.ts
@@ -36,9 +36,10 @@ const setPublisherProvidedId = (): void => {
 const setCookieDeprecationLabel = (): void => {
 	if ('cookieDeprecationLabel' in navigator) {
 		void navigator.cookieDeprecationLabel?.getValue().then((value) => {
+			const cookieDeprecationLabel = value || 'empty';
 			window.googletag
 				.pubads()
-				.setTargeting('cookieDeprecationLabel', value);
+				.setTargeting('cookieDeprecationLabel', cookieDeprecationLabel);
 		});
 	}
 };


### PR DESCRIPTION
## Why?
We're unsure how empty strings come through to ad manager, safer to set it to 'empty'.