### PR TITLE
Add post-merge hook to run `pnpm i` on git pull

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,22 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+RED='\033[0;31m'
+ENDCOLOR='\033[0m'
+
+changedFiles="$(git diff-tree -r --name-only --no-commit-id HEAD@{1} HEAD)"
+changedLock="$(echo "$changedFiles" | { grep -E 'pnpm-lock.yaml' || :; })"
+changedNode="$(echo "$changedFiles" | { grep '.nvmrc' || :; })"
+
+if [[ ! -z $changedNode ]]
+then
+	version="$(cat .nvmrc)"
+	echo "${RED}This project needs Node "$version". Please run 'nvm use', 'fnm use' or 'asdf install' (or whatever is appropriate) then run 'pnpm install --frozen-lockfile'${ENDCOLOR}"
+	exit 1
+fi
+
+if [[ ! -z $changedLock ]]
+then
+	echo "${RED}This application has updated dependencies. Installing with pnpm...${ENDCOLOR}"
+	pnpm install --frozen-lockfile
+fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,10 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+if [[ $currentBranch == "main" ]]
+then
+	echo "⚠️ You should not push to the \`main\` branch"
+	exit 1
+fi
+
 pnpm npm-run-all 'prepush:*'


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR adds a 'post-merge' hook to git with husky:

- If dependencies have been updated then run `pnpm i` to reinstall them

- If the .nvmrc has changed, notify users to install the new version

## Why?

Just to be confident that no issues will happen because someone forgot to update the dependencies and it should improve the developer experience. 
