### PR TITLE
Drop @guardian/support-dotcom-components as a dependency

### DIFF
--- a/.changeset/metal-spoons-build.md
+++ b/.changeset/metal-spoons-build.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Drop @guardian/support-dotcom-components as a dependency, it's not used anywhere

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
 		"@guardian/libs": "16.1.0",
 		"@guardian/prettier": "4.0.0",
 		"@guardian/source-foundations": "14.1.4",
-		"@guardian/support-dotcom-components": "1.0.7",
 		"@playwright/test": "1.40.1",
 		"@types/google.analytics": "^0.0.42",
 		"@types/googletag": "~3.0.3",
@@ -134,8 +133,7 @@
 		"@guardian/identity-auth": "^2.1.0",
 		"@guardian/identity-auth-frontend": "^4.0.0",
 		"@guardian/libs": "^16.1.0",
-		"@guardian/source-foundations": "^14.1.2",
-		"@guardian/support-dotcom-components": "^1.0.7"
+		"@guardian/source-foundations": "^14.1.2"
 	},
 	"browserslist": [
 		"extends @guardian/browserslist-config"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,9 +103,6 @@ devDependencies:
   '@guardian/source-foundations':
     specifier: 14.1.4
     version: 14.1.4(tslib@2.6.2)(typescript@4.9.5)
-  '@guardian/support-dotcom-components':
-    specifier: 1.0.7
-    version: 1.0.7
   '@playwright/test':
     specifier: 1.40.1
     version: 1.40.1
@@ -1731,7 +1728,7 @@ packages:
     resolution: {integrity: sha512-2LzVvEC26oYztK5woowBhK5lqnrsJGoA22Byi82kL/qubOMPPCOyimJHLXGhHrvvsyxQZM2NRm4+PuxGIdF8Nw==}
     peerDependencies:
       tslib: ^2.6.2
-      typescript: ~4.9.5
+      typescript: ~5.3.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1755,7 +1752,7 @@ packages:
     peerDependencies:
       '@guardian/libs': ^16.0.0
       tslib: ^2.6.2
-      typescript: ~4.9.5
+      typescript: ~5.3.3
       web-vitals: ^3.5.0
     peerDependenciesMeta:
       typescript:
@@ -1772,7 +1769,7 @@ packages:
     peerDependencies:
       eslint: ^8.0.0
       tslib: ^2.5.3
-      typescript: ~4.9.5
+      typescript: ~5.1.3
     dependencies:
       '@guardian/eslint-config': 4.1.0(@typescript-eslint/parser@5.59.9)(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0)(tslib@2.6.2)
       '@typescript-eslint/eslint-plugin': 5.59.9(@typescript-eslint/parser@5.59.9)(eslint@8.57.0)(typescript@4.9.5)
@@ -1812,7 +1809,7 @@ packages:
       '@guardian/identity-auth': ^2.1.0
       '@guardian/libs': ^16.0.0
       tslib: ^2.6.2
-      typescript: ~4.9.5
+      typescript: ~5.3.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1828,7 +1825,7 @@ packages:
     peerDependencies:
       '@guardian/libs': ^16.0.0
       tslib: ^2.6.2
-      typescript: ~4.9.5
+      typescript: ~5.3.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1842,7 +1839,7 @@ packages:
     resolution: {integrity: sha512-nb7r0C+UO4P6f0wH8sATtGYnGrfqCzOX4M1Pp2G+uj9c3tehMRSum4mgnqxSAVXN50LtkL2bwd4u3Ichk6670Q==}
     peerDependencies:
       tslib: ^2.6.2
-      typescript: ~4.9.5
+      typescript: ~5.3.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1896,7 +1893,7 @@ packages:
     resolution: {integrity: sha512-SHkFVBxsE2dSNTKfzmGY1hD9BA7qJ2+bGY1plrUJlYJBCRQdno/YuNummO+wm0Q+kMgxRT0iz5md2DjKYERzQw==}
     peerDependencies:
       tslib: ^2.6.2
-      typescript: ~4.9.5
+      typescript: ~5.3.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -1904,10 +1901,6 @@ packages:
       mini-svg-data-uri: 1.4.4
       tslib: 2.6.2
       typescript: 4.9.5
-    dev: true
-
-  /@guardian/support-dotcom-components@1.0.7:
-    resolution: {integrity: sha512-MhaO+rC+ujXMcaMd1TL5D0t0eEuHWGh3OrFkM8BhPwhMkjela/dCOPeVPvGJDJ0a37o4PeMszqy+dSuiR4BvvQ==}
     dev: true
 
   /@humanwhocodes/config-array@0.11.14:
@@ -8075,7 +8068,7 @@ packages:
       babel-jest: ^29.0.0
       esbuild: '*'
       jest: ^29.0.0
-      typescript: ~4.9.5
+      typescript: '>=4.3 <6'
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -8104,7 +8097,7 @@ packages:
     resolution: {integrity: sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      typescript: ~4.9.5
+      typescript: '*'
       webpack: ^5.0.0
     dependencies:
       chalk: 4.1.2
@@ -8136,7 +8129,7 @@ packages:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
-      typescript: ~4.9.5
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
       typescript: 4.9.5


### PR DESCRIPTION
## Why?
Whatever code used it has been subsequently been removed, so we can drop it