### PR TITLE
use `:scope` everywhere

### DIFF
--- a/.changeset/wicked-apricots-warn.md
+++ b/.changeset/wicked-apricots-warn.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+missing `:scope` in some spacefinder selectors

--- a/src/insert/spacefinder/article.ts
+++ b/src/insert/spacefinder/article.ts
@@ -318,16 +318,16 @@ const addMobileInlineAds = (fillSlot: FillAdSlot): Promise<boolean> => {
 	 */
 	const oldRules: SpacefinderRules = {
 		bodySelector: articleBodySelector,
-		candidateSelector: ' > p',
+		candidateSelector: ':scope > p',
 		minAbove: 200,
 		minBelow: 200,
 		opponentSelectorRules: {
-			' > h2': {
+			':scope > h2': {
 				minAboveSlot: 100,
 				minBelowSlot: 250,
 			},
 			...inlineAdSlotContainerRules,
-			[` > :not(p):not(h2):not(.${adSlotContainerClass}):not(#sign-in-gate)`]:
+			[`:scope > :not(p):not(h2):not(.${adSlotContainerClass}):not(#sign-in-gate)`]:
 				{
 					minAboveSlot: 35,
 					minBelowSlot: 200,

--- a/src/insert/spacefinder/carrot-traffic-driver.ts
+++ b/src/insert/spacefinder/carrot-traffic-driver.ts
@@ -13,46 +13,46 @@ const bodySelector = '.article-body-commercial-selector';
 
 const wideRules: SpacefinderRules = {
 	bodySelector,
-	candidateSelector: ' > p',
+	candidateSelector: ':scope > p',
 	minAbove: 500,
 	minBelow: 400,
 	clearContentMeta: 0,
 	opponentSelectorRules: {
-		' .element-rich-link': {
+		':scope .element-rich-link': {
 			minAboveSlot: 100,
 			minBelowSlot: 400,
 		},
-		' .element-image': {
+		':scope .element-image': {
 			minAboveSlot: 440,
 			minBelowSlot: 440,
 		},
 
-		' .player': {
+		':scope .player': {
 			minAboveSlot: 50,
 			minBelowSlot: 50,
 		},
-		' > h1': {
+		':scope > h1': {
 			minAboveSlot: 50,
 			minBelowSlot: 50,
 		},
-		' > h2': {
+		':scope > h2': {
 			minAboveSlot: 50,
 			minBelowSlot: 50,
 		},
-		' > *:not(p):not(h2):not(blockquote):not(#sign-in-gate)': {
+		':scope > *:not(p):not(h2):not(blockquote):not(#sign-in-gate)': {
 			minAboveSlot: 50,
 			minBelowSlot: 50,
 		},
-		' .ad-slot': {
+		':scope .ad-slot': {
 			minAboveSlot: 100,
 			minBelowSlot: 100,
 		},
-		' .element-pullquote': {
+		':scope .element-pullquote': {
 			minAboveSlot: 400,
 			minBelowSlot: 400,
 		},
 		// Don't place carrot ads near newsletter sign-up blocks
-		' > figure[data-spacefinder-role="inline"]': {
+		':scope > figure[data-spacefinder-role="inline"]': {
 			minAboveSlot: 400,
 			minBelowSlot: 400,
 		},
@@ -65,15 +65,15 @@ const desktopRules: SpacefinderRules = {
 	...wideRules,
 	opponentSelectorRules: {
 		...wideRules.opponentSelectorRules,
-		' .element-rich-link': {
+		':scope .element-rich-link': {
 			minAboveSlot: 400,
 			minBelowSlot: 400,
 		},
-		' .ad-slot': {
+		':scope .ad-slot': {
 			minAboveSlot: 400,
 			minBelowSlot: 400,
 		},
-		' .ad-slot--im': {
+		':scope .ad-slot--im': {
 			minAboveSlot: 400,
 			minBelowSlot: 400,
 		},

--- a/src/insert/spacefinder/carrot-traffic-driver.ts
+++ b/src/insert/spacefinder/carrot-traffic-driver.ts
@@ -18,16 +18,16 @@ const wideRules: SpacefinderRules = {
 	minBelow: 400,
 	clearContentMeta: 0,
 	opponentSelectorRules: {
-		':scope .element-rich-link': {
+		'.element-rich-link': {
 			minAboveSlot: 100,
 			minBelowSlot: 400,
 		},
-		':scope .element-image': {
+		'.element-image': {
 			minAboveSlot: 440,
 			minBelowSlot: 440,
 		},
 
-		':scope .player': {
+		'.player': {
 			minAboveSlot: 50,
 			minBelowSlot: 50,
 		},
@@ -43,11 +43,11 @@ const wideRules: SpacefinderRules = {
 			minAboveSlot: 50,
 			minBelowSlot: 50,
 		},
-		':scope .ad-slot': {
+		'.ad-slot': {
 			minAboveSlot: 100,
 			minBelowSlot: 100,
 		},
-		':scope .element-pullquote': {
+		'.element-pullquote': {
 			minAboveSlot: 400,
 			minBelowSlot: 400,
 		},
@@ -65,15 +65,15 @@ const desktopRules: SpacefinderRules = {
 	...wideRules,
 	opponentSelectorRules: {
 		...wideRules.opponentSelectorRules,
-		':scope .element-rich-link': {
+		'.element-rich-link': {
 			minAboveSlot: 400,
 			minBelowSlot: 400,
 		},
-		':scope .ad-slot': {
+		'.ad-slot': {
 			minAboveSlot: 400,
 			minBelowSlot: 400,
 		},
-		':scope .ad-slot--im': {
+		'.ad-slot--im': {
 			minAboveSlot: 400,
 			minBelowSlot: 400,
 		},


### PR DESCRIPTION
## What does this change?
`:scope` was introduced to spacefinder selectors in https://github.com/guardian/commercial/pull/1337, but some selectors were missed

## Why?
Consistency