### PR TITLE
Move `im` below `inline1`

### DIFF
--- a/.changeset/two-dolls-call.md
+++ b/.changeset/two-dolls-call.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Move im below inline1 to reduce revenue impact when the im won't serve ads"

--- a/playwright/fixtures/pages/fronts.ts
+++ b/playwright/fixtures/pages/fronts.ts
@@ -43,7 +43,7 @@ const tagPages: TagPage[] = [
 	{
 		path: getTestUrl({
 			stage,
-			path: '/world/americas',
+			path: '/tone/recipes/all',
 			type: 'tagPage',
 			adtest: 'fixed-puppies',
 		}),

--- a/src/insert/spacefinder/article.ts
+++ b/src/insert/spacefinder/article.ts
@@ -498,13 +498,13 @@ const init = async (fillAdSlot: FillAdSlot): Promise<boolean> => {
 		return Promise.resolve(false);
 	}
 
+	await addInlineAds(fillAdSlot);
+
 	const im = window.guardian.config.page.hasInlineMerchandise
 		? attemptToAddInlineMerchAd(fillAdSlot)
 		: Promise.resolve(false);
 	const inlineMerchAdded = await im;
 	if (inlineMerchAdded) await waitForAdvert('dfp-ad--im');
-
-	await addInlineAds(fillAdSlot);
 
 	await initCarrot();
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
This PR changes the order of the `im` and `inline1` slots so now we have the `im` below `inline1`. 

Occasionally `hasInlineMerch` will be true but won't serve, due to unsupported targeting being added to the line items, this causes `inline1` to be lower than it should be cause it will still try to avoid `im`.

`inline1` is our most valuable slot so changing the order seemed like the best way to avoid this `im` issue.

This change is tested locally and in CODE with this [article](https://www.theguardian.com/society/2024/apr/18/scottish-gender-clinic-pauses-prescribing-puberty-blockers-to-under-18s) using Spacefinder debug which you can use by adding `?sfdebug` at the end of the url.

## Why?
Reduce revenue impact when the above `im` issue occurs. 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![image](https://github.com/guardian/commercial/assets/23424805/f70c2968-6db6-49be-8c25-503d929917ce) | ![image](https://github.com/guardian/commercial/assets/23424805/140c4387-4118-4ba7-b0cb-48ea02b432e7) |

[before]: https://example.com/before.png
[after]: https://example.com/after.png
