### PR TITLE
adds tablet to fronts banner sizemapping for gam

### DIFF
--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -285,6 +285,7 @@ const slotSizeMappings = {
 		],
 	},
 	'fronts-banner': {
+		tablet: [adSizes.empty, adSizes.leaderboard],
 		desktop: [
 			adSizes.outOfPage,
 			adSizes.empty,

--- a/src/define/Advert.spec.ts
+++ b/src/define/Advert.spec.ts
@@ -168,7 +168,7 @@ describe('findSmallestAdHeightForSlot', () => {
 		['top-above-nav', 'phablet', 197],
 		['top-above-nav', 'mobile', 197],
 		['fronts-banner', 'mobile', null],
-		['fronts-banner', 'tablet', null],
+		['fronts-banner', 'tablet', 90],
 		['fronts-banner', 'desktop', 250],
 		['right', 'mobile', 250],
 		['right', 'tablet', 250],


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?
This PR adds sizemappings for tablet in `fronts-banner`, defining `leaderboard`.

Related PR: https://github.com/guardian/dotcom-rendering/pull/10766

## Why?
As a result of including ads to `fronts-banners` in `DCR` for the tablet size (see here), we need to update the sizeMappings to include a request for Leaderboard size, to effectively populate the ad slot in DCR.

Size mappings from googletag:
<img width="300" alt="Screenshot 2024-02-28 at 14 32 46" src="https://github.com/guardian/commercial/assets/49187886/5d32524e-65a4-4737-a9b9-a77d92e8d534">


