### PR TITLE
fix native ads cut off with max height

### DIFF
--- a/.changeset/nervous-papayas-type.md
+++ b/.changeset/nervous-papayas-type.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+fix native add max height for <980px breakpoint

--- a/src/core/messenger/resize.ts
+++ b/src/core/messenger/resize.ts
@@ -67,6 +67,7 @@ const resize = (
 
 		if (iframeContainer) {
 			Object.assign(iframeContainer.style, styles);
+			adSlot.style.maxHeight = 'none';
 		}
 	});
 };

--- a/src/core/messenger/resize.ts
+++ b/src/core/messenger/resize.ts
@@ -67,8 +67,9 @@ const resize = (
 
 		if (iframeContainer) {
 			Object.assign(iframeContainer.style, styles);
-			adSlot.style.maxHeight = 'none';
 		}
+
+		adSlot.style.maxHeight = 'none';
 	});
 };
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
This allows the viewport to be made <980px in width or to change orientation on an iPad without the native ad getting cut off at the the bottom.

## Why?
Native ads `resize` on render and therefore change ratio (width and height), therefore when we reduce the width of the viewport or change the orientation on the iPad the bottom gets cut off.
The CSS states a max-height of 624px which persists at all breakpoints.

The `resize` is a Post Message, so when messenger tells us to resize (which only happens for in-house creatives) it should also check the container and remove max-height if necessary.

### Screenshot

| Before | After |
|---|---|
| <img width="320" alt="Screenshot 2024-06-17 at 16 42 03" src="https://github.com/guardian/commercial/assets/49187886/6510737f-a6f8-4833-b850-6b101fe39a9a"> | <img width="350" alt="Screenshot 2024-06-17 at 16 01 52" src="https://github.com/guardian/commercial/assets/49187886/c09c96e9-b6c5-4bce-bc6a-db845422c4a6">  | 



