### PR TITLE
Less strict DOM structure for banner containers

### DIFF
--- a/.changeset/friendly-zoos-float.md
+++ b/.changeset/friendly-zoos-float.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Assume less about DOM structure when finding ad container elements to remove

--- a/src/events/empty-advert.spec.ts
+++ b/src/events/empty-advert.spec.ts
@@ -9,6 +9,9 @@ const adverts = {
 	adSlotWithoutAdContainer: `<div class="not-a-container">${adSlot}</div>`,
 	adSlotWithAdContainer: `<div class="ad-slot-container">${adSlot}</div>`,
 	frontsBannerAd: `<div class="top-fronts-banner-ad-container"><div class="ad-slot-container">${adSlot}</div></div>`,
+	frontsBannerAdWithExtraDivs: `<div class="top-fronts-banner-ad-container"><div><div><div class="ad-slot-container">${adSlot}</div></div></div></div>`,
+	topBannerAd: `<div class="top-banner-ad-container"><div class="ad-slot-container">${adSlot}</div></div>`,
+	topBannerAdWithExtraDivs: `<div class="top-banner-ad-container"><div><div><div class="ad-slot-container">${adSlot}</div></div></div></div>`,
 } satisfies Record<string, string>;
 
 const createAd = (html: string) => {
@@ -39,5 +42,23 @@ describe('findElementToRemove', () => {
 		createAd(adverts['frontsBannerAd']);
 		const result = findElementToRemove(getAd());
 		expect(result.classList).toContain('top-fronts-banner-ad-container');
+	});
+
+	it('returns the top-level fronts banner container when separated from the container by extra divs', () => {
+		createAd(adverts['frontsBannerAdWithExtraDivs']);
+		const result = findElementToRemove(getAd());
+		expect(result.classList).toContain('top-fronts-banner-ad-container');
+	});
+
+	it('returns the top-level banner container', () => {
+		createAd(adverts['topBannerAd']);
+		const result = findElementToRemove(getAd());
+		expect(result.classList).toContain('top-banner-ad-container');
+	});
+
+	it('returns the top-level banner container when separated from the container by extra divs', () => {
+		createAd(adverts['topBannerAdWithExtraDivs']);
+		const result = findElementToRemove(getAd());
+		expect(result.classList).toContain('top-banner-ad-container');
 	});
 });

--- a/src/events/empty-advert.ts
+++ b/src/events/empty-advert.ts
@@ -11,8 +11,8 @@ const removeFromDfpEnv = (advert: Advert) => {
 /**
  * Find the highest element responsible for the advert.
  *
- * Sometimes an advert has an advert container
- * Sometimes that container has a top-level container
+ * Sometimes an advert has an advert container as a direct parent
+ * Sometimes that container has a top-level container ancestor
  */
 const findElementToRemove = (advertNode: HTMLElement): HTMLElement => {
 	const parent = advertNode.parentElement;
@@ -24,16 +24,15 @@ const findElementToRemove = (advertNode: HTMLElement): HTMLElement => {
 		return advertNode;
 	}
 
-	if (
-		parent.parentElement?.classList.contains(
-			'top-fronts-banner-ad-container',
-		) ||
-		parent.parentElement?.classList.contains('top-banner-ad-container')
-	) {
-		return parent.parentElement;
+	const topLevelContainer = parent.closest<HTMLElement>(
+		'.top-fronts-banner-ad-container, .top-banner-ad-container',
+	);
+
+	if (!topLevelContainer) {
+		return parent;
 	}
 
-	return parent;
+	return topLevelContainer;
 };
 
 const removeSlotFromDom = (slotElement: HTMLElement) => {


### PR DESCRIPTION
## What does this change?

This PR loosens the assumptions around how the DOM is structured for banner slots (that's front banners and the top-above-nav "banner" container element).

Previously, we assumed the `top-fronts-banner-ad-container` and `top-banner-ad-container` must be direct parents of the ad slot container. Instead, these can now be any ancestor of the ad slot container. This allows for more flexibility in how the DOM is structured, with additional elements placed between the `ad-slot-container` elements and the top-level banner containers.

## Why?

Fix a bug whereby the top-above-nav slot is no longer properly collapsed, due to a change in the DOM structure introduced in https://github.com/guardian/dotcom-rendering/pull/11124.

## How has this been verified?

The existing unit tests pass, and I've added three test cases that assert the desired behaviour in this change.

I've also tested this locally, and observed the top-above-nav slot collapsing when I reject all in the CMP.
