### PR TITLE
reduce min distance from top of article to 200px for spacefinder

### DIFF
--- a/.changeset/shiny-turkeys-breathe.md
+++ b/.changeset/shiny-turkeys-breathe.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+reduce min height from top of article for first inline ad on mobile

--- a/src/insert/spacefinder/article.ts
+++ b/src/insert/spacefinder/article.ts
@@ -320,7 +320,7 @@ const addDesktopRightRailAds = (fillSlot: FillAdSlot): Promise<boolean> => {
 	});
 };
 
-const mobileMinDistanceFromArticleTop = 250;
+const mobileMinDistanceFromArticleTop = 200;
 
 const mobileIgnoreList = `:not(p):not(h2):not(hr):not(.${adSlotContainerClass}):not(#sign-in-gate):not([data-spacefinder-type$="NumberedTitleBlockElement"])`;
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
This PR reduces the spacefinder mobile minAbove distance to 250px

## Why?

| Before      | After      |
| ----------- | ---------- |
| ![localhost_3030_Article_https___www theguardian com_us-news_article_2024_may_17_university-of-georgia-cop-city-lawsuit_sfdebug(iPhone 12 Pro) (3)](https://github.com/guardian/commercial/assets/49187886/97a90de6-0b8e-434d-a59b-8de1986d39f9) | ![localhost_3030_Article_https___www theguardian com_us-news_article_2024_may_17_university-of-georgia-cop-city-lawsuit_sfdebug(iPhone 12 Pro) (6)](https://github.com/guardian/commercial/assets/49187886/e80f2dd3-3e1d-457f-bc2e-c571fdcc2214) |
