### PR TITLE
Remove top-level container from DOM when removing fronts-banner ad

### DIFF
--- a/.changeset/spicy-rats-shout.md
+++ b/.changeset/spicy-rats-shout.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Remove top-level container from DOM when removing fronts-banner ad

--- a/src/events/empty-advert.spec.ts
+++ b/src/events/empty-advert.spec.ts
@@ -1,0 +1,43 @@
+import { _ } from './empty-advert';
+
+const { findElementToRemove } = _;
+
+const adSelector = '.js-ad-slot';
+const adSlot = `<div class=js-ad-slot></div>`;
+
+const adverts = {
+	adSlotWithoutAdContainer: `<div class="not-a-container">${adSlot}</div>`,
+	adSlotWithAdContainer: `<div class="ad-slot-container">${adSlot}</div>`,
+	frontsBannerAd: `<div class="top-fronts-banner-ad-container"><div class="ad-slot-container">${adSlot}</div></div>`,
+} satisfies Record<string, string>;
+
+const createAd = (html: string) => {
+	document.body.innerHTML = html;
+};
+
+const getAd = (): HTMLElement =>
+	document.querySelector(adSelector) as HTMLElement;
+
+describe('findElementToRemove', () => {
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('returns the ad slot when NOT in an ad container', () => {
+		createAd(adverts['adSlotWithoutAdContainer']);
+		const result = findElementToRemove(getAd());
+		expect(result.classList).toContain('js-ad-slot');
+	});
+
+	it('returns the container when in an ad container', () => {
+		createAd(adverts['adSlotWithAdContainer']);
+		const result = findElementToRemove(getAd());
+		expect(result.classList).toContain('ad-slot-container');
+	});
+
+	it('returns the top-level container when advert is a fronts-banner ad', () => {
+		createAd(adverts['frontsBannerAd']);
+		const result = findElementToRemove(getAd());
+		expect(result.classList).toContain('top-fronts-banner-ad-container');
+	});
+});


### PR DESCRIPTION
## What does this change?

- Removes the top-level ad container from the DOM when removing a `fronts-banner` advert
- Adds a test

## Why?

- The top-level ad container has a minimum height on it to prevent layout shift, so we need to remove this too when removing a `fronts-banner` advert

## Screenshots

### Before

https://github.com/guardian/commercial/assets/9574885/22e2dd0c-35dc-459d-9a16-c8a647172062

### After

https://github.com/guardian/commercial/assets/9574885/5df91746-db79-477c-bffb-15ae58ac6256
