### PR TITLE
Update cmp with prebid change

### DIFF
--- a/.changeset/quiet-kids-count.md
+++ b/.changeset/quiet-kids-count.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Testing in Frontend

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"@babel/runtime": "^7.11.2",
 		"@guardian/ab-core": "5.0.0",
 		"@guardian/browserslist-config": "^5.1.0",
-		"@guardian/consent-management-platform": "13.7.3",
+		"@guardian/consent-management-platform": "0.0.0-beta-20240209115205",
 		"@guardian/core-web-vitals": "5.1.0",
 		"@guardian/eslint-config-typescript": "^6.0.0",
 		"@guardian/identity-auth": "^2.0.1",

--- a/src/init/consented/prepare-prebid.ts
+++ b/src/init/consented/prepare-prebid.ts
@@ -36,7 +36,10 @@ const setupPrebid = (): Promise<void> =>
 			if (!consentState.framework) {
 				return Promise.reject('Unknown framework');
 			}
-			if (!getConsentFor('prebid', consentState)) {
+			if (
+				!getConsentFor('prebid', consentState) ||
+				!getConsentFor('prebidCustom', consentState)
+			) {
 				return Promise.reject('No consent for prebid');
 			}
 			return loadPrebid(consentState.framework);

--- a/src/init/consented/prepare-prebid.ts
+++ b/src/init/consented/prepare-prebid.ts
@@ -37,8 +37,10 @@ const setupPrebid = (): Promise<void> =>
 				return Promise.reject('Unknown framework');
 			}
 			if (
-				!getConsentFor('prebid', consentState) &&
-				!getConsentFor('prebidCustom', consentState)
+				!(
+					getConsentFor('prebid', consentState) ||
+					getConsentFor('prebidCustom', consentState)
+				)
 			) {
 				return Promise.reject('No consent for prebid');
 			}

--- a/src/init/consented/prepare-prebid.ts
+++ b/src/init/consented/prepare-prebid.ts
@@ -37,7 +37,7 @@ const setupPrebid = (): Promise<void> =>
 				return Promise.reject('Unknown framework');
 			}
 			if (
-				!getConsentFor('prebid', consentState) ||
+				!getConsentFor('prebid', consentState) &&
 				!getConsentFor('prebidCustom', consentState)
 			) {
 				return Promise.reject('No consent for prebid');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,10 +1742,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-5.1.0.tgz#61cd822388dc196cea1b39c693366ed550edcd10"
   integrity sha512-QsyaZ7OZ6jBl8lByiLWtnobcS0IvIPVzDeGz9XY+CvPy5v5Kb0RJo+fFLEZbCqRLrfK+5f2sjrwPqrwtJBe2Sw==
 
-"@guardian/consent-management-platform@13.7.3":
-  version "13.7.3"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.7.3.tgz#f55304b2a07b083dad19f3ad4df16bbe19529856"
-  integrity sha512-fgA6JE0YYx20cjR2JvNaakvFp5pChic7rCTA99UPV1SO6f5NfX4o9kWL6oByZNA0rxsSLCwbLUiDbeXwe7aVbw==
+"@guardian/consent-management-platform@0.0.0-beta-20240209115205":
+  version "0.0.0-beta-20240209115205"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-0.0.0-beta-20240209115205.tgz#557d51965d3976224db9dd0ff3c9c569ac37ed39"
+  integrity sha512-s3HETvfkqTd25RF1lpQ5cKnMdfHeq7N1967ZK9QYqU8rbG+25IiOiRP/GwSEv8k9z4/esyO4Q8iLmwNkWwgQ6g==
 
 "@guardian/core-web-vitals@5.1.0":
   version "5.1.0"


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?
Checking for consent for either `prebid` or `prebidCustom` in prepare-bid.ts

## Why?
`prebid` has been removed from the  tcfv2 vendors and replaced with `prebidCustom`. We need to accomodate for both until late March (a scheduled re-permission) as newly consented users will be using `prebidCustom` and those who consented before the change was made will be using `prebid`.