### PR TITLE
Reduce CLS for inline1 when Teads passback - step 1

### DIFF
--- a/.changeset/early-dots-stare.md
+++ b/.changeset/early-dots-stare.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Reduces CLS for inline1 when Teads passback and centre ad in case of mpu

--- a/src/core/messenger/passback.ts
+++ b/src/core/messenger/passback.ts
@@ -127,14 +127,14 @@ const init = (register: RegisterListener): void => {
 								passbackElement,
 							);
 						})
-						.then(() => passbackElement.id);
+						.then(() => passbackElement);
 				},
 			);
 
 			/**
 			 * Create and display the new passback slot
 			 */
-			void createNewSlotElementPromise.then((passbackElementId) => {
+			void createNewSlotElementPromise.then((passbackElement) => {
 				/**
 				 * Find the initial slot object from googletag
 				 */
@@ -196,7 +196,7 @@ const init = (register: RegisterListener): void => {
 							event: googletag.events.SlotRenderEndedEvent,
 						) {
 							const slotId = event.slot.getSlotElementId();
-							if (slotId === passbackElementId) {
+							if (slotId === passbackElement.id) {
 								const size = event.size;
 								if (Array.isArray(size) && size[1]) {
 									const adHeight = size[1];
@@ -205,34 +205,28 @@ const init = (register: RegisterListener): void => {
 										`Passback: ad height is ${adHeight}`,
 									);
 									void fastdom.mutate(() => {
-										//The 100 is to redue CLS if Teads passes back so we don't resize back to 274px for desktop if we get an mpu
-										const slotHeight =
-											getCurrentBreakpoint() === 'mobile'
-												? `${
-														adHeight + adLabelHeight
-												  }px`
-												: `${
-														adHeight +
-														adLabelHeight +
-														100
-												  }px`;
+										const slotHeight = `${
+											(getCurrentBreakpoint() === 'mobile'
+												? adHeight
+												: adSizes.outstreamDesktop
+														.height) + adLabelHeight
+										}px`;
 										log(
 											'commercial',
 											`Passback: setting height of passback slot to ${slotHeight}`,
 										);
 										slotElement.style.height = slotHeight;
-										const passbackElement =
-											document.getElementById(
-												`${passbackElementId}`,
-											) as HTMLDivElement | null;
-										if (
-											passbackElement &&
-											getCurrentBreakpoint() ===
-												'desktop' &&
-											passbackElement.offsetHeight === 250
-										) {
-											passbackElement.style.top = '60px';
-										}
+
+										/*The centre styling is added in here instead of where the element is created
+										because googletag removes the display style on the passbackElement */
+										passbackElement.style.display = 'flex';
+										passbackElement.style.flexDirection =
+											'column';
+										passbackElement.style.justifyContent =
+											'center';
+										passbackElement.style.height =
+											'calc(100% - 24px)';
+
 										// Also resize the initial outstream iframe so
 										// it doesn't block text selection directly under
 										// the new ad
@@ -253,7 +247,7 @@ const init = (register: RegisterListener): void => {
 					const passbackSlot = googletag.defineSlot(
 						initialSlot.getAdUnitPath(),
 						[mpu, outstreamMobile, outstreamDesktop],
-						passbackElementId,
+						passbackElement.id,
 					);
 					if (passbackSlot) {
 						// https://developers.google.com/publisher-tag/guides/ad-sizes#responsive_ads
@@ -278,9 +272,9 @@ const init = (register: RegisterListener): void => {
 						);
 						log(
 							'commercial',
-							`Passback: displaying slot '${passbackElementId}'`,
+							`Passback: displaying slot '${passbackElement.id}'`,
 						);
-						googletag.display(passbackElementId);
+						googletag.display(passbackElement.id);
 					}
 				});
 			});

--- a/src/core/messenger/passback.ts
+++ b/src/core/messenger/passback.ts
@@ -205,10 +205,17 @@ const init = (register: RegisterListener): void => {
 										`Passback: ad height is ${adHeight}`,
 									);
 									void fastdom.mutate(() => {
-										//The 100 is to redue CLS if Teads passes back so we don't resize back to 274px if we get an mpu
-										const slotHeight = `${
-											adHeight + adLabelHeight + 100
-										}px`;
+										//The 100 is to redue CLS if Teads passes back so we don't resize back to 274px for desktop if we get an mpu
+										const slotHeight =
+											getCurrentBreakpoint() === 'mobile'
+												? `${
+														adHeight + adLabelHeight
+												  }px`
+												: `${
+														adHeight +
+														adLabelHeight +
+														100
+												  }px`;
 										log(
 											'commercial',
 											`Passback: setting height of passback slot to ${slotHeight}`,
@@ -220,6 +227,8 @@ const init = (register: RegisterListener): void => {
 											) as HTMLDivElement | null;
 										if (
 											passbackElement &&
+											getCurrentBreakpoint() ===
+												'desktop' &&
 											passbackElement.offsetHeight === 250
 										) {
 											passbackElement.style.top = '60px';

--- a/src/core/messenger/passback.ts
+++ b/src/core/messenger/passback.ts
@@ -205,15 +205,25 @@ const init = (register: RegisterListener): void => {
 										`Passback: ad height is ${adHeight}`,
 									);
 									void fastdom.mutate(() => {
+										//The 100 is to redue CLS if Teads passes back so we don't resize back to 274px if we get an mpu
 										const slotHeight = `${
-											adHeight + adLabelHeight
+											adHeight + adLabelHeight + 100
 										}px`;
 										log(
 											'commercial',
 											`Passback: setting height of passback slot to ${slotHeight}`,
 										);
 										slotElement.style.height = slotHeight;
-
+										const passbackElement =
+											document.getElementById(
+												`${passbackElementId}`,
+											) as HTMLDivElement | null;
+										if (
+											passbackElement &&
+											passbackElement.offsetHeight === 250
+										) {
+											passbackElement.style.top = '60px';
+										}
 										// Also resize the initial outstream iframe so
 										// it doesn't block text selection directly under
 										// the new ad

--- a/src/core/messenger/passback.ts
+++ b/src/core/messenger/passback.ts
@@ -226,8 +226,7 @@ const init = (register: RegisterListener): void => {
 											'center';
 										passbackElement.style.alignItems =
 											'center';
-										passbackElement.style.height =
-											`calc(100% - ${adLabelHeight}px)`;
+										passbackElement.style.height = `calc(100% - ${adLabelHeight}px)`;
 
 										// Also resize the initial outstream iframe so
 										// it doesn't block text selection directly under

--- a/src/core/messenger/passback.ts
+++ b/src/core/messenger/passback.ts
@@ -227,7 +227,7 @@ const init = (register: RegisterListener): void => {
 										passbackElement.style.alignItems =
 											'center';
 										passbackElement.style.height =
-											'calc(100% - 24px)';
+											`calc(100% - ${adLabelHeight}px)`;
 
 										// Also resize the initial outstream iframe so
 										// it doesn't block text selection directly under

--- a/src/core/messenger/passback.ts
+++ b/src/core/messenger/passback.ts
@@ -224,6 +224,8 @@ const init = (register: RegisterListener): void => {
 											'column';
 										passbackElement.style.justifyContent =
 											'center';
+										passbackElement.style.alignItems =
+											'center';
 										passbackElement.style.height =
 											'calc(100% - 24px)';
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR removes the second layout shift from `inline1` if Teads passes back the slot and centres in the middle of the slot in the case of an `mpu` ad size. Check the [ticket](https://trello.com/c/YxHvJgnv/2931-blip-reduce-layout-shift-for-inline1-teads-step-1) for more info.

For context we reserve `250px` for `inline1` in articles. Teads resizes it to `350px` (first shift).
If Teads passback then it resizes back to `250px` (second shift).

I made some checks to implement the changes just for desktop as we don't want to have a `350px` height for mobile.

These changes are tested locally and in CODE.

You can test an mpu locally by adding `?adtest=teadspassback2022` to the end of the article URL.

You can test a direct sold outstream by adding `?adtest=outstreampassback2024` to this article URL https://www.theguardian.com/technology/2017/mar/02/the-legend-of-zelda-breath-of-the-wild-review-link-nintendo-switch

**Before** 

https://github.com/guardian/commercial/assets/23424805/2556eb41-ad3a-4830-a909-2262b09e18c4

**After**

https://github.com/guardian/commercial/assets/23424805/bc195659-bed6-479d-867d-ff7a64117196

## Why?
Reduces CLS which means better user experience.
