### PR TITLE
Remove sendBeacon test for users with no ad blocker

### DIFF
--- a/.changeset/rude-plants-happen.md
+++ b/.changeset/rude-plants-happen.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Remove the sendBeacon for no ad blocker test

--- a/src/core/messenger/background.spec.ts
+++ b/src/core/messenger/background.spec.ts
@@ -14,8 +14,6 @@ const adSpec: BackgroundSpecs = {
 	transform: 'translate3d(0,0,0)',
 };
 
-navigator.sendBeacon = jest.fn();
-
 describe('Cross-frame messenger: setupBackground', () => {
 	class IntersectionObserver {
 		constructor() {

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -184,38 +184,6 @@ const setupBackground = async (
 		specs.scrollType,
 	);
 
-	/* We're sending both sendBeacon and fetch messages here to test if we receive the same numbers of each.
-	Our hypothesis is that sendBeacon is less reliable because it gets blocked by some ad blockers. This messenger
-	code only fires if a template ad (eg fabric or interscroller) is present on the page and sends a message. This
-	means we can control for ad blockers, as there should be no ad blocker present if we reach this code. So if
-	our hypothesis is true, we should observe parity in the number of messages received using each method */
-
-	const endpoint = window.guardian.config.page.isDev
-		? '//logs.code.dev-guardianapis.com/log'
-		: '//logs.guardianapis.com/log';
-
-	const shouldTestBeacon = Math.random() <= 1 / 100;
-
-	if (shouldTestBeacon) {
-		const beaconEvent = {
-			label: 'commercial.test_send_beacon',
-			properties: [{ name: 'userAgent', value: navigator.userAgent }],
-		};
-
-		const fetchEvent = {
-			label: 'commercial.test_fetch',
-			properties: [{ name: 'userAgent', value: navigator.userAgent }],
-		};
-
-		window.navigator.sendBeacon(endpoint, JSON.stringify(beaconEvent));
-
-		void fetch(endpoint, {
-			method: 'POST',
-			body: JSON.stringify(fetchEvent),
-			keepalive: true,
-		});
-	}
-
 	return fastdom.mutate(() => {
 		setBackgroundStyles(specs, background);
 


### PR DESCRIPTION
## What does this change?
Removes the test added in https://github.com/guardian/commercial/pull/1416

## Why?
The test has been running for over a week so we've got more than enough data now.
