### PR TITLE
Deeply read right ab test

### DIFF
--- a/.changeset/afraid-nails-speak.md
+++ b/.changeset/afraid-nails-speak.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Add Deeply Read 0% AB test

--- a/src/experiments/ab-tests.ts
+++ b/src/experiments/ab-tests.ts
@@ -1,5 +1,6 @@
 import type { ABTest } from '@guardian/ab-core';
 import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
+import { deeplyReadRightColumn } from './tests/deeply-read-right-column';
 
 /**
  * You only need to add tests to this file if the code you are testing is here in
@@ -9,4 +10,5 @@ import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
 export const concurrentTests: readonly ABTest[] = [
 	// one test per line
 	mpuWhenNoEpic,
+	deeplyReadRightColumn,
 ];

--- a/src/experiments/ab-tests.ts
+++ b/src/experiments/ab-tests.ts
@@ -1,6 +1,6 @@
 import type { ABTest } from '@guardian/ab-core';
-import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
 import { deeplyReadRightColumn } from './tests/deeply-read-right-column';
+import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
 
 /**
  * You only need to add tests to this file if the code you are testing is here in

--- a/src/experiments/tests/deeply-read-right-column.ts
+++ b/src/experiments/tests/deeply-read-right-column.ts
@@ -1,0 +1,35 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const deeplyReadRightColumn: ABTest = {
+	id: 'DeeplyReadRightColumn',
+	author: '@dotcom-platform',
+	start: '2024-04-30',
+	expiry: '2024-07-31',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: '',
+	successMeasure: 'Improved click though rate',
+	description:
+		'Test the impact of adding deeply read component to the right column.',
+	variants: [
+		{
+			id: 'most-viewed-only',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'deeply-read-and-most-viewed',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'deeply-read-only',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+	canRun: () => true,
+};

--- a/src/insert/spacefinder/article.ts
+++ b/src/insert/spacefinder/article.ts
@@ -27,6 +27,14 @@ import { isInHighValueSection } from './utils';
 
 type SlotName = Parameters<typeof createAdSlot>[0];
 
+/**
+ * As estimation of the height of the most viewed island.
+ * This appears from desktop breakpoints on the right-hand side.
+ * Knowing the height of the element is useful when
+ * calculating where to place ads in the right column.
+ */
+const MOST_VIEWED_HEIGHT = 600;
+
 const articleBodySelector = '.article-body-commercial-selector';
 
 const isPaidContent = window.guardian.config.page.isPaidContent;
@@ -214,17 +222,14 @@ const addDesktopInline1 = (fillSlot: FillAdSlot): Promise<boolean> => {
 const addDesktopRightRailAds = (fillSlot: FillAdSlot): Promise<boolean> => {
 	let minAbove = 1000;
 
-	if (isInDeeplyReadMostViewedVariant) {
-		minAbove += 650;
-	}
-
 	/**
 	 * In special cases, inline2 can overlap the "Most viewed" island, so
-	 * we need to make an adjustment to move the inline2 further down the page.
+	 * we need to make an adjustment to move the inline2 further down page
 	 */
-	if (isPaidContent) {
-		minAbove += 600;
+	if (isInDeeplyReadMostViewedVariant || isPaidContent) {
+		minAbove += MOST_VIEWED_HEIGHT;
 	}
+
 	// Some old articles don't have a main image, which means the first paragraph is much higher
 	if (!hasImages) {
 		minAbove += 600;

--- a/src/insert/spacefinder/article.ts
+++ b/src/insert/spacefinder/article.ts
@@ -224,7 +224,7 @@ const addDesktopRightRailAds = (fillSlot: FillAdSlot): Promise<boolean> => {
 
 	/**
 	 * In special cases, inline2 can overlap the "Most viewed" island, so
-	 * we need to make an adjustment to move the inline2 further down page
+	 * we need to make an adjustment to move the inline2 further down the page
 	 */
 	if (isInDeeplyReadMostViewedVariant || isPaidContent) {
 		minAbove += MOST_VIEWED_HEIGHT;

--- a/src/insert/spacefinder/article.ts
+++ b/src/insert/spacefinder/article.ts
@@ -212,7 +212,11 @@ const addDesktopInline1 = (fillSlot: FillAdSlot): Promise<boolean> => {
  * Inserts all inline ads on desktop except for inline1.
  */
 const addDesktopRightRailAds = (fillSlot: FillAdSlot): Promise<boolean> => {
-	let minAbove = isInDeeplyReadMostViewedVariant ? 1650 : 1000;
+	let minAbove = 1000;
+
+	if (isInDeeplyReadMostViewedVariant) {
+		minAbove += 650;
+	}
 
 	/**
 	 * In special cases, inline2 can overlap the "Most viewed" island, so

--- a/src/insert/spacefinder/article.ts
+++ b/src/insert/spacefinder/article.ts
@@ -17,6 +17,8 @@ import {
 	getCurrentBreakpoint,
 	getCurrentTweakpoint,
 } from 'lib/detect/detect-breakpoint';
+import { isInVariantSynchronous } from '../../experiments/ab';
+import { deeplyReadRightColumn } from '../../experiments/tests/deeply-read-right-column';
 import { waitForAdvert } from '../../lib/dfp/wait-for-advert';
 import fastdom from '../../utils/fastdom-promise';
 import { computeStickyHeights, insertHeightStyles } from '../sticky-inlines';
@@ -33,6 +35,11 @@ const hasImages = !!window.guardian.config.page.lightboxImages?.images.length;
 
 const hasShowcaseMainElement =
 	window.guardian.config.page.hasShowcaseMainElement;
+
+const isInDeeplyReadMostViewedVariant = isInVariantSynchronous(
+	deeplyReadRightColumn,
+	'deeply-read-and-most-viewed',
+);
 
 const minDistanceBetweenRightRailAds = 500;
 const minDistanceBetweenInlineAds = isInHighValueSection ? 500 : 750;
@@ -205,7 +212,7 @@ const addDesktopInline1 = (fillSlot: FillAdSlot): Promise<boolean> => {
  * Inserts all inline ads on desktop except for inline1.
  */
 const addDesktopRightRailAds = (fillSlot: FillAdSlot): Promise<boolean> => {
-	let minAbove = 1000;
+	let minAbove = isInDeeplyReadMostViewedVariant ? 1650 : 1000;
 
 	/**
 	 * In special cases, inline2 can overlap the "Most viewed" island, so


### PR DESCRIPTION

<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Adds 650px to top of desktopRightRailAds when in deeplyReadMostViewed test variant
## Why?
Corresponding change to DCR (pr https://github.com/guardian/dotcom-rendering/pull/11299)
Frontend (pr https://github.com/guardian/frontend/pull/27084)
