### PR TITLE
Bump `@guardian/support-dotcom-components`

### DIFF
--- a/.changeset/tasty-kids-return.md
+++ b/.changeset/tasty-kids-return.md
@@ -1,0 +1,7 @@
+---
+'@guardian/commercial': major
+---
+
+Bumps `@guardian/support-dotcom-components` to `v2.0.1`.
+This is a major change [as per our recommendations](https://github.com/guardian/recommendations/blob/main/npm-packages.md#changes-to-peerdependencies-ranges-are-breaking), and consumers should
+ensure that they provide a compatible version of the package.

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"@guardian/libs": "16.1.0",
 		"@guardian/prettier": "4.0.0",
 		"@guardian/source-foundations": "14.1.4",
-		"@guardian/support-dotcom-components": "1.0.7",
+		"@guardian/support-dotcom-components": "2.0.1",
 		"@playwright/test": "1.40.1",
 		"@types/google.analytics": "^0.0.42",
 		"@types/googletag": "~3.0.3",
@@ -135,7 +135,7 @@
 		"@guardian/identity-auth-frontend": "^4.0.0",
 		"@guardian/libs": "^16.1.0",
 		"@guardian/source-foundations": "^14.1.2",
-		"@guardian/support-dotcom-components": "^1.0.7"
+		"@guardian/support-dotcom-components": "^2.0.1"
 	},
 	"browserslist": [
 		"extends @guardian/browserslist-config"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,8 +104,8 @@ devDependencies:
     specifier: 14.1.4
     version: 14.1.4(tslib@2.6.2)(typescript@4.9.5)
   '@guardian/support-dotcom-components':
-    specifier: 1.0.7
-    version: 1.0.7
+    specifier: 2.0.1
+    version: 2.0.1
   '@playwright/test':
     specifier: 1.40.1
     version: 1.40.1
@@ -1906,8 +1906,8 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /@guardian/support-dotcom-components@1.0.7:
-    resolution: {integrity: sha512-MhaO+rC+ujXMcaMd1TL5D0t0eEuHWGh3OrFkM8BhPwhMkjela/dCOPeVPvGJDJ0a37o4PeMszqy+dSuiR4BvvQ==}
+  /@guardian/support-dotcom-components@2.0.1:
+    resolution: {integrity: sha512-ie4zXaSJb8/xh6FQ96gQoWypIx3CJ4A/GjPAKPFCIfTdhPgrmURe9w8OBqrqi7sZRSbcNgoiVoJzj+t6nNE5tg==}
     dev: true
 
   /@humanwhocodes/config-array@0.11.14:


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

Bumps `@guardian/support-dotcom-components` to `v2.0.1`.
This is a major change [as per our recommendations](https://github.com/guardian/recommendations/blob/main/npm-packages.md#changes-to-peerdependencies-ranges-are-breaking), and consumers should
ensure that they provide a compatible version of the package.

## Why?

The latest is v2.0.1 and this is what is used in `dotcom-rendering`.