### PR TITLE
Add 300x50 size to Prebid for `mobile-sticky`

### DIFF
--- a/.changeset/orange-apes-behave.md
+++ b/.changeset/orange-apes-behave.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Adds 300x50 ad size to Prebid for mobile-sticky

--- a/src/lib/header-bidding/slot-config.spec.ts
+++ b/src/lib/header-bidding/slot-config.spec.ts
@@ -119,7 +119,7 @@ describe('getPrebidAdSlots', () => {
 		).toEqual([
 			{
 				key: 'mobile-sticky',
-				sizes: [createAdSize(320, 50)],
+				sizes: [createAdSize(320, 50), createAdSize(300, 50)],
 			},
 		]);
 	});

--- a/src/lib/header-bidding/slot-config.ts
+++ b/src/lib/header-bidding/slot-config.ts
@@ -188,7 +188,9 @@ const getSlots = (): HeaderBiddingSizeMapping => {
 			],
 		},
 		'mobile-sticky': {
-			mobile: shouldIncludeMobileSticky() ? [adSizes.mobilesticky] : [],
+			mobile: shouldIncludeMobileSticky()
+				? [adSizes.mobilesticky, createAdSize(300, 50)]
+				: [],
 		},
 		'crossword-banner': {
 			desktop: isCrossword ? [adSizes.leaderboard] : [],


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR adds 300x50 ad size to Prebid for `mobile-sticky`. It's part of the work done in https://github.com/guardian/commercial/pull/1403

## Why?

We can use Prebid for the new size in `mobile-sticky` slot.
