### PR TITLE
enable prebid for mobile banner

### DIFF
--- a/.changeset/wicked-guests-protect.md
+++ b/.changeset/wicked-guests-protect.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+enables prebid to work on mobile crossword banner

--- a/src/lib/header-bidding/prebid-types.ts
+++ b/src/lib/header-bidding/prebid-types.ts
@@ -6,6 +6,7 @@ export type HeaderBiddingSlotName =
 	| 'banner'
 	| 'comments'
 	| 'crossword-banner'
+	| 'crossword-banner-mobile'
 	| 'mobile-sticky'
 	| 'mostpop'
 	| 'right'

--- a/src/lib/header-bidding/slot-config.ts
+++ b/src/lib/header-bidding/slot-config.ts
@@ -191,6 +191,9 @@ const getSlots = (): HeaderBiddingSizeMapping => {
 			desktop: isCrossword ? [adSizes.leaderboard] : [],
 			tablet: isCrossword ? [adSizes.leaderboard] : [],
 		},
+		'crossword-banner-mobile': {
+			mobile: [adSizes.mobilesticky],
+		},
 		merchandising: {
 			mobile: [adSizes.mpu],
 			desktop: [adSizes.billboard],


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?
This PR enables `prebid` for the new ad slot added to `crossword-banner-mobile`.


## Why?
Currently the ad slot does communicate with GAM and has been implemented through the this PR: https://github.com/guardian/commercial/pull/1229

This will allow us to better monetise these slots, by exposing them to more demand.


| Prebid.js Event | 
|----------|
| <img width="560" alt="Screenshot 2024-02-14 at 12 39 21" src="https://github.com/guardian/commercial/assets/49187886/cc40e117-fe19-4b3c-aa25-fef25c2af08e">  |
