### PR TITLE
Extend mpuWhenNoEpic AB test

### DIFF
--- a/src/experiments/tests/mpu-when-no-epic.ts
+++ b/src/experiments/tests/mpu-when-no-epic.ts
@@ -4,7 +4,7 @@ export const mpuWhenNoEpic: ABTest = {
 	id: 'MpuWhenNoEpic',
 	author: '@commercial-dev',
 	start: '2023-11-22',
-	expiry: '2024-03-29',
+	expiry: '2024-04-30',
 	audience: 0 / 100,
 	audienceOffset: 5 / 100,
 	audienceCriteria: '',


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR extends mpuWhenNoEpic AB test until we have a chat with @Amouzle to check if it is still needed.

## Why?

Expires before Easter break and we still don't know if it is needed or we can remove it.