### PR TITLE
Bump consent-management-platform to 13.11.1

### DIFF
--- a/.changeset/warm-planes-decide.md
+++ b/.changeset/warm-planes-decide.md
@@ -1,5 +1,5 @@
 ---
-'@guardian/commercial': minor
+'@guardian/commercial': major
 ---
 
 bump consent-management-platform to include final parameter in onConsentChange function

--- a/.changeset/warm-planes-decide.md
+++ b/.changeset/warm-planes-decide.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+bump consent-management-platform to include final parameter in onConsentChange function

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"@babel/runtime": "^7.11.2",
 		"@guardian/ab-core": "5.0.0",
 		"@guardian/browserslist-config": "^5.1.0",
-		"@guardian/consent-management-platform": "13.10.0",
+		"@guardian/consent-management-platform": "13.11.1",
 		"@guardian/core-web-vitals": "5.1.0",
 		"@guardian/eslint-config-typescript": "^6.0.0",
 		"@guardian/identity-auth": "^2.0.1",
@@ -131,7 +131,7 @@
 	},
 	"peerDependencies": {
 		"@guardian/ab-core": "^7.0.1",
-		"@guardian/consent-management-platform": "^13.7.3",
+		"@guardian/consent-management-platform": "^13.11.1",
 		"@guardian/core-web-vitals": "^6.0.0",
 		"@guardian/identity-auth": "^2.0.1",
 		"@guardian/identity-auth-frontend": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,10 +1742,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-5.1.0.tgz#61cd822388dc196cea1b39c693366ed550edcd10"
   integrity sha512-QsyaZ7OZ6jBl8lByiLWtnobcS0IvIPVzDeGz9XY+CvPy5v5Kb0RJo+fFLEZbCqRLrfK+5f2sjrwPqrwtJBe2Sw==
 
-"@guardian/consent-management-platform@13.10.0":
-  version "13.10.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.10.0.tgz#c0d34ef67ca90a5e8dabf8f346d0b3f14129f93e"
-  integrity sha512-ura73/w9VOOTI+p+h52J+hePq6S4YeIV3iRiUYhc6IdqpdBkJfKKGE3zh9fxd+S/ktH8ZSQR4ebRjM2GKtMJrw==
+"@guardian/consent-management-platform@13.11.1":
+  version "13.11.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.11.1.tgz#dac49f3920238e60251fa5b7705c9ada9e12a882"
+  integrity sha512-cU9ssmMVV6EpX7H9QVAf0gdPrIdrGkvi/5ylGXF6xGvyvJ6CwUxM+vZhhm5tujoCiq6EuAVJX1tiZ3oHQMEdZg==
 
 "@guardian/core-web-vitals@5.1.0":
   version "5.1.0"


### PR DESCRIPTION

## What does this change?

Bumps the consent-management-platform to the latest version

## Why?

To include the final parameter in the onConsentChange function as well as some dependency bumps.