### PR TITLE
Remove the `hr` element as a candidate from mobile spacefinder

### DIFF
--- a/.changeset/tough-rice-enjoy.md
+++ b/.changeset/tough-rice-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Remove HR as candidate for mobile spacefinder

--- a/playwright/fixtures/pages/articles.ts
+++ b/playwright/fixtures/pages/articles.ts
@@ -44,7 +44,7 @@ const articles: GuPage[] = [
 			path: '/football/2024/feb/09/premier-league-10-things-to-look-out-for-this-weekend',
 		}),
 		name: 'inlineSlots',
-		expectedSlotPositionsOnMobile: [6, 13, 19, 25, 31, 38, 45, 57],
+		expectedSlotPositionsOnMobile: [7, 14, 20, 26, 32, 39, 46, 58],
 		expectedSlotPositionsOnDesktop: [14, 30, 43, 55],
 	},
 	{

--- a/src/insert/spacefinder/article-body-adverts.ts
+++ b/src/insert/spacefinder/article-body-adverts.ts
@@ -292,7 +292,6 @@ const addMobileInlineAds = (): Promise<boolean> => {
 		bodySelector: articleBodySelector,
 		candidateSelector: [
 			' > p',
-			' > hr',
 			' > h2',
 			' > [data-spacefinder-type$="NumberedTitleBlockElement"]',
 		],


### PR DESCRIPTION
## What does this change?
Remove the `hr` element as a candidate from mobile spacefinder

## Why?
These elements have a large top margin (~50px), an ad would obviously be above this margin but spacefinder is unable to account for it, leading to ads being inserted a tad closer than we'd like to images if a `hr` follows an image. 

With the introduction of the `bypassMinBelow` rule it's unnecessary to have it be a candidate anyway.

Before:
<img width="386" alt="Screenshot 2024-03-06 at 10 58 39" src="https://github.com/guardian/commercial/assets/1731150/d1f5a97e-b4d0-475b-bdf9-7f83f3cf8656">

After:
<img width="374" alt="Screenshot 2024-03-06 at 10 58 21" src="https://github.com/guardian/commercial/assets/1731150/2da711a2-fc7c-4981-a89b-8fb361ec05f2">


