### PR TITLE
Add AB testing documentation

### DIFF
--- a/docs/ab-testing/readme.md
+++ b/docs/ab-testing/readme.md
@@ -1,0 +1,45 @@
+# AB Testing in Commercial
+
+## Client side tests
+
+### Setup
+
+1. Follow steps 1-6 in [the DCR documentation](https://github.com/guardian/frontend/blob/main/common/app/conf/switches/ABTestSwitches.scala)
+1. Create a test in [src/experiments/tests](https://github.com/guardian/commercial-core/blob/main/src/experiments/tests)
+1. Add the test to [concurrent tests](https://github.com/guardian/commercial-core/blob/b668f247a6f938fc833da58449d9fa8b9011a5a2/src/experiments/ab-tests.ts)
+
+### Example usage
+
+```ts
+import { isInVariantSynchronous } from 'experiments/ab';
+import { sectionAdDensity } from 'experiments/tests/section-ad-density.ts';
+
+const isInVariant = (): boolean => isInVariantSynchronous(sectionAdDensity, 'variant');
+```
+
+### How to test
+
+Use the URL opt-in link to force yourself into a particular variant, e.g. `http://localhost:3030/Front/https://www.theguardian.com/uk#ab-yourTest=yourVariant`
+
+If you test has multiple variants, you can test each one by updating the `yourVariant` part of the above URL.
+
+## Server-side tests
+
+### Setup
+
+1. Follow the instructions in the [frontend documentation](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md#write-a-server-side-test)
+
+### Example usage
+
+> [!WARNING]
+> The name of the test in unintuitive.
+
+```ts
+const isInABTest = window.guardian.config.tests?.crosswordMobileBannerVariant === 'variant';
+```
+
+### How to test
+
+There are two ways to check the test, outlined in the [frontend documentation](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md#checking-the-test) and summarised here:
+- When running locally, you will need to change the headers of your request for a page by using a header hacker extension.
+- When using CODE (or production), you can use the above OR you can use the simpler method of an opt-in link e.g. https://www.theguardian.com/opt/in/your-test-name

--- a/docs/ab-testing/readme.md
+++ b/docs/ab-testing/readme.md
@@ -6,7 +6,7 @@
 
 1. Follow steps 1-6 in [the DCR documentation](https://github.com/guardian/frontend/blob/main/common/app/conf/switches/ABTestSwitches.scala)
 1. Create a test in [src/experiments/tests](https://github.com/guardian/commercial-core/blob/main/src/experiments/tests)
-1. Add the test to [concurrent tests](https://github.com/guardian/commercial-core/blob/b668f247a6f938fc833da58449d9fa8b9011a5a2/src/experiments/ab-tests.ts)
+1. Add the test to [concurrent tests](https://github.com/guardian/commercial-core/blob/main/src/experiments/ab-tests.ts)
 
 ### Example usage
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

- Add documentation on creating AB tests

## Why?

- We have documentation in [Frontend](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md) and [DCR](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/docs/development/ab-testing-in-dcr.md) for how to set up AB tests in each repo. For commercial, it can be hard to know where to start and what to do for each type of test (client-side and server-side), so this document can serve as a starting point when needing to add an AB test for commercial purposes.