### PR TITLE
Check global and custom vendor for Prebid

### DIFF
--- a/.changeset/healthy-guests-kick.md
+++ b/.changeset/healthy-guests-kick.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Check custom Prebid vendor for consent

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"@babel/runtime": "^7.11.2",
 		"@guardian/ab-core": "5.0.0",
 		"@guardian/browserslist-config": "^5.1.0",
-		"@guardian/consent-management-platform": "0.0.0-beta-20240209115205",
+		"@guardian/consent-management-platform": "13.10.0",
 		"@guardian/core-web-vitals": "5.1.0",
 		"@guardian/eslint-config-typescript": "^6.0.0",
 		"@guardian/identity-auth": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"@babel/runtime": "^7.11.2",
 		"@guardian/ab-core": "5.0.0",
 		"@guardian/browserslist-config": "^5.1.0",
-		"@guardian/consent-management-platform": "13.7.3",
+		"@guardian/consent-management-platform": "0.0.0-beta-20240209115205",
 		"@guardian/core-web-vitals": "5.1.0",
 		"@guardian/eslint-config-typescript": "^6.0.0",
 		"@guardian/identity-auth": "^2.0.1",

--- a/playwright/tests/targeting.spec.ts
+++ b/playwright/tests/targeting.spec.ts
@@ -68,7 +68,7 @@ test.describe('GAM targeting', () => {
 	});
 });
 
-test.skip('Prebid targeting', () => {
+test.describe('Prebid targeting', () => {
 	test.beforeEach(async ({ page }) => {
 		return page.route(bidderURLs.criteo, (route) => {
 			const url = route.request().url();

--- a/src/init/consented/prepare-prebid.spec.ts
+++ b/src/init/consented/prepare-prebid.spec.ts
@@ -60,7 +60,17 @@ const mockOnConsent = (consentState: ConsentState) =>
 	(onConsent as jest.Mock).mockReturnValueOnce(Promise.resolve(consentState));
 
 const mockGetConsentFor = (hasConsent: boolean) =>
-	(getConsentFor as jest.Mock).mockReturnValueOnce(hasConsent);
+	(getConsentFor as jest.Mock)
+		.mockReturnValueOnce(hasConsent)
+		.mockReturnValueOnce(hasConsent);
+
+const mockGetConsentForWithCustom = (
+	hasGlobalVendorConsent: boolean,
+	hasCustomVendorConsent: boolean,
+) =>
+	(getConsentFor as jest.Mock)
+		.mockReturnValueOnce(hasGlobalVendorConsent)
+		.mockReturnValueOnce(hasCustomVendorConsent);
 
 const defaultTCFv2State: TCFv2ConsentState = {
 	consents: { 1: false },
@@ -390,6 +400,57 @@ describe('init', () => {
 			'commercial',
 			expect.stringContaining('Failed to execute prebid'),
 			expect.stringContaining('Unknown framework'),
+		);
+
+		expect(prebid.initialise).not.toBeCalled();
+	});
+
+	it('should initialise Prebid in TCF when global vendor has consent and custom vendor does not', async () => {
+		expect.hasAssertions();
+
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+		};
+		commercialFeatures.shouldLoadGoogletag = true;
+		commercialFeatures.adFree = false;
+		mockOnConsent(tcfv2WithConsent);
+		mockGetConsentForWithCustom(true, false);
+
+		await setupPrebid();
+		expect(prebid.initialise).toBeCalled();
+	});
+
+	it('should initialise Prebid in TCF when global vendor does not have consent but the custom vendor does', async () => {
+		expect.hasAssertions();
+
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+		};
+		commercialFeatures.shouldLoadGoogletag = true;
+		commercialFeatures.adFree = false;
+		mockOnConsent(tcfv2WithConsent);
+		mockGetConsentForWithCustom(false, true);
+
+		await setupPrebid();
+		expect(prebid.initialise).toBeCalled();
+	});
+
+	it('should NOT initialise Prebid in TCF when neither the global vendor or custom vendor has consent', async () => {
+		expect.hasAssertions();
+
+		window.guardian.config.switches = {
+			prebidHeaderBidding: true,
+		};
+		commercialFeatures.shouldLoadGoogletag = true;
+		commercialFeatures.adFree = false;
+		mockOnConsent(tcfv2WithConsent);
+		mockGetConsentForWithCustom(false, false);
+
+		await setupPrebid();
+		expect(log).toHaveBeenCalledWith(
+			'commercial',
+			expect.stringContaining('Failed to execute prebid'),
+			expect.stringContaining('No consent for prebid'),
 		);
 
 		expect(prebid.initialise).not.toBeCalled();

--- a/src/init/consented/prepare-prebid.ts
+++ b/src/init/consented/prepare-prebid.ts
@@ -36,7 +36,13 @@ const setupPrebid = (): Promise<void> =>
 			if (!consentState.framework) {
 				return Promise.reject('Unknown framework');
 			}
-			if (!getConsentFor('prebid', consentState)) {
+			if (
+				// Check if we do NOT have consent to either the old global or custom prebid vendor
+				!(
+					getConsentFor('prebid', consentState) ||
+					getConsentFor('prebidCustom', consentState)
+				)
+			) {
 				return Promise.reject('No consent for prebid');
 			}
 			return loadPrebid(consentState.framework);

--- a/src/init/consented/prepare-prebid.ts
+++ b/src/init/consented/prepare-prebid.ts
@@ -36,11 +36,19 @@ const setupPrebid = (): Promise<void> =>
 			if (!consentState.framework) {
 				return Promise.reject('Unknown framework');
 			}
+			const hasConsentForGlobalPrebidVendor = getConsentFor(
+				'prebid',
+				consentState,
+			);
+			const hasConsentForCustomPrebidVendor = getConsentFor(
+				'prebidCustom',
+				consentState,
+			);
 			if (
 				// Check if we do NOT have consent to either the old global or custom prebid vendor
 				!(
-					getConsentFor('prebid', consentState) ||
-					getConsentFor('prebidCustom', consentState)
+					hasConsentForGlobalPrebidVendor ||
+					hasConsentForCustomPrebidVendor
 				)
 			) {
 				return Promise.reject('No consent for prebid');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,10 +1742,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-5.1.0.tgz#61cd822388dc196cea1b39c693366ed550edcd10"
   integrity sha512-QsyaZ7OZ6jBl8lByiLWtnobcS0IvIPVzDeGz9XY+CvPy5v5Kb0RJo+fFLEZbCqRLrfK+5f2sjrwPqrwtJBe2Sw==
 
-"@guardian/consent-management-platform@0.0.0-beta-20240209115205":
-  version "0.0.0-beta-20240209115205"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-0.0.0-beta-20240209115205.tgz#557d51965d3976224db9dd0ff3c9c569ac37ed39"
-  integrity sha512-s3HETvfkqTd25RF1lpQ5cKnMdfHeq7N1967ZK9QYqU8rbG+25IiOiRP/GwSEv8k9z4/esyO4Q8iLmwNkWwgQ6g==
+"@guardian/consent-management-platform@13.10.0":
+  version "13.10.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.10.0.tgz#c0d34ef67ca90a5e8dabf8f346d0b3f14129f93e"
+  integrity sha512-ura73/w9VOOTI+p+h52J+hePq6S4YeIV3iRiUYhc6IdqpdBkJfKKGE3zh9fxd+S/ktH8ZSQR4ebRjM2GKtMJrw==
 
 "@guardian/core-web-vitals@5.1.0":
   version "5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,10 +1742,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-5.1.0.tgz#61cd822388dc196cea1b39c693366ed550edcd10"
   integrity sha512-QsyaZ7OZ6jBl8lByiLWtnobcS0IvIPVzDeGz9XY+CvPy5v5Kb0RJo+fFLEZbCqRLrfK+5f2sjrwPqrwtJBe2Sw==
 
-"@guardian/consent-management-platform@13.7.3":
-  version "13.7.3"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.7.3.tgz#f55304b2a07b083dad19f3ad4df16bbe19529856"
-  integrity sha512-fgA6JE0YYx20cjR2JvNaakvFp5pChic7rCTA99UPV1SO6f5NfX4o9kWL6oByZNA0rxsSLCwbLUiDbeXwe7aVbw==
+"@guardian/consent-management-platform@0.0.0-beta-20240209115205":
+  version "0.0.0-beta-20240209115205"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-0.0.0-beta-20240209115205.tgz#557d51965d3976224db9dd0ff3c9c569ac37ed39"
+  integrity sha512-s3HETvfkqTd25RF1lpQ5cKnMdfHeq7N1967ZK9QYqU8rbG+25IiOiRP/GwSEv8k9z4/esyO4Q8iLmwNkWwgQ6g==
 
 "@guardian/core-web-vitals@5.1.0":
   version "5.1.0"


### PR DESCRIPTION
## What does this change?

The TCF global Prebid vendor has been dropped from Sourcepoint which means Prebid header bidding is failing for newly consented users in TCF.

This PR adds an additional check for consent for the new custom Prebid vendor so that we maintain consent for existing consented users and newly consented users.

If the user does not consent to either vendor Prebid will not load.




