### PR TITLE
Downgrade cmp peer dep

### DIFF
--- a/.changeset/few-ladybugs-explain.md
+++ b/.changeset/few-ladybugs-explain.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Downgrade cmp peer dep

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
 	},
 	"peerDependencies": {
 		"@guardian/ab-core": "^7.0.1",
-		"@guardian/consent-management-platform": "~13.7.3",
+		"@guardian/consent-management-platform": "^13.7.3",
 		"@guardian/core-web-vitals": "^6.0.0",
 		"@guardian/identity-auth": "^2.0.1",
 		"@guardian/identity-auth-frontend": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
 	},
 	"peerDependencies": {
 		"@guardian/ab-core": "^7.0.1",
-		"@guardian/consent-management-platform": "^13.8.0",
+		"@guardian/consent-management-platform": "~13.7.3",
 		"@guardian/core-web-vitals": "^6.0.0",
 		"@guardian/identity-auth": "^2.0.1",
 		"@guardian/identity-auth-frontend": "^3.0.0",


### PR DESCRIPTION
## What does this change?

Missed the downgrade of the cmp peer dep following https://github.com/guardian/commercial/pull/1244

