### PR TITLE
Only import sf debug tools if sfdebug url param is present

### DIFF
--- a/.changeset/loud-cameras-learn.md
+++ b/.changeset/loud-cameras-learn.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Only import spacefinder debug tools when the sfdebug url param is present

--- a/src/insert/spacefinder/spacefinder-debug-tools.ts
+++ b/src/insert/spacefinder/spacefinder-debug-tools.ts
@@ -1,5 +1,4 @@
 import { log } from '@guardian/libs';
-import { getUrlVars } from 'utils/url';
 import type {
 	SpacefinderExclusions,
 	SpacefinderItem,
@@ -7,8 +6,6 @@ import type {
 	SpacefinderRules,
 } from './spacefinder';
 import logo from './spacefinder-logo.svg';
-
-const enableDebug = !!getUrlVars().sfdebug;
 
 const isCurrentPass = (pass: SpacefinderPass) => {
 	const sfdebugPass = document.querySelector<HTMLInputElement>(
@@ -418,8 +415,6 @@ const init = (
 	rules: SpacefinderRules,
 	pass: SpacefinderPass,
 ): void => {
-	if (!enableDebug) return;
-
 	addDebugPanel();
 	annotate(exclusions, winners, rules, pass);
 	addPassToDebugPanel(pass);

--- a/src/insert/spacefinder/spacefinder.ts
+++ b/src/insert/spacefinder/spacefinder.ts
@@ -594,8 +594,9 @@ const findSpace = async (
 	const enableDebug = !!getUrlVars().sfdebug;
 
 	if (enableDebug) {
-		void import('./spacefinder-debug-tools').then((debugTools) => {
-			debugTools.init(exclusions, winners, rules, options.pass);
+		const pass = options.pass;
+		void import('./spacefinder-debug-tools').then(({ init }) => {
+			init(exclusions, winners, rules, pass);
 		});
 	}
 

--- a/src/insert/spacefinder/spacefinder.ts
+++ b/src/insert/spacefinder/spacefinder.ts
@@ -3,7 +3,7 @@
 import { log } from '@guardian/libs';
 import { memoize } from 'lodash-es';
 import fastdom from 'utils/fastdom-promise';
-import { init as initSpacefinderDebugger } from './spacefinder-debug-tools';
+import { getUrlVars } from 'utils/url';
 
 type RuleSpacing = {
 	/**
@@ -591,7 +591,13 @@ const findSpace = async (
 	const measurements = await getMeasurements(rules, candidates);
 	const winners = enforceRules(measurements, rules, exclusions);
 
-	initSpacefinderDebugger(exclusions, winners, rules, options.pass);
+	const enableDebug = !!getUrlVars().sfdebug;
+
+	if (enableDebug) {
+		void import('./spacefinder-debug-tools').then((debugTools) => {
+			debugTools.init(exclusions, winners, rules, options.pass);
+		});
+	}
 
 	window.performance.mark('commercial:spacefinder:findSpace:end');
 


### PR DESCRIPTION
## What does this change?
Moves the check for the `?sfdebug` url param to be before the debug tools are imported. This allows us to only import the debug tools if someone wants to run debug mode.

## Why?
At the moment, we import the 6kb of code needed for spacefinder debug mode for all users. By selectively importing when the `?sfedebug` param is present, we can ship less javascript to users.

