### PR TITLE
Improve readability of prebid consent check and log

### DIFF
--- a/.changeset/shiny-tigers-tease.md
+++ b/.changeset/shiny-tigers-tease.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Improve readability of prebid consent check and log

--- a/src/init/consented/prepare-prebid.spec.ts
+++ b/src/init/consented/prepare-prebid.spec.ts
@@ -435,7 +435,7 @@ describe('init', () => {
 		expect(prebid.initialise).toBeCalled();
 	});
 
-	it('should NOT initialise Prebid in TCF when neither the global vendor or custom vendor has consent', async () => {
+	it('should NOT initialise Prebid in TCF when BOTH the global vendor AND custom vendor do NOT have consent', async () => {
 		expect.hasAssertions();
 
 		window.guardian.config.switches = {

--- a/src/init/consented/prepare-prebid.ts
+++ b/src/init/consented/prepare-prebid.ts
@@ -44,12 +44,14 @@ const setupPrebid = (): Promise<void> =>
 				'prebidCustom',
 				consentState,
 			);
+			log('commercial', {
+				hasConsentForGlobalPrebidVendor,
+				hasConsentForCustomPrebidVendor,
+			});
 			if (
-				// Check if we do NOT have consent to either the old global or custom prebid vendor
-				!(
-					hasConsentForGlobalPrebidVendor ||
-					hasConsentForCustomPrebidVendor
-				)
+				// Check if we do NOT have consent to BOTH the old global and custom prebid vendor
+				!hasConsentForGlobalPrebidVendor &&
+				!hasConsentForCustomPrebidVendor
 			) {
 				return Promise.reject('No consent for prebid');
 			}


### PR DESCRIPTION
## What does this change?

Improve readability of prebid consent check and log

The logic is equivalent

I'm adding a changeset to force a release


