### PR TITLE
remove redundant slot definitions

### DIFF
--- a/.changeset/clever-news-dream.md
+++ b/.changeset/clever-news-dream.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': major
+---
+
+remove redundant ad slots possible side affects to other bundles frontend and dcr

--- a/.changeset/happy-gorillas-end.md
+++ b/.changeset/happy-gorillas-end.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+remove redundant ad slots

--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -101,13 +101,11 @@ type SlotName =
 	| 'comments'
 	| 'crossword-banner'
 	| 'crossword-banner-mobile'
-	| 'epic'
 	| 'exclusion'
 	| 'external'
 	| 'fronts-banner'
 	| 'im'
 	| 'inline'
-	| 'merchandising-high-lucky'
 	| 'merchandising-high'
 	| 'merchandising'
 	| 'mobile-sticky'
@@ -358,9 +356,6 @@ const slotSizeMappings = {
 			adSizes.billboard,
 		],
 	},
-	'merchandising-high-lucky': {
-		mobile: [adSizes.outOfPage, adSizes.empty, adSizes.fluid],
-	},
 	merchandising: {
 		mobile: [
 			adSizes.outOfPage,
@@ -387,9 +382,6 @@ const slotSizeMappings = {
 		desktop: [adSizes.outOfPage],
 	},
 	carrot: {
-		mobile: [adSizes.fluid],
-	},
-	epic: {
 		mobile: [adSizes.fluid],
 	},
 	'mobile-sticky': {


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

This PR removes the ad slots:
- merchandising-high-lucky
- epic

These slots are not bwingf used across any of the relevant repos - `commercial`/`dotcom-rendering`/`frontend`

## Why?
These ad slots are being served via a different ad slot definition (`merchandise-high` and `MPU`)
