### PR TITLE
Remove DCR discussion ads feature switch

### DIFF
--- a/.changeset/slow-falcons-turn.md
+++ b/.changeset/slow-falcons-turn.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Remove dcr discussion ads switch

--- a/src/insert/comments-expanded-advert.ts
+++ b/src/insert/comments-expanded-advert.ts
@@ -178,12 +178,6 @@ export const initCommentsExpandedAdverts = (): Promise<void> => {
 	document.addEventListener('comments-loaded', () => {
 		const currentBreakpoint = getBreakpoint(getViewport().width);
 		if (currentBreakpoint === 'mobile') {
-			if (
-				window.guardian.config.isDotcomRendering &&
-				!window.guardian.config.switches.mobileDiscussionAds
-			) {
-				return;
-			}
 			void handleCommentsLoadedMobileEvent();
 		} else {
 			void handleCommentsLoadedEvent();


### PR DESCRIPTION
## What does this change?

- Remove DCR discussion ads feature switch

## Why?

- This feature has been live for a while and the switch is no longer needed