### PR TITLE
Enable first party cookie for comscore

### DIFF
--- a/.changeset/yellow-hotels-train.md
+++ b/.changeset/yellow-hotels-train.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Enable comscore first party cookie

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"@babel/runtime": "^7.11.2",
 		"@guardian/ab-core": "5.0.0",
 		"@guardian/browserslist-config": "^5.1.0",
-		"@guardian/consent-management-platform": "13.12.0",
+		"@guardian/consent-management-platform": "13.12.1",
 		"@guardian/core-web-vitals": "5.1.0",
 		"@guardian/eslint-config-typescript": "^6.0.0",
 		"@guardian/identity-auth": "^2.1.0",

--- a/src/init/consented/comscore.ts
+++ b/src/init/consented/comscore.ts
@@ -16,6 +16,9 @@ const getGlobals = (keywords: string): ComscoreGlobals => {
 		c1: comscoreC1,
 		c2: comscoreC2,
 		cs_ucfr: '1',
+		options: {
+			enableFirstPartyCookie: true,
+		},
 	};
 
 	if (keywords !== 'Network Front') {

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -259,6 +259,9 @@ type ComscoreGlobals = {
 	c2: string;
 	cs_ucfr: string;
 	comscorekw?: string;
+	options?: {
+		enableFirstPartyCookie?: boolean;
+	};
 };
 
 type CustomIdTokenClaims = CustomClaims & {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,10 +1742,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/browserslist-config/-/browserslist-config-5.1.0.tgz#61cd822388dc196cea1b39c693366ed550edcd10"
   integrity sha512-QsyaZ7OZ6jBl8lByiLWtnobcS0IvIPVzDeGz9XY+CvPy5v5Kb0RJo+fFLEZbCqRLrfK+5f2sjrwPqrwtJBe2Sw==
 
-"@guardian/consent-management-platform@13.12.0":
-  version "13.12.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.12.0.tgz#7cd52881ac017eca8697b368c313678664acc10e"
-  integrity sha512-weLk3tR1ZtMvn5tfTFItvbIT84JFaXMdP5zcbu1Aynt+eTKZD8oVKTtuvdg6ZmTuxsEOIfsel0fFirjDUo5ccQ==
+"@guardian/consent-management-platform@13.12.1":
+  version "13.12.1"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-13.12.1.tgz#699ee56cc695baeb26a1ec702e098d98b1ead255"
+  integrity sha512-ng6Pl760icPXobdm3qBhV82ATipW/o0nlnBTQTMuYvKVWFEebqFJ5su77/DSaCXyqJkXIKn3UeDTU8JyFQnBtQ==
 
 "@guardian/core-web-vitals@5.1.0":
   version "5.1.0"


### PR DESCRIPTION
## Why?
To deal with the depreciation of third party cookies in Google Chrome, Comscore has requested changes to the tag which currently sits on site. The changes will allow them to drop their cookie as a first-party cookie on our domain.

This has been through and been approved as part of the Tech Review process.

Once added, if consent is given for comscore a new first party cookie will be added `_scor_uid`

