### PR TITLE
Configure dependabot to keep up to date with dependency bumps in Commercial

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,10 +22,9 @@ updates:
       guardian:
         patterns:
           - '@guardian/*'
-      typescript:
+      types:
         patterns:
           - '@types/*'
-          - 'typescript'
           - 'type-fest'
           - 'tslib'
       eslint:
@@ -42,27 +41,32 @@ updates:
           - '*jest*'
       webpack:
         patterns:
-          - 'webpack*'
+          - '*webpack*'
+          - '*-loader'
       dependencies:
         dependency-type: 'production'
-        update-types: ['minor', 'patch']
+        update-types:
+          - 'minor'
+          - 'patch'
       devDependencies:
         dependency-type: 'development'
-        update-types: ['minor', 'patch']
+        update-types:
+          - 'minor'
+          - 'patch'
         exclude-patterns:
           - '@changesets/*'
           - '@babel/*'
           - 'babel-*'
           - '@guardian/*'
           - '@types/*'
-          - 'typescript'
           - 'type-fest'
           - 'tslib'
           - '*eslint*'
           - '*prettier*'
           - '@playwright/*'
           - '*jest*'
-          - 'webpack*'
+          - '*webpack*'
+          - '*-loader'
     ignore:
       - dependency-name: '*'
         # ignore all major updates as we want to do them manually

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,40 +15,62 @@ updates:
       changesets:
         patterns:
           - '@changesets/*'
+        update-types:
+          - 'minor'
+          - 'patch'
       babel:
         patterns:
           - '@babel/*'
           - 'babel-*'
+        update-types:
+          - 'minor'
+          - 'patch'
       guardian:
         patterns:
           - '@guardian/*'
+        update-types:
+          - 'minor'
+          - 'patch'
       types:
         patterns:
           - '@types/*'
           - 'type-fest'
           - 'tslib'
-      eslint:
+        update-types:
+          - 'minor'
+          - 'patch'
+      trouble-makers:
         patterns:
           - '*eslint*'
-      prettier:
-        patterns:
           - '*prettier*'
+        update-types:
+          - 'minor'
+          - 'patch'
       playwright:
         patterns:
           - '@playwright/*'
+        update-types:
+          - 'minor'
+          - 'patch'
       jest:
         patterns:
           - '*jest*'
+        update-types:
+          - 'minor'
+          - 'patch'
       webpack:
         patterns:
           - '*webpack*'
           - '*-loader'
-      dependencies:
+        update-types:
+          - 'minor'
+          - 'patch'
+      minor-dependencies:
         dependency-type: 'production'
         update-types:
           - 'minor'
           - 'patch'
-      devDependencies:
+      minor-devDependencies:
         dependency-type: 'development'
         update-types:
           - 'minor'
@@ -67,10 +89,16 @@ updates:
           - '*jest*'
           - '*webpack*'
           - '*-loader'
-    ignore:
-      - dependency-name: '*'
-        # ignore all major updates as we want to do them manually
-        update-types: ['version-update:semver-major']
+      # We can have a PR for all major updates for production or development dependencies.
+      # if we want to be more granular we can create a group with update-type major for each dependency.
+      major-dependencies:
+        dependency-type: 'production'
+        update-types:
+          - 'major'
+      major-devDependencies:
+        dependency-type: 'development'
+        update-types:
+          - 'major'
     # The default is 5 but as we are going to group dependencies we might need to increase it
     open-pull-requests-limit: 10
   - package-ecosystem: 'github-actions'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -89,16 +89,6 @@ updates:
           - '*jest*'
           - '*webpack*'
           - '*-loader'
-      # We can have a PR for all major updates for production or development dependencies.
-      # if we want to be more granular we can create a group with update-type major for each dependency.
-      major-dependencies:
-        dependency-type: 'production'
-        update-types:
-          - 'major'
-      major-devDependencies:
-        dependency-type: 'development'
-        update-types:
-          - 'major'
     # The default is 5 but as we are going to group dependencies we might need to increase it
     open-pull-requests-limit: 10
   - package-ecosystem: 'github-actions'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,14 +9,66 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+      time: '09:00'
+      day: 'tuesday'
     groups:
-      npm:
+      changesets:
         patterns:
-          - '*'
+          - '@changesets/*'
+      babel:
+        patterns:
+          - '@babel/*'
+          - 'babel-*'
+      guardian:
+        patterns:
+          - '@guardian/*'
+      typescript:
+        patterns:
+          - '@types/*'
+          - 'typescript'
+          - 'type-fest'
+          - 'tslib'
+      eslint:
+        patterns:
+          - '*eslint*'
+      prettier:
+        patterns:
+          - '*prettier*'
+      playwright:
+        patterns:
+          - '@playwright/*'
+      jest:
+        patterns:
+          - '*jest*'
+      webpack:
+        patterns:
+          - 'webpack*'
+      dependencies:
+        dependency-type: 'production'
+        update-types: ['minor', 'patch']
+      devDependencies:
+        dependency-type: 'development'
+        update-types: ['minor', 'patch']
+        exclude-patterns:
+          - '@changesets/*'
+          - '@babel/*'
+          - 'babel-*'
+          - '@guardian/*'
+          - '@types/*'
+          - 'typescript'
+          - 'type-fest'
+          - 'tslib'
+          - '*eslint*'
+          - '*prettier*'
+          - '@playwright/*'
+          - '*jest*'
+          - 'webpack*'
     ignore:
       - dependency-name: '*'
         # ignore all major updates as we want to do them manually
         update-types: ['version-update:semver-major']
+    # The default is 5 but as we are going to group dependencies we might need to increase it
+    open-pull-requests-limit: 10
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR groups dependencies in `dependabot.yml` and adds more configuration rules to make it granular and easier to keep up to date with dependency bumps in Commercial.

## Why?

The main reason is to avoid being out of sync with other dependencies we rely on to run Commercial or the other way around when other dependencies relies on Commercial . This will save us time and development effort. 
