### PR TITLE
Reduce beacon test sampling

### DIFF
--- a/.changeset/stupid-turkeys-learn.md
+++ b/.changeset/stupid-turkeys-learn.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Reduce sendBeacon test sampling to 1%

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -194,7 +194,7 @@ const setupBackground = async (
 		? '//logs.code.dev-guardianapis.com/log'
 		: '//logs.guardianapis.com/log';
 
-	const shouldTestBeacon = Math.random() <= 10 / 100;
+	const shouldTestBeacon = Math.random() <= 1 / 100;
 
 	if (shouldTestBeacon) {
 		const beaconEvent = {


### PR DESCRIPTION
## What does this change?
Reduces the sendBeacon test sampling rate from 10% to 1%.

## Why?
We're getting loads more data than I thought, and we got about 73000 data points just for yesterday. We definitely don't need that much so I'm reducing the sampling. I would rather sample at a lower rate over a longer time period to better account for different usage patterns.