### PR TITLE
Only play the video interscroller when it's in the viewport

### DIFF
--- a/.changeset/selfish-buses-press.md
+++ b/.changeset/selfish-buses-press.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Only play interscroller video ad when ad is in the viewport

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -251,9 +251,9 @@ const setupBackground = async (
 					(entries) => {
 						entries.forEach((entry) => {
 							if (entry.isIntersecting && !played) {
-								void video.play();
+								video.paused && void video.play();
 							} else {
-								video.pause();
+								!video.paused && video.pause();
 							}
 						});
 					},

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -244,6 +244,25 @@ const setupBackground = async (
 					return undefined;
 				};
 
+				let played = false;
+				video.onended = () => (played = true);
+
+				const observer = new IntersectionObserver(
+					(entries) => {
+						entries.forEach((entry) => {
+							const intersecting = entry.isIntersecting;
+							if (intersecting && !played) {
+								void video.play();
+							} else {
+								video.pause();
+							}
+						});
+					},
+					{ threshold: 0.2 },
+				);
+
+				observer.observe(video);
+
 				EventTimer.get().setProperty(
 					'videoInterscrollerCreativeId',
 					getCreativeId(),

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -250,18 +250,17 @@ const setupBackground = async (
 				const observer = new IntersectionObserver(
 					(entries) => {
 						entries.forEach((entry) => {
-							const intersecting = entry.isIntersecting;
-							if (intersecting && !played) {
+							if (entry.isIntersecting && !played) {
 								void video.play();
 							} else {
 								video.pause();
 							}
 						});
 					},
-					{ threshold: 0.2 },
+					{ root: null, rootMargin: '0px', threshold: 0.2 },
 				);
 
-				observer.observe(video);
+				observer.observe(backgroundParent);
 
 				EventTimer.get().setProperty(
 					'videoInterscrollerCreativeId',


### PR DESCRIPTION
## What does this change?
Uses an intersection observer to play the video interscroller when it's in the viewport, and pause it when it isn't. This is the default behaviour on Chrome on Android, but not on other browsers.

## Why?
This replicates the behaviour of the fabric video ad, and should improve the accuracy of the video progress data we've been seeing.

## Videos
### Before - on Safari
Video does not pause when we scroll away from the ad.

https://github.com/guardian/commercial/assets/108270776/dad6c0cb-059b-4a0e-8c69-ea28f00d10ff

### After - on Safari
Video does pause when we scroll away from the ad.

https://github.com/guardian/commercial/assets/108270776/c5e85c9f-94f6-4301-8b9c-888f6288513e

