### PR TITLE
Add slot name to AppNexus bidder

### DIFF
--- a/.changeset/fair-turkeys-flash.md
+++ b/.changeset/fair-turkeys-flash.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Add slot to AppNexus bidder key words

--- a/src/lib/header-bidding/prebid/appnexus.ts
+++ b/src/lib/header-bidding/prebid/appnexus.ts
@@ -83,6 +83,7 @@ export const getAppNexusDirectPlacementId = (
 export const getAppNexusDirectBidParams = (
 	sizes: HeaderBiddingSize[],
 	pageTargeting: PageTargeting,
+	slotId: string,
 ): AppNexusDirectBidParams => {
 	if (isInAuOrNz() && window.guardian.config.switches.prebidAppnexusInvcode) {
 		const invCode = getAppNexusInvCode(sizes);
@@ -93,13 +94,17 @@ export const getAppNexusDirectBidParams = (
 				keywords: {
 					invc: [invCode],
 					...buildAppNexusTargetingObject(pageTargeting),
+					slot: slotId,
 				},
 			};
 		}
 	}
 	return {
 		placementId: getAppNexusDirectPlacementId(sizes),
-		keywords: buildAppNexusTargetingObject(pageTargeting),
+		keywords: {
+			...buildAppNexusTargetingObject(pageTargeting),
+			slot: slotId,
+		},
 	};
 };
 

--- a/src/lib/header-bidding/prebid/bid-config.ts
+++ b/src/lib/header-bidding/prebid/bid-config.ts
@@ -231,7 +231,12 @@ const appNexusBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
 	bidParams: (
 		slotId: string,
 		sizes: HeaderBiddingSize[],
-	): PrebidAppNexusParams => getAppNexusDirectBidParams(sizes, pageTargeting),
+	): PrebidAppNexusParams =>
+		getAppNexusDirectBidParams(
+			sizes,
+			pageTargeting,
+			stripDfpAdPrefixFrom(slotId),
+		),
 });
 
 const openxClientSideBidder: (pageTargeting: PageTargeting) => PrebidBidder = (


### PR DESCRIPTION
## What does this change?
Adds a 'slot' keyword to the AppNexus bidder to send the slot name with the request.

## Why?
This will allow better targeting for ads coming via AppNexus as they will now be able to target by slot.

This has been tested locally and the slot name is being added as expected (note 'and' is the bidder name for AppNexus):
<img width="352" alt="Screenshot 2024-02-14 at 12 52 14" src="https://github.com/guardian/commercial/assets/108270776/0bdf0652-3221-472d-b228-0eb8cdeda89b">
