### PR TITLE
Add ads between comments on frontend-rendered pages

### DIFF
--- a/.changeset/chilly-candles-visit.md
+++ b/.changeset/chilly-candles-visit.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Add ads between comments on frontend-rendered pages

--- a/src/insert/comments-expanded-advert.ts
+++ b/src/insert/comments-expanded-advert.ts
@@ -131,9 +131,6 @@ const removeMobileCommentsExpandedAds = (): Promise<void> => {
 	);
 };
 
-/**
- * If there is a right-hand column, inserts an ad if there is space for it.
- */
 const handleCommentsLoadedEvent = (): void => {
 	const rightColumnNode = getRightColumn();
 


### PR DESCRIPTION
## What does this change?

- Inserts an advert between comments on frontend-rendered pages when a `comments-loaded` [Custom Event](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent) is received. [PR to insert ads on crossword pages](https://github.com/guardian/frontend/pull/26943)
- Inserts `comments-expanded` adverts _between_ top-level comments, instead of inside a top-level comment.
- Moves the advert container inside an `li` element, since the parent is a `ul` element.
- For the `comments-expanded` ad on DCR desktop pages, the resizeObserver has been removed. This is because we now fire the event once the comments have been loaded, instead of when the button has been clicked, so we know how much space is available and do not need to wait. [DCR PR](https://github.com/guardian/dotcom-rendering/pull/10783)

## Why?
- We do not currently serve ads in the comments on crossword pages. We can insert ads whilst retaining an acceptable user experience with regards to adverts.
- Refactor of `comments-expanded` ad on DCR desktop pages to bring consistency with how comments adverts are inserted on mobile