### PR TITLE
Add test to compare sendBeacon and fetch numbers for users with no ad blocker

### DIFF
--- a/.changeset/big-pens-agree.md
+++ b/.changeset/big-pens-agree.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Add sendBeacon test to messenger code

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -198,12 +198,12 @@ const setupBackground = async (
 
 	if (shouldTestBeacon) {
 		const beaconEvent = {
-			label: 'commercial.amiused.test_send_beacon',
+			label: 'commercial.test_send_beacon',
 			properties: [{ name: 'userAgent', value: navigator.userAgent }],
 		};
 
 		const fetchEvent = {
-			label: 'commercial.amiused.test_fetch',
+			label: 'commercial.test_fetch',
 			properties: [{ name: 'userAgent', value: navigator.userAgent }],
 		};
 

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -184,6 +184,38 @@ const setupBackground = async (
 		specs.scrollType,
 	);
 
+	/* We're sending both sendBeacon and fetch messages here to test if we receive the same numbers of each.
+	Our hypothesis is that sendBeacon is less reliable because it gets blocked by some ad blockers. This messenger
+	code only fires if a template ad (eg fabric or interscroller) is present on the page and sends a message. This
+	means we can control for ad blockers, as there should be no ad blocker present if we reach this code. So if
+	our hypothesis is true, we should observe parity in the number of messages received using each method */
+
+	const endpoint = window.guardian.config.page.isDev
+		? '//logs.code.dev-guardianapis.com/log'
+		: '//logs.guardianapis.com/log';
+
+	const shouldTestBeacon = Math.random() <= 10 / 100;
+
+	if (shouldTestBeacon) {
+		const beaconEvent = {
+			label: 'commercial.amiused.test_send_beacon',
+			properties: [{ name: 'userAgent', value: navigator.userAgent }],
+		};
+
+		const fetchEvent = {
+			label: 'commercial.amiused.test_fetch',
+			properties: [{ name: 'userAgent', value: navigator.userAgent }],
+		};
+
+		window.navigator.sendBeacon(endpoint, JSON.stringify(beaconEvent));
+
+		void fetch(endpoint, {
+			method: 'POST',
+			body: JSON.stringify(fetchEvent),
+			keepalive: true,
+		});
+	}
+
 	return fastdom.mutate(() => {
 		setBackgroundStyles(specs, background);
 


### PR DESCRIPTION
## What does this change?
Adds a test `sendBeacon` and `fetch` call to 10% of messenger background calls.

## Why?
Jake and Ashish realised that `sendBeacon` is blocked by some ad blockers. In earlier testing, we discovered that `sendBeacon` is less reliable than `fetch`. It would be good to test if **all** of the flakiness of `sendBeacon` is explained by ad blockers. By adding a test to a part of the code that only executes if there’s no ad blocker, we can see if we then observe parity between `fetch` and `sendBeacon`.

This messenger code is only called by certain commercial templates, which will only be sending messages on the page if there is no ad blocker. This allows us to control for ad blockers, and hopefully to determine if ad blockers are the sole cause of `sendBeacon`'s flakiness.