### PR TITLE
Tell dependabot not to bump major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,9 @@ updates:
         patterns:
           - '*'
     ignore:
-      - dependency-name: "*"
+      - dependency-name: '*'
         # ignore all major updates as we want to do them manually
-        update-types: ["version-update:semver-major"]
+        update-types: ['version-update:semver-major']
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
       npm:
         patterns:
           - '*'
+    ignore:
+      - dependency-name: "*"
+        # ignore all major updates as we want to do them manually
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
## Why?
Major versions may contain breaking changes, so we'll want to do those bumps manually