### PR TITLE
Increase spacefinder mobile minAbove distance by 100px

### DIFF
--- a/.changeset/sour-peas-train.md
+++ b/.changeset/sour-peas-train.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Increase spacefinder minAbove distance by 100px

--- a/src/insert/spacefinder/article.ts
+++ b/src/insert/spacefinder/article.ts
@@ -322,7 +322,7 @@ const addDesktopRightRailAds = (fillSlot: FillAdSlot): Promise<boolean> => {
 };
 
 const addMobileInlineAds = (fillSlot: FillAdSlot): Promise<boolean> => {
-	const minDistanceFromArticleTop = 100;
+	const minDistanceFromArticleTop = 200;
 
 	const ignoreList = `:not(p):not(h2):not(hr):not(.${adSlotContainerClass}):not(#sign-in-gate):not([data-spacefinder-type$="NumberedTitleBlockElement"])`;
 


### PR DESCRIPTION
## Move the first mobile ad down the article slightly

## Why?
The current rule specifies the first ad can appear 100px from the top of the article. This means that sometimes the first ad appears after the opening sentence/paragraph, and this has raised concerns within the editorial team. 

Increasing the rule to 200px should mean that the at least a couple of sentences are included before the first ad on mobile.

Testing suggests the issue is not as common on desktop (where the rule is 300px).