### PR TITLE
Add 300x50 ad size to mobile-sticky

### DIFF
--- a/.changeset/swift-bears-eat.md
+++ b/.changeset/swift-bears-eat.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Adds 300x50 ad size to mobile-sticky

--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -389,7 +389,7 @@ const slotSizeMappings = {
 		mobile: [adSizes.fluid],
 	},
 	'mobile-sticky': {
-		mobile: [adSizes.mobilesticky, adSizes.empty],
+		mobile: [adSizes.mobilesticky, adSizes.empty, createAdSize(300, 50)],
 	},
 	'crossword-banner-mobile': {
 		mobile: [adSizes.mobilesticky],


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This enables a new ad size 300x50 to `mobile-sticky`.

I tested in CODE and using a VPN to be in a region that has a `mobile-sticky` slot. Here is a screenshot from `googletag.openConsole()` with the new size.

![image](https://github.com/guardian/commercial/assets/23424805/77e5a5b7-7a85-4b74-b52f-3ea4bc23b36b)


## Why?

This request was made by AdOps which will give us the opportunity to serve creatives in smaller size. 

