### PR TITLE
use fetch to send commercial metrics

### DIFF
--- a/.changeset/lovely-zoos-wink.md
+++ b/.changeset/lovely-zoos-wink.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Use fetch instead of sendBeacon for commercial metrics

--- a/src/core/send-commercial-metrics.spec.ts
+++ b/src/core/send-commercial-metrics.spec.ts
@@ -47,6 +47,14 @@ const defaultMetrics = {
 	],
 };
 
+const expectedOptions = {
+	method: 'POST',
+	body: JSON.stringify(defaultMetrics),
+	keepalive: true,
+	cache: 'no-store',
+	mode: 'no-cors',
+};
+
 const tcfv2AllConsent: ConsentState = {
 	tcfv2: {
 		consents: {
@@ -124,7 +132,7 @@ afterEach(() => {
 });
 
 describe('send commercial metrics', () => {
-	Object.defineProperty(navigator, 'sendBeacon', {
+	Object.defineProperty(window, 'fetch', {
 		configurable: true,
 		enumerable: true,
 		value: jest.fn(),
@@ -147,8 +155,8 @@ describe('send commercial metrics', () => {
 		setVisibility('hidden');
 		global.dispatchEvent(new Event('visibilitychange'));
 
-		expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
-			[Endpoints.PROD, JSON.stringify(defaultMetrics)],
+		expect((window.fetch as jest.Mock).mock.calls).toEqual([
+			[Endpoints.PROD, expectedOptions],
 		]);
 	});
 
@@ -166,7 +174,7 @@ describe('send commercial metrics', () => {
 		setVisibility('visible');
 		global.dispatchEvent(new Event('visibilitychange'));
 
-		expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([]);
+		expect((window.fetch as jest.Mock).mock.calls).toEqual([]);
 	});
 
 	it('does not send metrics when user is not in sampling group', async () => {
@@ -183,7 +191,7 @@ describe('send commercial metrics', () => {
 		setVisibility('hidden');
 		global.dispatchEvent(new Event('visibilitychange'));
 
-		expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([]);
+		expect((window.fetch as jest.Mock).mock.calls).toEqual([]);
 	});
 
 	it('does not send metrics when consent does not include purpose 8', async () => {
@@ -200,7 +208,7 @@ describe('send commercial metrics', () => {
 		setVisibility('hidden');
 		global.dispatchEvent(new Event('visibilitychange'));
 
-		expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([]);
+		expect((window.fetch as jest.Mock).mock.calls).toEqual([]);
 	});
 
 	it('sends metrics when non-TCFv2 user (i.e. USA or Australia) consents', async () => {
@@ -217,8 +225,8 @@ describe('send commercial metrics', () => {
 		setVisibility('hidden');
 		global.dispatchEvent(new Event('visibilitychange'));
 
-		expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
-			[Endpoints.PROD, JSON.stringify(defaultMetrics)],
+		expect((window.fetch as jest.Mock).mock.calls).toEqual([
+			[Endpoints.PROD, expectedOptions],
 		]);
 	});
 
@@ -236,8 +244,8 @@ describe('send commercial metrics', () => {
 		setVisibility('hidden');
 		global.dispatchEvent(new Event('visibilitychange'));
 
-		expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
-			[Endpoints.PROD, JSON.stringify(defaultMetrics)],
+		expect((window.fetch as jest.Mock).mock.calls).toEqual([
+			[Endpoints.PROD, expectedOptions],
 		]);
 	});
 
@@ -280,8 +288,8 @@ describe('send commercial metrics', () => {
 			setVisibility('hidden');
 			global.dispatchEvent(new Event('visibilitychange'));
 
-			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
-				[Endpoints.PROD, JSON.stringify(defaultMetrics)],
+			expect((window.fetch as jest.Mock).mock.calls).toEqual([
+				[Endpoints.PROD, expectedOptions],
 			]);
 		});
 
@@ -300,7 +308,7 @@ describe('send commercial metrics', () => {
 			setVisibility('hidden');
 			global.dispatchEvent(new Event('visibilitychange'));
 
-			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([]);
+			expect((window.fetch as jest.Mock).mock.calls).toEqual([]);
 		});
 
 		it('expects to be initialised before calling bypassCoreWebVitalsSampling', async () => {
@@ -333,16 +341,22 @@ describe('send commercial metrics', () => {
 			setVisibility('hidden');
 			global.dispatchEvent(new Event('visibilitychange'));
 
-			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
+			expect((window.fetch as jest.Mock).mock.calls).toEqual([
 				[
 					Endpoints.CODE,
-					JSON.stringify({
-						...defaultMetrics,
-						properties: [
-							{ name: 'isDev', value: 'testurl.theguardian.com' },
-							{ name: 'adBlockerInUse', value: 'false' },
-						],
-					}),
+					{
+						...expectedOptions,
+						body: JSON.stringify({
+							...defaultMetrics,
+							properties: [
+								{
+									name: 'isDev',
+									value: 'testurl.theguardian.com',
+								},
+								{ name: 'adBlockerInUse', value: 'false' },
+							],
+						}),
+					},
 				],
 			]);
 		});
@@ -368,17 +382,20 @@ describe('send commercial metrics', () => {
 			setVisibility('hidden');
 			global.dispatchEvent(new Event('visibilitychange'));
 
-			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
+			expect((window.fetch as jest.Mock).mock.calls).toEqual([
 				[
 					Endpoints.PROD,
-					JSON.stringify({
-						...defaultMetrics,
-						properties: [
-							{ name: 'downlink', value: '1' },
-							{ name: 'effectiveType', value: '4g' },
-							{ name: 'adBlockerInUse', value: 'false' },
-						],
-					}),
+					{
+						...expectedOptions,
+						body: JSON.stringify({
+							...defaultMetrics,
+							properties: [
+								{ name: 'downlink', value: '1' },
+								{ name: 'effectiveType', value: '4g' },
+								{ name: 'adBlockerInUse', value: 'false' },
+							],
+						}),
+					},
 				],
 			]);
 		});
@@ -404,18 +421,24 @@ describe('send commercial metrics', () => {
 			setVisibility('hidden');
 			global.dispatchEvent(new Event('pagehide'));
 
-			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
+			expect((window.fetch as jest.Mock).mock.calls).toEqual([
 				[
 					Endpoints.CODE,
-					JSON.stringify({
-						...defaultMetrics,
-						properties: [
-							{ name: 'downlink', value: '1' },
-							{ name: 'effectiveType', value: '4g' },
-							{ name: 'isDev', value: 'testurl.theguardian.com' },
-							{ name: 'adBlockerInUse', value: 'false' },
-						],
-					}),
+					{
+						...expectedOptions,
+						body: JSON.stringify({
+							...defaultMetrics,
+							properties: [
+								{ name: 'downlink', value: '1' },
+								{ name: 'effectiveType', value: '4g' },
+								{
+									name: 'isDev',
+									value: 'testurl.theguardian.com',
+								},
+								{ name: 'adBlockerInUse', value: 'false' },
+							],
+						}),
+					},
 				],
 			]);
 		});
@@ -467,17 +490,23 @@ describe('send commercial metrics', () => {
 			setVisibility('hidden');
 			global.dispatchEvent(new Event('pagehide'));
 
-			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
+			expect((window.fetch as jest.Mock).mock.calls).toEqual([
 				[
 					Endpoints.CODE,
-					JSON.stringify({
-						...defaultMetrics,
-						properties: [
-							{ name: 'downlink', value: '1' },
-							{ name: 'effectiveType', value: '4g' },
-							{ name: 'isDev', value: 'testurl.theguardian.com' },
-						],
-					}),
+					{
+						...expectedOptions,
+						body: JSON.stringify({
+							...defaultMetrics,
+							properties: [
+								{ name: 'downlink', value: '1' },
+								{ name: 'effectiveType', value: '4g' },
+								{
+									name: 'isDev',
+									value: 'testurl.theguardian.com',
+								},
+							],
+						}),
+					},
 				],
 			]);
 		});
@@ -498,17 +527,23 @@ describe('send commercial metrics', () => {
 			setVisibility('hidden');
 			global.dispatchEvent(new Event('pagehide'));
 
-			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
+			expect((window.fetch as jest.Mock).mock.calls).toEqual([
 				[
 					Endpoints.CODE,
-					JSON.stringify({
-						...defaultMetrics,
-						properties: [
-							{ name: 'adSlotsInline', value: '5' },
-							{ name: 'adSlotsTotal', value: '10' },
-							{ name: 'isDev', value: 'testurl.theguardian.com' },
-						],
-					}),
+					{
+						...expectedOptions,
+						body: JSON.stringify({
+							...defaultMetrics,
+							properties: [
+								{ name: 'adSlotsInline', value: '5' },
+								{ name: 'adSlotsTotal', value: '10' },
+								{
+									name: 'isDev',
+									value: 'testurl.theguardian.com',
+								},
+							],
+						}),
+					},
 				],
 			]);
 		});
@@ -531,13 +566,16 @@ describe('send commercial metrics', () => {
 			setVisibility('hidden');
 			global.dispatchEvent(new Event('pagehide'));
 
-			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
+			expect((window.fetch as jest.Mock).mock.calls).toEqual([
 				[
 					Endpoints.PROD,
-					JSON.stringify({
-						...defaultMetrics,
-						metrics: [{ name: 'offlineCount', value: 3 }],
-					}),
+					{
+						...expectedOptions,
+						body: JSON.stringify({
+							...defaultMetrics,
+							metrics: [{ name: 'offlineCount', value: 3 }],
+						}),
+					},
 				],
 			]);
 		});
@@ -558,13 +596,16 @@ describe('send commercial metrics', () => {
 			setVisibility('hidden');
 			global.dispatchEvent(new Event('pagehide'));
 
-			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
+			expect((window.fetch as jest.Mock).mock.calls).toEqual([
 				[
 					Endpoints.PROD,
-					JSON.stringify({
-						...defaultMetrics,
-						metrics: [{ name: 'offlineCount', value: 0 }],
-					}),
+					{
+						...expectedOptions,
+						body: JSON.stringify({
+							...defaultMetrics,
+							metrics: [{ name: 'offlineCount', value: 0 }],
+						}),
+					},
 				],
 			]);
 		});
@@ -585,13 +626,16 @@ describe('send commercial metrics', () => {
 			setVisibility('hidden');
 			global.dispatchEvent(new Event('pagehide'));
 
-			expect((navigator.sendBeacon as jest.Mock).mock.calls).toEqual([
+			expect((window.fetch as jest.Mock).mock.calls).toEqual([
 				[
 					Endpoints.PROD,
-					JSON.stringify({
-						...defaultMetrics,
-						metrics: [],
-					}),
+					{
+						...expectedOptions,
+						body: JSON.stringify({
+							...defaultMetrics,
+							metrics: [],
+						}),
+					},
 				],
 			]);
 		});

--- a/src/core/send-commercial-metrics.ts
+++ b/src/core/send-commercial-metrics.ts
@@ -115,10 +115,13 @@ function sendMetrics() {
 		commercialMetricsPayload,
 	);
 
-	return navigator.sendBeacon(
-		endpoint,
-		JSON.stringify(commercialMetricsPayload),
-	);
+	void fetch(endpoint, {
+		method: 'POST',
+		body: JSON.stringify(commercialMetricsPayload),
+		keepalive: true,
+		cache: 'no-store',
+		mode: 'no-cors',
+	});
 }
 
 type ArrayMetric = [key: string, value: string | number];


### PR DESCRIPTION
## What does this change?
replace `sendBeacon` with fetch for sending commercial metrics

## Why?
fetch should be more reliable than `sendBeacon`

Upon testing `fetch` will go through on the occasions that `sendBeacon` is blocked.

@emma-imber also [did some testing on this](https://github.com/guardian/commercial/pull/888) a while back and determined `fetch` to be more reliable.

