### PR TITLE
add 2x2 mobile sticky size

### DIFF
--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -387,7 +387,7 @@ const slotSizeMappings = {
 		mobile: [adSizes.fluid],
 	},
 	'mobile-sticky': {
-		mobile: [adSizes.mobilesticky],
+		mobile: [adSizes.mobilesticky, adSizes.empty],
 	},
 	'crossword-banner-mobile': {
 		mobile: [adSizes.mobilesticky],


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `yarn changeset`.

-->

## What does this change?
We are adding the (2x2) size to the mobile-sticky slot.
This behaviour cannot be replicated in UK geo location, so using VPN to test with AUS.
## Why?
This will remove the ad-slot for the mobile-sticky when a Line Item with a 2x2 creative targets the slot.

## Testing

| mobile-sticky slot| googletag.console() |
|----------|----------|
| <img width="300" alt="Screenshot 2024-03-14 at 15 50 39" src="https://github.com/guardian/commercial/assets/49187886/c7123f44-f3ff-4a2d-aba4-2367d7bd67e4"> | <img width="300" alt="Screenshot 2024-03-14 at 15 42 25" src="https://github.com/guardian/commercial/assets/49187886/ac2ad18b-e3e3-44b3-a045-8b9140b262c1"> |
