### PR TITLE
Remove old amiused call

### DIFF
--- a/src/insert/spacefinder/spacefinder.ts
+++ b/src/insert/spacefinder/spacefinder.ts
@@ -2,7 +2,6 @@
 
 import { log } from '@guardian/libs';
 import { memoize } from 'lodash-es';
-import { amIUsed } from 'utils/am-i-used';
 import fastdom from 'utils/fastdom-promise';
 import { init as initSpacefinderDebugger } from './spacefinder-debug-tools';
 
@@ -132,8 +131,6 @@ const isIframeLoaded = (iframe: HTMLIFrameElement) => {
 	try {
 		return iframe.contentWindow?.document.readyState === 'complete';
 	} catch (err) {
-		// TODO remove try / catch if an error is never thrown
-		amIUsed('spacefinder.ts', 'isIframeLoaded');
 		return true;
 	}
 };


### PR DESCRIPTION
## What does this change?
Removes an `amiused` call which has been there for a pretty long time.

## Why?
It is used:
<img width="914" alt="Screenshot 2024-04-10 at 10 58 57" src="https://github.com/guardian/commercial/assets/108270776/6f493490-469d-47e9-95a2-e2c605b5eff8">

Removing this means we can reduce a bit of noise in our logging.