### PR TITLE
Interscroller video progress tracking

### DIFF
--- a/.changeset/brown-tables-act.md
+++ b/.changeset/brown-tables-act.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Video progress reporting for video interscroller

--- a/src/core/event-timer.ts
+++ b/src/core/event-timer.ts
@@ -23,6 +23,10 @@ interface EventTimerProperties {
 	 * distinct from the property we pass into commercial metrics, and in the
 	 * future _could_ be removed in favour of this property */
 	detectedAdBlocker?: boolean;
+	/** creative ID of a video interscroller for video reporting metrics */
+	videoInterscrollerCreativeId?: number | null | undefined;
+	/** percentage progress of video interscroller on page unload */
+	videoInterscrollerPercentageProgress?: number;
 }
 
 // Events will be logged using the performance API for all slots, but only these slots will be tracked as commercial metrics and sent to the data lake

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -230,11 +230,6 @@ const setupBackground = async (
 				video.style.transform = 'translate(-50%, -50%)';
 				background.appendChild(video);
 
-				// video.ontimeupdate = function () {
-				// 	const percent = 100 * (video.currentTime / video.duration);
-				// 	console.log(`${percent}% complete`);
-				// };
-
 				if (!window.guardian.config.switches.sentinelLogger) return;
 
 				const sendVideoProgress = () => {

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -237,6 +237,7 @@ const setupBackground = async (
 						? '//logs.code.dev-guardianapis.com/log'
 						: '//logs.guardianapis.com/log';
 
+					// TODO: might need to add a new variable to the template to allow us to link video data to a specific creative
 					const videoAdId = 'id_goes_here';
 
 					const event = {
@@ -275,7 +276,7 @@ const setupBackground = async (
 					}
 				};
 
-				// Report all available metrics when the page is unloaded or in background.
+				// Report video ad progress when the page is unloaded or in background.
 				window.addEventListener('visibilitychange', listener, {
 					once: true,
 				});

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -238,7 +238,7 @@ const setupBackground = async (
 						: '//logs.guardianapis.com/log';
 
 					// TODO: might need to add a new variable to the template to allow us to link video data to a specific creative
-					const videoAdId = 'id_goes_here';
+					const videoAdId = 'testing';
 
 					const event = {
 						label: 'commercial.videoadprogresstracking',
@@ -249,8 +249,9 @@ const setupBackground = async (
 							},
 							{
 								name: 'percent_progress',
-								value:
+								value: Math.round(
 									100 * (video.currentTime / video.duration),
+								),
 							},
 						],
 					};
@@ -263,26 +264,17 @@ const setupBackground = async (
 					);
 				};
 
-				const listener = (e: Event): void => {
-					switch (e.type) {
-						case 'visibilitychange':
-							if (document.visibilityState === 'hidden') {
-								sendVideoProgress();
-							}
-							return;
-						case 'pagehide':
-							sendVideoProgress();
-							return;
+				const listener = (): void => {
+					if (document.visibilityState === 'hidden') {
+						sendVideoProgress();
 					}
+					return;
 				};
 
 				// Report video ad progress when the page is unloaded or in background.
 				window.addEventListener('visibilitychange', listener, {
 					once: true,
 				});
-
-				// Safari does not reliably fire the `visibilitychange` on page unload.
-				window.addEventListener('pagehide', listener, { once: true });
 			}
 		} else {
 			adSlot.insertBefore(backgroundParent, adSlot.firstChild);

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -232,20 +232,30 @@ const setupBackground = async (
 
 				if (!window.guardian.config.switches.sentinelLogger) return;
 
+				const getCreativeId = () => {
+					const slots = googletag.pubads().getSlots();
+
+					for (const slot of slots) {
+						const creativeTemplateId =
+							slot.getResponseInformation()?.creativeTemplateId;
+						if (creativeTemplateId === 11885667) {
+							return slot.getResponseInformation()?.creativeId;
+						}
+					}
+					return null;
+				};
+
 				const sendVideoProgress = () => {
 					const endpoint = window.guardian.config.page.isDev
 						? '//logs.code.dev-guardianapis.com/log'
 						: '//logs.guardianapis.com/log';
-
-					// TODO: might need to add a new variable to the template to allow us to link video data to a specific creative
-					const videoAdId = 'testing';
 
 					const event = {
 						label: 'commercial.videoadprogresstracking',
 						properties: [
 							{
 								name: 'video_ad_id',
-								value: videoAdId,
+								value: String(getCreativeId()),
 							},
 							{
 								name: 'percent_progress',
@@ -255,8 +265,6 @@ const setupBackground = async (
 							},
 						],
 					};
-
-					console.log('Sending video ad progress data');
 
 					window.navigator.sendBeacon(
 						endpoint,

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -229,6 +229,11 @@ const setupBackground = async (
 				video.style.height = '100%';
 				video.style.transform = 'translate(-50%, -50%)';
 				background.appendChild(video);
+
+				video.ontimeupdate = function () {
+					const percent = 100 * (video.currentTime / video.duration);
+					console.log(`${percent}% complete`);
+				};
 			}
 		} else {
 			adSlot.insertBefore(backgroundParent, adSlot.firstChild);

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -254,6 +254,8 @@ const setupBackground = async (
 						],
 					};
 
+					console.log('Sending video ad progress data');
+
 					window.navigator.sendBeacon(
 						endpoint,
 						JSON.stringify(event),


### PR DESCRIPTION
## What does this change?
Sends the percentage of a video interscroller ad that was shown to a user as part of commercial metrics. Also finds the `creativeId` of the interscroller so that we can match video progress data to specific creatives. We do this by searching the slots on the page to find which one is using the interscroller template, as only one native interscroller will appear on any one pageview. Tested with two different creatives on CODE and the data is added to commercial metrics payload as expected:

<img width="338" alt="Screenshot 2024-04-22 at 17 49 42" src="https://github.com/guardian/commercial/assets/108270776/03f8e590-c1ed-4934-9f2a-e41d2456de2b">
<img width="338" alt="Screenshot 2024-04-22 at 17 52 59" src="https://github.com/guardian/commercial/assets/108270776/c27ebf79-0a17-4552-92d7-5aab3001a5e0">

## Why?
DAP would like to be able to offer video progress tracking for our native ads, as this is often a metric that advertisers are particularly interested in which we don't currently support.