### PR TITLE
Check that innerHeight is greater than 0

### DIFF
--- a/.changeset/shiny-moons-jam.md
+++ b/.changeset/shiny-moons-jam.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Resolve bug for new tabs on Firefox on Android

--- a/src/core/track-scroll-depth.ts
+++ b/src/core/track-scroll-depth.ts
@@ -10,35 +10,43 @@ import { EventTimer } from './event-timer';
 const initTrackScrollDepth = () => {
 	const pageHeight = document.body.offsetHeight;
 	const intViewportHeight = window.innerHeight;
-	// how many viewports tall is the page?
-	const pageHeightVH = Math.floor(pageHeight / intViewportHeight);
-	const eventTimer = EventTimer.get();
-	eventTimer.setProperty('pageHeightVH', pageHeightVH);
 
-	const observer = new IntersectionObserver(
-		/* istanbul ignore next */
-		(entries) => {
-			entries.forEach((entry) => {
-				if (entry.isIntersecting) {
-					const currentDepthVH = String(
-						entry.target.getAttribute('data-depth'),
-					);
-					log('commercial', `current scroll depth ${currentDepthVH}`);
-					eventTimer.mark(`scroll-depth-vh-${currentDepthVH}`);
-					observer.unobserve(entry.target);
-				}
-			});
-		},
-	);
+	// this if statement is here to handle a bug in Firefox in Android where the innerHeight
+	// of a new tab can be 0, so we end up dividing by 0 and looping through infinity
+	if (intViewportHeight > 0) {
+		// how many viewports tall is the page?
+		const pageHeightVH = Math.floor(pageHeight / intViewportHeight);
+		const eventTimer = EventTimer.get();
+		eventTimer.setProperty('pageHeightVH', pageHeightVH);
 
-	for (let depth = 1; depth <= pageHeightVH; depth++) {
-		const div = document.createElement('div');
-		div.dataset.depth = String(depth);
-		div.style.top = String(100 * depth) + '%';
-		div.style.position = 'absolute';
-		div.className = 'scroll-depth-marker';
-		document.body.appendChild(div);
-		observer.observe(div);
+		const observer = new IntersectionObserver(
+			/* istanbul ignore next */
+			(entries) => {
+				entries.forEach((entry) => {
+					if (entry.isIntersecting) {
+						const currentDepthVH = String(
+							entry.target.getAttribute('data-depth'),
+						);
+						log(
+							'commercial',
+							`current scroll depth ${currentDepthVH}`,
+						);
+						eventTimer.mark(`scroll-depth-vh-${currentDepthVH}`);
+						observer.unobserve(entry.target);
+					}
+				});
+			},
+		);
+
+		for (let depth = 1; depth <= pageHeightVH; depth++) {
+			const div = document.createElement('div');
+			div.dataset.depth = String(depth);
+			div.style.top = String(100 * depth) + '%';
+			div.style.position = 'absolute';
+			div.className = 'scroll-depth-marker';
+			document.body.appendChild(div);
+			observer.observe(div);
+		}
 	}
 };
 


### PR DESCRIPTION
## What does this change?
Checks that `window.innerHeight` is more than 0 before we then divide by that value and loop through infinity. Dividing by 0 is not a thing we want to do!

## Why?
There's a bug on Firefox for Android where the `window.innerHeight` for a new tab can be 0, which means we end up looping through infinity which can crash the page. See issue here: https://github.com/guardian/commercial/issues/1388