### PR TITLE
Changes to Prebid for comments-expanded ads

### DIFF
--- a/.changeset/hungry-hounds-rule.md
+++ b/.changeset/hungry-hounds-rule.md
@@ -2,4 +2,4 @@
 '@guardian/commercial': minor
 ---
 
-Use minHeight instead of height for mobile discussion ads and don't run prebid for these slots
+Enable Prebid for desktop comments-expanded ads, and disable it for mobile comments-expanded ads.

--- a/.changeset/hungry-hounds-rule.md
+++ b/.changeset/hungry-hounds-rule.md
@@ -2,4 +2,4 @@
 '@guardian/commercial': minor
 ---
 
-Use minHeight instead of height for mobile discussion ads
+Use minHeight instead of height for mobile discussion ads and don't run prebid for these slots

--- a/.changeset/hungry-hounds-rule.md
+++ b/.changeset/hungry-hounds-rule.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Use minHeight instead of height for mobile discussion ads

--- a/src/insert/comments-expanded-advert.ts
+++ b/src/insert/comments-expanded-advert.ts
@@ -42,11 +42,11 @@ const insertAdMobile = (anchor: HTMLElement, id: number) => {
 		name: `comments-expanded-${id}`,
 		classes: 'comments-expanded',
 	});
+	slot.style.minHeight = `${adSizes.mpu.height + AD_LABEL_HEIGHT}px`;
 
 	const adSlotContainer = document.createElement('div');
 	adSlotContainer.className = 'ad-slot-container';
 	adSlotContainer.style.width = '300px';
-	adSlotContainer.style.height = `${adSizes.mpu.height + AD_LABEL_HEIGHT}px`;
 	adSlotContainer.style.margin = '20px auto';
 	adSlotContainer.appendChild(slot);
 

--- a/src/lib/header-bidding/prebid-types.ts
+++ b/src/lib/header-bidding/prebid-types.ts
@@ -20,8 +20,7 @@ export type HeaderBiddingSlotName =
 export type HeaderBiddingSizeKey =
 	| HeaderBiddingSlotName
 	| 'inline'
-	| 'fronts-banner'
-	| 'comments-expanded';
+	| 'fronts-banner';
 
 export type HeaderBiddingSlot = {
 	key: HeaderBiddingSizeKey;

--- a/src/lib/header-bidding/prebid-types.ts
+++ b/src/lib/header-bidding/prebid-types.ts
@@ -5,6 +5,7 @@ export type HeaderBiddingSize = AdSize;
 export type HeaderBiddingSlotName =
 	| 'banner'
 	| 'comments'
+	| 'comments-expanded'
 	| 'crossword-banner'
 	| 'crossword-banner-mobile'
 	| 'mobile-sticky'

--- a/src/lib/header-bidding/slot-config.ts
+++ b/src/lib/header-bidding/slot-config.ts
@@ -173,6 +173,9 @@ const getSlots = (): HeaderBiddingSizeMapping => {
 		comments: {
 			desktop: [adSizes.skyscraper, adSizes.mpu, adSizes.halfPage],
 		},
+		'comments-expanded': {
+			desktop: [adSizes.skyscraper, adSizes.mpu, adSizes.halfPage],
+		},
 		banner: {
 			// Banner slots appear on interactives, like on
 			// https://www.theguardian.com/us-news/ng-interactive/2018/nov/06/midterm-elections-2018-live-results-latest-winners-and-seats

--- a/src/lib/header-bidding/slot-config.ts
+++ b/src/lib/header-bidding/slot-config.ts
@@ -67,10 +67,6 @@ const getHeaderBiddingKey = (
 		return 'fronts-banner';
 	}
 
-	if (name?.includes('comments-expanded')) {
-		return 'comments-expanded';
-	}
-
 	return undefined;
 };
 
@@ -210,9 +206,6 @@ const getSlots = (): HeaderBiddingSizeMapping => {
 			mobile: isInUk() ? [adSizes.mpu] : [],
 			tablet: isInUk() ? [adSizes.mpu] : [],
 			desktop: isInUk() ? [adSizes.mpu] : [],
-		},
-		'comments-expanded': {
-			mobile: [adSizes.mpu],
 		},
 	};
 };


### PR DESCRIPTION
## What does this change?
- Enables Prebid for desktop `comments-expanded` ad.
- Don't run Prebid for mobile `comments-expanded` ads - we only want MPU sizes in these slots and Prebid can send through ads that aren't the size we expect.
- Uses a minHeight on the mobile discussion ads ad slot instead of a fixed height on the container.

Note that the mobile `comments-expanded` ads are numbered in the same way as `inline` or `fronts-banner` ads, so by adding `comments-expanded` to slot-config, we're only targeting the desktop slots with the name `comments-expanded`, not the mobile slots that are called `comments-expanded-2` for example.

## Why?
Desktop `comments-expanded` ads have never had Prebid enabled on them. Hopefully by enabling it we can get some higher value ads in that slot. I've tested locally and it seems to be working as expected:

<img width="213" alt="Screenshot 2024-02-27 at 15 20 29" src="https://github.com/guardian/commercial/assets/108270776/4794b69d-d168-4455-85cf-165384e92008">


Some third-party ads were coming through into the mobile `comments-expanded` slot that weren't the MPU size we expected. This caused display issues as we were setting a fixed height on the as slot container. See image for example of this incorrect behaviour. We've decided to switch off Prebid for these slots for now, as well as using a min-height instead of a fixed height.

<img src="https://github.com/guardian/commercial/assets/108270776/b9ccf20d-9793-457d-ba4f-b8cb7aa96cd7" width="300">