### PR TITLE
Add commercialMetricsInitialised to window

### DIFF
--- a/.changeset/silly-pandas-give.md
+++ b/.changeset/silly-pandas-give.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Add commercialMetricsInitialised to the window

--- a/src/core/send-commercial-metrics.ts
+++ b/src/core/send-commercial-metrics.ts
@@ -52,7 +52,6 @@ let commercialMetricsPayload: CommercialMetricsPayload = {
 
 let devProperties: Property[] | [] = [];
 let adBlockerProperties: Property[] | [] = [];
-let initialised = false;
 let endpoint: Endpoints;
 
 const setEndpoint = (isDev: boolean) =>
@@ -225,7 +224,7 @@ const checkConsent = async (): Promise<boolean> => {
  * A method to asynchronously send metrics after initialization.
  */
 async function bypassCommercialMetricsSampling(): Promise<void> {
-	if (!initialised) {
+	if (!window.guardian.config.commercialMetricsInitialised) {
 		console.warn('initCommercialMetrics not yet initialised');
 		return;
 	}
@@ -269,11 +268,11 @@ async function initCommercialMetrics({
 	setDevProperties(isDev);
 	setAdBlockerProperties(adBlockerInUse);
 
-	if (initialised) {
+	if (window.guardian.config.commercialMetricsInitialised) {
 		return false;
 	}
 
-	initialised = true;
+	window.guardian.config.commercialMetricsInitialised = true;
 
 	const userIsInSamplingGroup = Math.random() <= sampling;
 
@@ -296,7 +295,7 @@ export const _ = {
 	roundTimeStamp,
 	transformToObjectEntries,
 	reset: (): void => {
-		initialised = false;
+		window.guardian.config.commercialMetricsInitialised = false;
 		commercialMetricsPayload = {
 			page_view_id: undefined,
 			browser_id: undefined,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -39,6 +39,7 @@ export type GetThirdPartyTag = (arg0: { shouldRun: boolean }) => ThirdPartyTag;
 export type Edition = 'UK' | 'AU' | 'US';
 
 export type GuardianWindowConfig = {
+	commercialMetricsInitialised: boolean;
 	isDotcomRendering: boolean;
 	ophan: {
 		// somewhat redundant with guardian.ophan

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -145,6 +145,7 @@ interface PageConfig extends CommercialPageConfig {
 }
 
 interface Config {
+	commercialMetricsInitialised?: boolean;
 	frontendAssetsFullURL?: string;
 	isDotcomRendering: boolean;
 	ophan: {


### PR DESCRIPTION
## What does this change?
Adds a new property - `commercialMetricsInitialised` - to the Guardian window config.

## Why?
At the moment, `bypassCommercialMetricsSampling` doesn't work in the commercial repository, because DCR initialises the metrics, so the commercial bundle doesn't have access to that version of the `initialised` variable. By storing the state of initialisation on the window instead, we can share the value between DCR and commercial, which means `bypassCommercialMetricsSampling` should now work for commercial code.

Tested on CODE:
<img width="322" alt="Screenshot 2024-06-25 at 16 56 29" src="https://github.com/guardian/commercial/assets/108270776/511a7b0a-9949-418f-8bef-abeec072712a">
