### PR TITLE
Rename TagFront endpoint to TagPage

### DIFF
--- a/playwright/fixtures/pages/fronts.ts
+++ b/playwright/fixtures/pages/fronts.ts
@@ -5,7 +5,7 @@ type Front = GuPage & {
 	section: string;
 };
 
-type TagFront = GuPage;
+type TagPage = GuPage;
 
 const stage = getStage();
 
@@ -39,12 +39,12 @@ const fronts: Front[] = [
 	},
 ];
 
-const tagFronts: TagFront[] = [
+const tagPages: TagPage[] = [
 	{
 		path: getTestUrl({
 			stage,
 			path: '/world/americas',
-			type: 'tagFront',
+			type: 'tagPage',
 			adtest: 'fixed-puppies',
 		}),
 	},
@@ -60,4 +60,4 @@ const frontWithPageSkin: Front = {
 	section: 'uk',
 };
 
-export { frontWithPageSkin, fronts, tagFronts };
+export { frontWithPageSkin, fronts, tagPages };

--- a/playwright/fixtures/pages/index.ts
+++ b/playwright/fixtures/pages/index.ts
@@ -1,7 +1,7 @@
 import { articles } from './articles';
 import { blogs } from './blogs';
-import { fronts, frontWithPageSkin, tagFronts } from './fronts';
+import { fronts, frontWithPageSkin, tagPages } from './fronts';
 
 const allPages = [...articles, ...blogs];
 
-export { allPages, articles, blogs, fronts, frontWithPageSkin, tagFronts };
+export { allPages, articles, blogs, fronts, frontWithPageSkin, tagPages };

--- a/playwright/lib/util.ts
+++ b/playwright/lib/util.ts
@@ -3,7 +3,7 @@ import type { UserFeaturesResponse } from '../../src/types/membership';
 
 type Stage = 'code' | 'prod' | 'dev';
 
-type ContentType = 'article' | 'liveblog' | 'front' | 'tagFront';
+type ContentType = 'article' | 'liveblog' | 'front' | 'tagPage';
 
 const normalizeStage = (stage: string): Stage =>
 	['code', 'prod', 'dev'].includes(stage) ? (stage as Stage) : 'dev';
@@ -31,13 +31,13 @@ const getHost = (stage?: Stage | undefined) => {
 
 const getDcrContentType = (
 	type: ContentType,
-): 'Article' | 'Front' | 'TagFront' => {
+): 'Article' | 'Front' | 'TagPage' => {
 	switch (type) {
 		case 'front':
 			return 'Front';
 
-		case 'tagFront':
-			return 'TagFront';
+		case 'tagPage':
+			return 'TagPage';
 
 		default:
 			return 'Article';

--- a/playwright/tests/front-inline-slots.spec.ts
+++ b/playwright/tests/front-inline-slots.spec.ts
@@ -1,5 +1,5 @@
 import { test } from '@playwright/test';
-import { fronts, tagFronts } from '../fixtures/pages';
+import { fronts, tagPages } from '../fixtures/pages';
 import { cmpAcceptAll } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
 import { waitForSlot } from '../lib/util';
@@ -15,8 +15,8 @@ test.describe('Slots and iframes load on fronts pages', () => {
 	});
 });
 
-test.describe('Slots and iframes load on tagged fronts pages', () => {
-	tagFronts.forEach(({ path }) => {
+test.describe('Slots and iframes load on tag pages', () => {
+	tagPages.forEach(({ path }) => {
 		test(`fronts-banner ads are loaded on ${path}`, async ({ page }) => {
 			await loadPage(page, path);
 			await cmpAcceptAll(page);


### PR DESCRIPTION
## What does this change?

Rename TagFront endpoint to TagPage in e2e tests following https://github.com/guardian/dotcom-rendering/pull/10542

