### PR TITLE
Crossword mobile banner advert - Send live and AB test

### DIFF
--- a/.changeset/fifty-glasses-wait.md
+++ b/.changeset/fifty-glasses-wait.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+adds banner to all users in mobile crosswords and another option for those in AB test

--- a/src/insert/mobile-crossword-banner.ts
+++ b/src/insert/mobile-crossword-banner.ts
@@ -29,7 +29,7 @@ export const init = (): Promise<void> => {
 	}
 
 	const anchorSelector = isInABTest
-		? '.crossword__container__game + *'
+		? '.crossword__container__above-controls + *'
 		: '.crossword__container__below-controls + *';
 
 	const anchor: HTMLElement | null = document.querySelector(anchorSelector);

--- a/src/insert/mobile-crossword-banner.ts
+++ b/src/insert/mobile-crossword-banner.ts
@@ -24,13 +24,13 @@ export const init = (): Promise<void> => {
 		window.guardian.config.tests?.crosswordMobileBannerVariant ===
 		'variant';
 
-	if (window.guardian.config.isDotcomRendering || !isInABTest) {
+	if (window.guardian.config.isDotcomRendering) {
 		return Promise.resolve();
 	}
 
-	const anchorSelector = window.guardian.config.page.commentable
-		? '.crossword__container__below-controls + *'
-		: '.content-footer > :first-child';
+	const anchorSelector = isInABTest
+		? '.crossword__container__game + *'
+		: '.crossword__container__below-controls + *';
 
 	const anchor: HTMLElement | null = document.querySelector(anchorSelector);
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?

- Shows the crossword mobile banner ad in position 1 (below controls) for all users
- Shows the crossword mobile banner ad in position 2 (above controls) for users in the AB test

Prior to this change, the ad slot would be placed below the controls element as part of the "Option 1" server side test https://github.com/guardian/commercial/pull/1229.

This has been tested on other crossword pages that we have:
- [Cryptic](http://localhost:9000/crosswords/cryptic/29335)
- [Quiptic](http://localhost:9000/crosswords/quiptic/1269)
- [Everyman](http://localhost:9000/crosswords/everyman/4039)
- [Speedy](http://localhost:9000/crosswords/speedy/1484)

## Why?

- The AB test results no significant reduction in UX metric following the introduction of this change and resulted in increased revenue.
- We would like to run another AB test to find the optimum position for this advert

## How to test

- Run this branch locally, along with the `ds/add-option2-mobile-crossword-banner` branch in frontend. [Instructions here](https://github.com/guardian/commercial/blob/main/README.md#working-locally-with-frontend)
- Opt in the the 2A test bucket with a header hacker extension. [Details on how to do that](https://github.com/guardian/frontend/blob/main/docs/03-dev-howtos/01-ab-testing.md#forcing-yourself-into-the-test)
- Go to a crossword page locally, e.g. http://localhost:9000/crosswords/quick/16770 and use a mobile viewport.


## Screenshots


| Position 1  | Position 2  |
| - | - |
| ![below1] | ![above1] |
| ![below2] | ![above2] |

[below1]: https://github.com/guardian/commercial/assets/9574885/056a5883-50c4-45c0-99d5-dd4cdb3d82de
[below2]: https://github.com/guardian/commercial/assets/9574885/c9608a16-7937-42f1-b7fd-d1bf06a99f24
[above1]: https://github.com/guardian/commercial/assets/9574885/123d8524-d9d9-4a0c-ae4c-e4d30515e0ac
[above2]: https://github.com/guardian/commercial/assets/9574885/71306413-3ff9-40d5-a93a-bebc6a62893c

