### PR TITLE
Define sendBeacon in test file

### DIFF
--- a/src/core/messenger/background.spec.ts
+++ b/src/core/messenger/background.spec.ts
@@ -14,6 +14,8 @@ const adSpec: BackgroundSpecs = {
 	transform: 'translate3d(0,0,0)',
 };
 
+navigator.sendBeacon = jest.fn();
+
 describe('Cross-frame messenger: setupBackground', () => {
 	class IntersectionObserver {
 		constructor() {


### PR DESCRIPTION
## What does this change?
Fixes the test error in the background spec file by defining sendBeacon as a jest function.

## Why?
For some reason this test passed fine on the PR but then after merging it flaked on main with the error: `TypeError: window.navigator.sendBeacon is not a function`. Hopefully this fixes the error.