### PR TITLE
Don't add an advertisement label to native templates served via opt out

### DIFF
--- a/.changeset/clever-brooms-judge.md
+++ b/.changeset/clever-brooms-judge.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Don't add an advertisement label for native templates served through opt out

--- a/src/init/consentless/define-slot.ts
+++ b/src/init/consentless/define-slot.ts
@@ -25,13 +25,17 @@ const defineSlot = (
 
 	const filledCallback: OptOutFilledCallback = (
 		_adSlot,
-		{ width, height },
+		{ width, height, optOutExt },
 	) => {
 		log('commercial', `Filled consentless ${slotId}`);
 
 		const isFluid = width === 1 && height === 1;
 		if (isFluid) {
 			slot.classList.add('ad-slot--fluid');
+		}
+
+		if (optOutExt.tags.includes('NATIVE')) {
+			slot.classList.add('ad-slot--native');
 		}
 
 		void renderConsentlessAdvertLabel(slot);

--- a/src/init/consentless/render-advert-label.ts
+++ b/src/init/consentless/render-advert-label.ts
@@ -7,17 +7,12 @@ import fastdom from 'utils/fastdom-promise';
 
 const shouldRenderConsentlessLabel = (adSlotNode: HTMLElement): boolean => {
 	if (
-		adSlotNode.classList.contains('ad-slot--merchandising') ||
-		adSlotNode.classList.contains('ad-slot--merchandising-high')
-	) {
-		return true;
-	}
-	if (
 		adSlotNode.classList.contains('ad-slot--frame') ||
 		adSlotNode.classList.contains('ad-slot--gc') ||
 		adSlotNode.classList.contains('u-h') ||
 		// set for out-of-page (1x1) and empty (2x2) ads
 		adSlotNode.classList.contains('ad-slot--collapse') ||
+		adSlotNode.classList.contains('ad-slot--native') ||
 		adSlotNode.getAttribute('data-label') === 'false'
 	) {
 		return false;

--- a/src/init/consentless/render-advert-label.ts
+++ b/src/init/consentless/render-advert-label.ts
@@ -10,9 +10,9 @@ const shouldRenderConsentlessLabel = (adSlotNode: HTMLElement): boolean => {
 		adSlotNode.classList.contains('ad-slot--frame') ||
 		adSlotNode.classList.contains('ad-slot--gc') ||
 		adSlotNode.classList.contains('u-h') ||
+		adSlotNode.classList.contains('ad-slot--native') ||
 		// set for out-of-page (1x1) and empty (2x2) ads
 		adSlotNode.classList.contains('ad-slot--collapse') ||
-		adSlotNode.classList.contains('ad-slot--native') ||
 		adSlotNode.getAttribute('data-label') === 'false'
 	) {
 		return false;


### PR DESCRIPTION
## What does this change?
Checks the opt out ad request for the `'NATIVE'` tag which has been added to the native template in the ad server. If present, we add an `ad-slot--native` class to the ad slot. We then check that this class isn't present before adding a label.

Also removes some redundant logic that was a workaround from when we only used to show house ads in the merch slots. This is no longer needed so we can tidy it up 🧹

## Why?
We'll be using opt out to show some native templates but they currently appear with an advertisement label, which we don't want. This change aligns the code with the way these ads show when they come from GAM.

## Screenshots
### Native ad before - label showing
<img width="1495" alt="Screenshot 2024-04-08 at 16 23 00" src="https://github.com/guardian/commercial/assets/108270776/537f499c-6db3-4927-b043-80f21781125f">

### Native ad after - label not showing
<img width="1499" alt="Screenshot 2024-04-08 at 16 22 43" src="https://github.com/guardian/commercial/assets/108270776/6ca90020-917c-4991-96ea-ed21290dc77e">

### Normal ad in merch slot after - label still showing as expected
<img width="1487" alt="Screenshot 2024-04-08 at 16 20 29" src="https://github.com/guardian/commercial/assets/108270776/125aec81-29b1-4831-860b-d4f5ef00eed7">
