### PR TITLE
Bypass metrics sampling for video interscroller progress data

### DIFF
--- a/.changeset/shaggy-shoes-sniff.md
+++ b/.changeset/shaggy-shoes-sniff.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Bypass metrics sampling for video interscroller

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -1,6 +1,7 @@
 import { isObject } from '@guardian/libs';
 import { EventTimer } from 'core/event-timer';
 import type { RegisterListener } from 'core/messenger';
+import { bypassCommercialMetricsSampling } from 'core/send-commercial-metrics';
 import fastdom from 'utils/fastdom-promise';
 import {
 	renderAdvertLabel,
@@ -266,6 +267,8 @@ const setupBackground = async (
 					'videoInterscrollerCreativeId',
 					getCreativeId(),
 				);
+
+				void bypassCommercialMetricsSampling();
 
 				video.ontimeupdate = function () {
 					const percent = Math.round(


### PR DESCRIPTION
## What does this change?
Bypasses the commercial metrics sampling for the video interscroller progress reporting.

## Why?
We want to get progress data for all video interscroller ads, not 1% of them.