### PR TITLE
Add Playwright test for comments-expanded ads

### DIFF
--- a/playwright/fixtures/pages/articles.ts
+++ b/playwright/fixtures/pages/articles.ts
@@ -56,6 +56,12 @@ const articles: GuPage[] = [
 		expectedSlotPositionsOnMobile: [4, 11, 18, 25, 32, 39, 46, 53, 57, 64],
 		expectedSlotPositionsOnDesktop: [6, 13, 20, 30, 37, 44, 51, 58, 65],
 	},
+	{
+		path: getTestUrl({
+			stage,
+			path: '/commentisfree/2024/feb/05/cook-gas-induction-hob-electric',
+		}),
+	},
 ];
 
 export { articles };

--- a/playwright/fixtures/pages/articles.ts
+++ b/playwright/fixtures/pages/articles.ts
@@ -56,12 +56,6 @@ const articles: GuPage[] = [
 		expectedSlotPositionsOnMobile: [4, 11, 18, 25, 32, 39, 46, 53, 57, 64],
 		expectedSlotPositionsOnDesktop: [6, 13, 20, 30, 37, 44, 51, 58, 65],
 	},
-	{
-		path: getTestUrl({
-			stage,
-			path: '/commentisfree/2024/feb/05/cook-gas-induction-hob-electric',
-		}),
-	},
 ];
 
 export { articles };

--- a/playwright/tests/comments-expanded.spec.ts
+++ b/playwright/tests/comments-expanded.spec.ts
@@ -1,0 +1,65 @@
+import { breakpoints } from '@guardian/source-foundations';
+import { expect, test } from '@playwright/test';
+import { articles } from '../fixtures/pages';
+import type { GuPage } from '../fixtures/pages/Page';
+import { cmpAcceptAll } from '../lib/cmp';
+import { loadPage } from '../lib/load-page';
+import { waitForIsland, waitForSlot } from '../lib/util';
+
+const { path } = articles[6] as unknown as GuPage;
+
+test.describe('desktop comments-expanded slot', () => {
+	test(`Check that comments-expanded slot is added when comments are expanded on desktop`, async ({
+		page,
+	}) => {
+		await page.setViewportSize({
+			width: breakpoints['wide'],
+			height: 800,
+		});
+
+		await loadPage(page, path);
+
+		await cmpAcceptAll(page);
+
+		await expect(
+			page.locator('[data-testid=comment-counts]').nth(0),
+		).toBeVisible({
+			timeout: 10000,
+		});
+
+		// Click the comment count to expand the comments
+		await page.locator('[data-testid=comment-counts]').click();
+
+		await waitForIsland(page, 'DiscussionWeb');
+
+		await waitForSlot(page, 'comments-expanded');
+	});
+});
+
+test.describe('mobile comments-expanded slot', () => {
+	test(`Check that comments-expanded slot is added when comments are expanded on mobile`, async ({
+		page,
+	}) => {
+		await page.setViewportSize({
+			width: breakpoints['mobile'],
+			height: 800,
+		});
+
+		await loadPage(page, path);
+
+		await cmpAcceptAll(page);
+
+		await expect(
+			page.locator('[data-testid=comment-counts]').nth(0),
+		).toBeVisible({
+			timeout: 10000,
+		});
+
+		// Click the comment count to expand the comments
+		await page.locator('[data-testid=comment-counts]').click();
+
+		await waitForIsland(page, 'DiscussionWeb');
+
+		await waitForSlot(page, 'comments-expanded-1');
+	});
+});

--- a/playwright/tests/comments-expanded.spec.ts
+++ b/playwright/tests/comments-expanded.spec.ts
@@ -1,12 +1,13 @@
 import { breakpoints } from '@guardian/source-foundations';
 import { expect, test } from '@playwright/test';
-import { articles } from '../fixtures/pages';
-import type { GuPage } from '../fixtures/pages/Page';
 import { cmpAcceptAll } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
-import { waitForIsland, waitForSlot } from '../lib/util';
+import { getStage, getTestUrl, waitForIsland, waitForSlot } from '../lib/util';
 
-const { path } = articles[6] as unknown as GuPage;
+const path = getTestUrl({
+	stage: getStage(),
+	path: '/commentisfree/2024/feb/05/cook-gas-induction-hob-electric',
+});
 
 test.describe('desktop comments-expanded slot', () => {
 	test(`Check that comments-expanded slot is added when comments are expanded on desktop`, async ({


### PR DESCRIPTION
## What does this change?
Adds a Playwright test to check that the desktop and mobile versions of the `comments-expanded` ads are added when the comments are opened.

## Why?
In the comments on [this PR](https://github.com/guardian/commercial/pull/1239), I promised to add an E2E test for the `comments-expanded` ads when the new mobile ads were stable.