### PR TITLE
New commercial metric for ad block detection

### DIFF
--- a/.changeset/calm-dryers-poke.md
+++ b/.changeset/calm-dryers-poke.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+New commercial metric for recording ad-block detection

--- a/src/core/event-timer.ts
+++ b/src/core/event-timer.ts
@@ -12,13 +12,17 @@ interface EventTimerProperties {
 	effectiveType?: string;
 	adSlotsInline?: number;
 	adSlotsTotal?: number;
-	// the height of the page / the viewport height
+	/** the height of the page / the viewport height  */
 	pageHeightVH?: number;
 	gpcSignal?: number;
-	// distance in percentage of viewport height at which ads are lazy loaded
+	/** distance in percentage of viewport height at which ads are lazy loaded */
 	lazyLoadMarginPercent?: number;
 	hasLabsContainer?: boolean;
 	labsUrl?: string;
+	/** Record whether we've detected an ad blocker. This is intentionally
+	 * distinct from the property we pass into commercial metrics, and in the
+	 * future _could_ be removed in favour of this property */
+	detectedAdBlocker?: boolean;
 }
 
 // Events will be logged using the performance API for all slots, but only these slots will be tracked as commercial metrics and sent to the data lake


### PR DESCRIPTION
## What does this change?

Add a new commercial metric _property_ that we can set when we detect the user is running an ad blocker.

Note there is an [existing metric](https://github.com/guardian/commercial-core/blob/03b572557fa492e05b7f30a896acd23d527df1bf/src/core/send-commercial-metrics.ts#L54), but we'd like to keep this distinct as we roll out the new [AdBlockAsk](https://github.com/guardian/dotcom-rendering/pull/11124).

## Why?

So that we can record the number of pageviews for which we perform adblock detection.


