### PR TITLE
Add labels for opt-out fabric ads

### DIFF
--- a/.changeset/honest-pants-melt.md
+++ b/.changeset/honest-pants-melt.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Add labels to opt-out fabrics

--- a/src/init/consentless/render-advert-label.ts
+++ b/src/init/consentless/render-advert-label.ts
@@ -10,7 +10,6 @@ const shouldRenderConsentlessLabel = (adSlotNode: HTMLElement): boolean => {
 		adSlotNode.classList.contains('ad-slot--frame') ||
 		adSlotNode.classList.contains('ad-slot--gc') ||
 		adSlotNode.classList.contains('u-h') ||
-		adSlotNode.classList.contains('ad-slot--native') ||
 		// set for out-of-page (1x1) and empty (2x2) ads
 		adSlotNode.classList.contains('ad-slot--collapse') ||
 		adSlotNode.getAttribute('data-label') === 'false'


### PR DESCRIPTION
## What does this change?
We added a native class to native ads in opt-out so that we can serve them without labels in this PR: https://github.com/guardian/commercial/pull/1334

This tag has ended up being added to fabric ads in opt-out, but unlike their GAM counterparts they have no built-in label. There's a takeover going live on monday morning and the native templates for opt-out can't be edited without the opt-out team, so this quick fix is the only way we can get labels on these takeover ads in time for monday.

Next week we'll look to fix the tagging so that we can have labels on fabrics but not on the labs multiple.

Takeover banner ads (tested locally):

<img width="1491" alt="Screenshot 2024-04-26 at 17 15 21" src="https://github.com/guardian/commercial/assets/108270776/43415972-3c60-4586-8b24-2d754260837c">
