### PR TITLE
Add `didDisplayAdBlockAsk` to event timer properties

### DIFF
--- a/.changeset/spicy-readers-return.md
+++ b/.changeset/spicy-readers-return.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Add didDisplayAdBlockAsk to event timer properties

--- a/src/core/event-timer.ts
+++ b/src/core/event-timer.ts
@@ -24,7 +24,7 @@ interface EventTimerProperties {
 	 * future _could_ be removed in favour of this property */
 	detectedAdBlocker?: boolean;
 	/** Record whether we've shown the adblock as message */
- 	didDisplayAdBlockAsk?: boolean;
+	didDisplayAdBlockAsk?: boolean;
 	/** creative ID of a video interscroller for video reporting metrics */
 	videoInterscrollerCreativeId?: number | null | undefined;
 	/** percentage progress of video interscroller on page unload */

--- a/src/core/event-timer.ts
+++ b/src/core/event-timer.ts
@@ -23,6 +23,8 @@ interface EventTimerProperties {
 	 * distinct from the property we pass into commercial metrics, and in the
 	 * future _could_ be removed in favour of this property */
 	detectedAdBlocker?: boolean;
+	/** Record whether we've shown the adblock as message */
+ 	didDisplayAdBlockAsk?: boolean;
 	/** creative ID of a video interscroller for video reporting metrics */
 	videoInterscrollerCreativeId?: number | null | undefined;
 	/** percentage progress of video interscroller on page unload */


### PR DESCRIPTION
## What does this change?
Add `didDisplayAdBlockAsk` to event timer properties

## Why?
Not every time we've detected an ad blocker will we show the ad block ask message, so add this prop to record it separately.