### PR TITLE
Tweaks for interactive ad article slots

### DIFF
--- a/.changeset/rich-schools-brake.md
+++ b/.changeset/rich-schools-brake.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Add 'interactive' slot to size mappings, instead of falling back to data attributes , merge them with  size mappings

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/core/__mocks__/ad-sizes.ts

--- a/src/core/__mocks__/ad-sizes.ts
+++ b/src/core/__mocks__/ad-sizes.ts
@@ -1,0 +1,21 @@
+import { AdSize as RealAdSize } from 'core/ad-sizes';
+
+class AdSize extends RealAdSize {
+	constructor(arraySize: number);
+	constructor([width, height]: [number, number]);
+	constructor(args: [number, number] | number) {
+		// The class needs to be able to be instantiable with a single number like a normal `Array`, so that it can be used in jest, where it uses this internally somehow.
+		if (typeof args === 'number') {
+			super([0, 0]);
+		} else {
+			super(args);
+		}
+	}
+}
+
+const createAdSize = (width: number, height: number): AdSize => {
+	return new AdSize([width, height]);
+};
+
+export * from './ad-sizes';
+export { createAdSize };

--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -113,7 +113,8 @@ type SlotName =
 	| 'right'
 	| 'sponsor-logo'
 	| 'survey'
-	| 'top-above-nav';
+	| 'top-above-nav'
+	| 'interactive';
 
 type SizeMapping = Partial<Record<Breakpoint, Readonly<AdSize[]>>>;
 
@@ -414,6 +415,12 @@ const slotSizeMappings = {
 			adSizes.fluid,
 			adSizes.sponsorLogo,
 		],
+	},
+	interactive: {
+		// Mappings are dynamically added for this slot using data attributes
+		mobile: [adSizes.outOfPage, adSizes.empty],
+		tablet: [adSizes.outOfPage, adSizes.empty],
+		desktop: [adSizes.outOfPage, adSizes.empty],
 	},
 } as const satisfies SlotSizeMappings;
 

--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -27,19 +27,10 @@ class AdSize extends Array<number> {
 	readonly [0]: number;
 	readonly [1]: number;
 
-	constructor(arraySize: number);
-	constructor([width, height]: [number, number]);
-	constructor(args: [number, number] | number) {
-		// The class needs to be able to be instantiable with a single number like a normal `Array`, so that it can be used in jest, where the constructor is called with a single number for comparisons
-		if (typeof args === 'number') {
-			super(args);
-			this[0] = 0;
-			this[1] = 0;
-		} else {
-			super();
-			this[0] = args[0];
-			this[1] = args[1];
-		}
+	constructor([width, height]: [number, number]) {
+		super();
+		this[0] = width;
+		this[1] = height;
 	}
 
 	public toString(): AdSizeString {

--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -27,10 +27,19 @@ class AdSize extends Array<number> {
 	readonly [0]: number;
 	readonly [1]: number;
 
-	constructor([width, height]: [number, number]) {
-		super();
-		this[0] = width;
-		this[1] = height;
+	constructor(arraySize: number);
+	constructor([width, height]: [number, number]);
+	constructor(args: [number, number] | number) {
+		// The class needs to be able to be instantiable with a single number like a normal `Array`, so that it can be used in jest, where the constructor is called with a single number for comparisons
+		if (typeof args === 'number') {
+			super(args);
+			this[0] = 0;
+			this[1] = 0;
+		} else {
+			super();
+			this[0] = args[0];
+			this[1] = args[1];
+		}
 	}
 
 	public toString(): AdSizeString {
@@ -475,16 +484,10 @@ const findAppliedSizesForBreakpoint = (
 // Export for testing
 export const _ = { createAdSize };
 
-export type {
-	AdSizeString,
-	AdSize,
-	SizeKeys,
-	SizeMapping,
-	SlotSizeMappings,
-	SlotName,
-};
+export type { AdSizeString, SizeKeys, SizeMapping, SlotSizeMappings, SlotName };
 
 export {
+	AdSize,
 	adSizes,
 	standardAdSizes,
 	outstreamSizes,

--- a/src/core/create-ad-slot.spec.ts
+++ b/src/core/create-ad-slot.spec.ts
@@ -1,4 +1,5 @@
-import { createAdSlot } from './create-ad-slot';
+import { createAdSize } from './ad-sizes';
+import { concatSizeMappings, createAdSlot } from './create-ad-slot';
 
 const imHtml = `
 <div id="dfp-ad--im"
@@ -46,5 +47,66 @@ describe('Create Ad Slot', () => {
 		expect(adSlot.outerHTML).toBe(
 			htmls.replace(/\n/g, '').replace(/\s+/g, ' '),
 		);
+	});
+});
+
+describe('concatSizeMappings', () => {
+	it('should exist', () => {
+		expect(concatSizeMappings).toBeDefined();
+	});
+
+	it('should return the same size mapping if only one provided', () => {
+		const sizeMapping = {
+			mobile: [createAdSize(300, 250)],
+			tablet: [createAdSize(728, 90)],
+			desktop: [createAdSize(970, 250)],
+			wide: [createAdSize(970, 250)],
+		};
+
+		expect(concatSizeMappings(sizeMapping)).toEqual(sizeMapping);
+	});
+
+	it('should return the combined size mapping if multiple provided', () => {
+		const sizeMapping1 = {
+			mobile: [createAdSize(300, 250)],
+		};
+		const sizeMapping2 = {
+			tablet: [createAdSize(728, 90)],
+		};
+
+		const test = concatSizeMappings(sizeMapping1, sizeMapping2);
+
+		console.log(test);
+
+		expect(concatSizeMappings(sizeMapping1, sizeMapping2)).toEqual({
+			mobile: [createAdSize(300, 250)],
+			tablet: [createAdSize(728, 90)],
+		});
+	});
+
+	it('should return the combined size mapping if multiple provided with overlapping breakpoints', () => {
+		const sizeMapping1 = {
+			mobile: [createAdSize(300, 250)],
+			tablet: [createAdSize(728, 90)],
+		};
+		const sizeMapping2 = {
+			mobile: [createAdSize(300, 250), createAdSize(320, 50)],
+		};
+
+		expect(concatSizeMappings(sizeMapping1, sizeMapping2)).toEqual({
+			mobile: [createAdSize(300, 250), createAdSize(320, 50)],
+			tablet: [createAdSize(728, 90)],
+		});
+	});
+
+	it('should return the combined size mapping if the first size mapping is empty', () => {
+		const sizeMapping1 = {};
+		const sizeMapping2 = {
+			wide: [createAdSize(728, 90)],
+		};
+
+		expect(concatSizeMappings(sizeMapping1, sizeMapping2)).toEqual({
+			wide: [createAdSize(728, 90)],
+		});
 	});
 });

--- a/src/core/create-ad-slot.spec.ts
+++ b/src/core/create-ad-slot.spec.ts
@@ -74,10 +74,6 @@ describe('concatSizeMappings', () => {
 			tablet: [createAdSize(728, 90)],
 		};
 
-		const test = concatSizeMappings(sizeMapping1, sizeMapping2);
-
-		console.log(test);
-
 		expect(concatSizeMappings(sizeMapping1, sizeMapping2)).toEqual({
 			mobile: [createAdSize(300, 250)],
 			tablet: [createAdSize(728, 90)],

--- a/src/core/create-ad-slot.ts
+++ b/src/core/create-ad-slot.ts
@@ -1,5 +1,4 @@
 import { log } from '@guardian/libs';
-import { findAppliedSizesForBreakpoint } from './ad-sizes';
 import type { SizeMapping } from './ad-sizes';
 import { isBreakpoint } from './lib/breakpoint';
 
@@ -117,20 +116,24 @@ const concatSizeMappings = (
 	defaultSizeMappings: SizeMapping,
 	optionSizeMappings: SizeMapping = {},
 ): SizeMapping =>
-	Object.entries(optionSizeMappings).reduce<SizeMapping>(
-		(sizeMappings, [breakpoint, optionSizes]) => {
-			// Only perform concatenation if breakpoint is of the correct type
-			if (isBreakpoint(breakpoint)) {
-				const sizes = findAppliedSizesForBreakpoint(
-					sizeMappings,
-					breakpoint,
-				);
-
-				// Concatenate the option sizes onto any existing sizes present for a given breakpoint
-				sizeMappings[breakpoint] = sizes.concat(optionSizes);
+	Object.entries(optionSizeMappings).reduce(
+		(combinedSizeMapping, [device, optionSizes]) => {
+			if (!isBreakpoint(device)) {
+				throw new Error(`Unknown device breakpoint: ${device}`);
 			}
 
-			return sizeMappings;
+			const sizes = [...(combinedSizeMapping[device] ?? [])];
+
+			for (const size of optionSizes) {
+				if (!sizes.some((s) => s.width === size.width)) {
+					sizes.push(size);
+				}
+			}
+
+			return {
+				...combinedSizeMapping,
+				[device]: sizes,
+			};
 		},
 		{ ...defaultSizeMappings },
 	);

--- a/src/core/create-ad-slot.ts
+++ b/src/core/create-ad-slot.ts
@@ -122,13 +122,19 @@ const concatSizeMappings = (
 				throw new Error(`Unknown device breakpoint: ${device}`);
 			}
 
-			const sizes = [...(combinedSizeMapping[device] ?? [])];
-
-			for (const size of optionSizes) {
-				if (!sizes.some((s) => s.width === size.width)) {
-					sizes.push(size);
-				}
-			}
+			const sizes = optionSizes.reduce(
+				(acc, size) => {
+					const existingSize = acc.find(
+						(s) =>
+							s.width === size.width && s.height === size.height,
+					);
+					if (!existingSize) {
+						acc.push(size);
+					}
+					return acc;
+				},
+				[...(combinedSizeMapping[device] ?? [])],
+			);
 
 			return {
 				...combinedSizeMapping,

--- a/src/core/lib/breakpoint.spec.ts
+++ b/src/core/lib/breakpoint.spec.ts
@@ -7,7 +7,7 @@ describe('isBreakpoint', () => {
 		['tablet', true],
 		['desktop', true],
 		['foo', false],
-		['wide', false],
+		['wide', true],
 		['leftCol', false],
 	];
 	it.each(cases)(

--- a/src/core/lib/breakpoint.ts
+++ b/src/core/lib/breakpoint.ts
@@ -1,7 +1,7 @@
 /**
  * Breakpoints ordered from smallest to largest
  */
-const breakpoints = ['mobile', 'phablet', 'tablet', 'desktop'] as const;
+const breakpoints = ['mobile', 'phablet', 'tablet', 'desktop', 'wide'] as const;
 
 type Breakpoint = (typeof breakpoints)[number];
 

--- a/src/define/Advert.ts
+++ b/src/define/Advert.ts
@@ -74,6 +74,8 @@ const getSlotSizeMapping = (name: string): SizeMapping => {
 		slotName = 'external';
 	} else if (name.includes('comments-expanded')) {
 		slotName = 'comments-expanded';
+	} else if (name.includes('interactive')) {
+		slotName = 'interactive';
 	} else {
 		slotName = name;
 	}

--- a/src/define/Advert.ts
+++ b/src/define/Advert.ts
@@ -191,31 +191,28 @@ class Advert {
 	 * @returns A mapping of breakpoints to ad sizes
 	 */
 	generateSizeMapping(additionalSizeMapping: SizeMapping): SizeMapping {
-		// Try to used size mappings if available
+		// Try to use size mappings defined in core if available
 		const defaultSizeMappingForSlot = this.node.dataset.name
 			? getSlotSizeMapping(this.node.dataset.name)
 			: {};
+
+		// Data attribute size mappings are used in interactives e.g. https://www.theguardian.com/education/ng-interactive/2021/sep/11/the-best-uk-universities-2022-rankings
+		const dataAttrSizeMapping = getSlotSizeMappingsFromDataAttrs(this.node);
 
 		let sizeMapping = concatSizeMappings(
 			defaultSizeMappingForSlot,
 			additionalSizeMapping,
 		);
 
-		/**
-		 * If the size mapping is empty, use the data attributes to create a size mapping,
-		 * this is used on some interactives e.g. https://www.theguardian.com/education/ng-interactive/2021/sep/11/the-best-uk-universities-2022-rankings
-		 */
-		if (isSizeMappingEmpty(sizeMapping)) {
-			sizeMapping = getSlotSizeMappingsFromDataAttrs(this.node);
+		sizeMapping = concatSizeMappings(sizeMapping, dataAttrSizeMapping);
 
-			// If the size mapping is still empty, throw an error as this should never happen
-			if (isSizeMappingEmpty(sizeMapping)) {
-				throw new Error(
-					`Tried to render ad slot '${
-						this.node.dataset.name ?? ''
-					}' without any size mappings`,
-				);
-			}
+		// If the size mapping is still empty, throw an error as this should never happen
+		if (isSizeMappingEmpty(sizeMapping)) {
+			throw new Error(
+				`Tried to render ad slot '${
+					this.node.dataset.name ?? ''
+				}' without any size mappings`,
+			);
 		}
 
 		return sizeMapping;

--- a/src/define/define-slot.ts
+++ b/src/define/define-slot.ts
@@ -11,6 +11,7 @@ const breakpointViewports: Record<keyof SizeMapping, [number, number]> = {
 	phablet: [sourceBreakpoints.phablet, 0],
 	tablet: [sourceBreakpoints.tablet, 0],
 	desktop: [sourceBreakpoints.desktop, 0],
+	wide: [sourceBreakpoints.wide, 0],
 };
 
 const adUnit = once((): string => {

--- a/src/init/consented/remove-slots.ts
+++ b/src/init/consented/remove-slots.ts
@@ -4,7 +4,11 @@ import { dfpEnv } from '../../lib/dfp/dfp-env';
 import fastdom from '../../utils/fastdom-promise';
 
 // Remove ad slots
-const selectors: string[] = [dfpEnv.adSlotSelector, '.top-banner-ad-container'];
+const selectors: string[] = [
+	dfpEnv.adSlotSelector,
+	'.top-banner-ad-container',
+	'.ad-slot-container',
+];
 
 const selectNodes = () =>
 	selectors.reduce(

--- a/src/lib/header-bidding/slot-config.spec.ts
+++ b/src/lib/header-bidding/slot-config.spec.ts
@@ -207,9 +207,9 @@ describe('getPrebidAdSlots', () => {
 		);
 		expect(hbSlots).toHaveLength(1);
 		expect(hbSlots[0]?.sizes).toEqual([
-			adSizes.skyscraper,
-			adSizes.halfPage,
-			adSizes.mpu,
+			createAdSize(160, 600),
+			createAdSize(300, 600),
+			createAdSize(300, 250),
 		]);
 	});
 });

--- a/src/lib/header-bidding/slot-config.spec.ts
+++ b/src/lib/header-bidding/slot-config.spec.ts
@@ -1,5 +1,5 @@
 import type { SizeMapping } from 'core/ad-sizes';
-import { adSizes } from 'core/ad-sizes';
+import { adSizes, createAdSize } from 'core/ad-sizes';
 import { Advert } from '../../define/Advert';
 import { getHeaderBiddingAdSlots } from './slot-config';
 import { getBreakpointKey, shouldIncludeMobileSticky } from './utils';
@@ -65,10 +65,7 @@ describe('getPrebidAdSlots', () => {
 		expect(getHeaderBiddingAdSlots(buildAdvert('top-above-nav'))).toEqual([
 			{
 				key: 'top-above-nav',
-				sizes: [
-					[970, 250],
-					[728, 90],
-				],
+				sizes: [createAdSize(970, 250), createAdSize(728, 90)],
 			},
 		]);
 	});
@@ -97,7 +94,7 @@ describe('getPrebidAdSlots', () => {
 		expect(getHeaderBiddingAdSlots(buildAdvert('top-above-nav'))).toEqual([
 			{
 				key: 'top-above-nav',
-				sizes: [[728, 90]],
+				sizes: [createAdSize(728, 90)],
 			},
 		]);
 	});
@@ -107,7 +104,7 @@ describe('getPrebidAdSlots', () => {
 		expect(getHeaderBiddingAdSlots(buildAdvert('top-above-nav'))).toEqual([
 			{
 				key: 'top-above-nav',
-				sizes: [[300, 250]],
+				sizes: [createAdSize(300, 250)],
 			},
 		]);
 	});
@@ -122,7 +119,7 @@ describe('getPrebidAdSlots', () => {
 		).toEqual([
 			{
 				key: 'mobile-sticky',
-				sizes: [[320, 50]],
+				sizes: [createAdSize(320, 50)],
 			},
 		]);
 	});
@@ -134,8 +131,8 @@ describe('getPrebidAdSlots', () => {
 		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline1'));
 		expect(hbSlots).toHaveLength(1);
 		expect(hbSlots[0]?.sizes).toEqual([
-			[300, 250],
-			[620, 350],
+			createAdSize(300, 250),
+			createAdSize(620, 350),
 		]);
 	});
 
@@ -146,9 +143,9 @@ describe('getPrebidAdSlots', () => {
 		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline1'));
 		expect(hbSlots).toHaveLength(1);
 		expect(hbSlots[0]?.sizes).toEqual([
-			[300, 197],
-			[300, 250],
-			[320, 480],
+			createAdSize(300, 197),
+			createAdSize(300, 250),
+			createAdSize(320, 480),
 		]);
 	});
 
@@ -159,9 +156,9 @@ describe('getPrebidAdSlots', () => {
 		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline2'));
 		expect(hbSlots).toHaveLength(1);
 		expect(hbSlots[0]?.sizes).toEqual([
-			[160, 600],
-			[300, 600],
-			[300, 250],
+			createAdSize(160, 600),
+			createAdSize(300, 600),
+			createAdSize(300, 250),
 		]);
 	});
 
@@ -172,8 +169,8 @@ describe('getPrebidAdSlots', () => {
 		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline2'));
 		expect(hbSlots).toHaveLength(1);
 		expect(hbSlots[0]?.sizes).toEqual([
-			[300, 250],
-			[320, 480],
+			createAdSize(300, 250),
+			createAdSize(320, 480),
 		]);
 	});
 
@@ -183,7 +180,10 @@ describe('getPrebidAdSlots', () => {
 		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline4'));
 
 		expect(hbSlots).toContainEqual(
-			expect.objectContaining({ key: 'inline', sizes: [[300, 250]] }),
+			expect.objectContaining({
+				key: 'inline',
+				sizes: [createAdSize(300, 250)],
+			}),
 		);
 	});
 
@@ -193,7 +193,7 @@ describe('getPrebidAdSlots', () => {
 
 		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline4'));
 		expect(hbSlots).toHaveLength(1);
-		expect(hbSlots[0]?.sizes).toEqual([[300, 250]]);
+		expect(hbSlots[0]?.sizes).toEqual([createAdSize(300, 250)]);
 	});
 
 	test('should return the correct inline slot at breakpoint D with additional size mappings', () => {
@@ -207,9 +207,9 @@ describe('getPrebidAdSlots', () => {
 		);
 		expect(hbSlots).toHaveLength(1);
 		expect(hbSlots[0]?.sizes).toEqual([
-			[160, 600],
-			[300, 600],
-			[300, 250],
+			adSizes.skyscraper,
+			adSizes.halfPage,
+			adSizes.mpu,
 		]);
 	});
 });


### PR DESCRIPTION
## What does this change?
Add a size mapping for `interactive` ad slots to our size mapping

Rather than fallback to data attributes, merge them with any other size mappings for that slot.

## Why?
Allows us to remove the `outofpage` and `empty` sizes from interactive slot data attributes.