### PR TITLE
Increase spacefinder mobile minAbove distance to 250px

### DIFF
--- a/.changeset/green-clouds-hammer.md
+++ b/.changeset/green-clouds-hammer.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Increase spacefinder mobile minAbove distance to 250px

--- a/src/insert/spacefinder/article.ts
+++ b/src/insert/spacefinder/article.ts
@@ -322,7 +322,7 @@ const addDesktopRightRailAds = (fillSlot: FillAdSlot): Promise<boolean> => {
 };
 
 const addMobileInlineAds = (fillSlot: FillAdSlot): Promise<boolean> => {
-	const minDistanceFromArticleTop = 200;
+	const minDistanceFromArticleTop = 250;
 
 	const ignoreList = `:not(p):not(h2):not(hr):not(.${adSlotContainerClass}):not(#sign-in-gate):not([data-spacefinder-type$="NumberedTitleBlockElement"])`;
 


### PR DESCRIPTION
## What does this change?

Increase spacefinder mobile minAbove distance to 250px

Tweak to #1384 

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://github.com/guardian/commercial/assets/7014230/bda2336c-59a6-4956-8518-761fd395bb55
[after]: https://github.com/guardian/commercial/assets/7014230/a81344e3-e630-4ca2-95eb-224d637e818c



