### PR TITLE
Fix broken link for article.ts in spacefinder docs

### DIFF
--- a/docs/spacefinder/readme.md
+++ b/docs/spacefinder/readme.md
@@ -62,7 +62,7 @@ Mobile does not need to take into account the potential height of an ad:
 
 ## Spacefinder rules
 
-There are different rules for different passes see [article-body-adverts.ts](https://github.com/guardian/commercial/blob/main/src/insert/spacefinder/article-body-adverts.ts)
+There are different rules for different passes see [article.ts](https://github.com/guardian/commercial/blob/main/src/insert/spacefinder/article.ts)
 
 ---
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This is a small change to fix the broken link in Spacefinder rules in the docs.

## Why?

A working link to the correct file name and path.
