### PR TITLE
Spacefinder handle opponents/candidates overlapping

### DIFF
--- a/.changeset/itchy-cows-relate.md
+++ b/.changeset/itchy-cows-relate.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Spacefinder - Handle opponents/candidates overlapping

--- a/playwright/tests/front-inline-slots.spec.ts
+++ b/playwright/tests/front-inline-slots.spec.ts
@@ -15,7 +15,8 @@ test.describe('Slots and iframes load on fronts pages', () => {
 	});
 });
 
-test.describe('Slots and iframes load on tag pages', () => {
+// currently no banners on tag fronts
+test.skip('Slots and iframes load on tag pages', () => {
 	tagPages.forEach(({ path }) => {
 		test(`fronts-banner ads are loaded on ${path}`, async ({ page }) => {
 			await loadPage(page, path);

--- a/src/insert/spacefinder/article.ts
+++ b/src/insert/spacefinder/article.ts
@@ -171,7 +171,7 @@ const addDesktopInline1 = (fillSlot: FillAdSlot): Promise<boolean> => {
 				minBelowSlot: 600,
 			},
 			'figure.element--supporting': {
-				minAboveSlot: 500,
+				minAboveSlot: 100,
 				minBelowSlot: 0,
 			},
 		},

--- a/src/insert/spacefinder/spacefinder-debug-tools.ts
+++ b/src/insert/spacefinder/spacefinder-debug-tools.ts
@@ -58,6 +58,10 @@ const exclusionTypes = {
 		colour: colours.blue,
 		reason: 'Too close to other element',
 	},
+	overlaps: {
+		colour: colours.blue,
+		reason: 'Overlaps other element',
+	},
 } as const;
 
 const isExclusionType = (type: string): type is keyof typeof exclusionTypes =>
@@ -72,7 +76,9 @@ const addOverlay = (element: HTMLElement, text: string) => {
 
 const addHoverListener = (
 	candidate: HTMLElement,
-	tooClose: Exclude<SpacefinderItem['meta'], undefined>['tooClose'],
+	tooClose: Exclude<SpacefinderItem['meta'], undefined>[
+		| 'tooClose'
+		| 'overlaps'],
 	pass: SpacefinderPass,
 ) => {
 	tooClose.forEach((opponent) => {
@@ -100,10 +106,12 @@ const addHoverListener = (
 			}
 
 			opponent.element.classList.add('blocking-element');
-			addOverlay(
-				opponent.element,
-				`${opponent.actual}px/${opponent.required}px`,
-			);
+			if (opponent.actual && opponent.required) {
+				addOverlay(
+					opponent.element,
+					`${opponent.actual}px/${opponent.required}px`,
+				);
+			}
 		});
 
 		candidate.addEventListener('mouseleave', () => {
@@ -138,6 +146,9 @@ const annotateExclusions = (
 				element.setAttribute(`data-sfdebug-${pass}`, 'isStartAt');
 			} else if (type) {
 				element.setAttribute(`data-sfdebug-${pass}`, key);
+			} else if (meta && meta.overlaps.length > 0) {
+				element.setAttribute(`data-sfdebug-${pass}`, 'overlaps');
+				addHoverListener(element, meta.overlaps, pass);
 			} else if (meta && meta.tooClose.length > 0) {
 				element.setAttribute(`data-sfdebug-${pass}`, 'tooClose');
 				addHoverListener(element, meta.tooClose, pass);

--- a/src/insert/spacefinder/spacefinder.ts
+++ b/src/insert/spacefinder/spacefinder.ts
@@ -234,24 +234,6 @@ const partitionCandidates = <T>(
 	return [filtered, exclusions];
 };
 
-const opponentPositionRelativeToCandidate = (
-	candidate: SpacefinderItem,
-	opponent: SpacefinderItem,
-): 'above' | 'below' | 'surrounding' | 'surrounded' => {
-	if (opponent.bottom < candidate.top) {
-		return 'above';
-	}
-	if (opponent.top < candidate.bottom) {
-		return 'below';
-	}
-
-	if (opponent.top < candidate.top && opponent.bottom > candidate.bottom) {
-		return 'surrounding';
-	}
-
-	return 'surrounded';
-};
-
 /**
  * Check if the top of the candidate is far enough from the opponent
  *


### PR DESCRIPTION
## What does this change?
Handle where spacefinder candidates/opponents overlap each other by improving the check for opponents being below - to also a check that `opponent.top` is below `candidate.bottom` and handling when opponents/candidates are adjacent/overlapping.

I suspect this may be happening now due to #1271 which fixed some bugs in the `testCandidate` code, there's a rule [here](https://github.com/guardian/commercial/pull/1377/files#diff-40044f4d0100808638e7ed46790f93dbaff168485b9043e4a6bacb4df4578ae6L174) that set a 500px margin for interactives that I think was a "hack" that worked with the old `testCandidate` but not the new one.

With this change spacefinder can now handle a bit more gracefully this edge case and can remove the "hack" setting the margin to a more reasonable 100px.

Also updated spacefinder debugger to display when it's overlapping like this.

## Why?
The code currently considers any opponent that satisfies `opponent.bottom > candidate.bottom` to be below the candidate and anything that doesn't to be above.

This doesn't account for opponents that are not above or below but adjacent/overlapping:
![Untitled-2023-02-24-1349](https://github.com/guardian/commercial/assets/1731150/6fa493b1-004d-40ef-bd88-b45e6fe328df)


