### PR TITLE
Log when slot is viewable

### DIFF
--- a/src/events/on-slot-viewable.ts
+++ b/src/events/on-slot-viewable.ts
@@ -123,7 +123,9 @@ const onSlotViewableFunction = (): ((
 	const queryParams = getUrlVars();
 
 	return (event: googletag.events.ImpressionViewableEvent) => {
-		EventTimer.get().mark('viewable', event.slot.getTargeting('slot')[0]);
+		const slot = event.slot.getTargeting('slot')[0];
+		EventTimer.get().mark('viewable', slot);
+		log('commercial', 'Slot viewable', slot);
 		if (queryParams.adrefresh !== 'false') {
 			setSlotAdRefresh(event);
 		}


### PR DESCRIPTION
## What does this change?

Log to commercial logger when slot is viewable

## Why?

So we have insight into when a slot is [viewable](https://www.iabuk.com/news-article/quick-qa-viewability)

<img width="792" alt="Screenshot 2024-03-20 at 12 14 15" src="https://github.com/guardian/commercial/assets/7014230/658aafe3-a668-4257-b875-eb23d1f31c3f">

