### PR TITLE
Spacefinder rule optimisation

### DIFF
--- a/.changeset/fluffy-meals-shake.md
+++ b/.changeset/fluffy-meals-shake.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Spacefinder rule optimisation

--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -139,15 +139,13 @@ const mobileOpponentSelectorRules = {
 		minAboveSlot: 35,
 		minBelowSlot: 200,
 		// Usually we don't want an ad right before videos, embeds and atoms etc. so that we don't break up related content too much. But if we have a heading above, anything above the heading won't be related to the current content, so we can place an ad there.
-		bypassMinBelow:
-			'h2,[data-spacefinder-type$="NumberedTitleBlockElement"]',
+		bypassMinBelow: mobileHeadingSelector,
 	},
 	[rightColumnOpponentSelector]: {
 		minAboveSlot: 35,
 		minBelowSlot: 200,
 		// Usually we don't want an ad right before videos, embeds and atoms etc. so that we don't break up related content too much. But if we have a heading above, anything above the heading won't be related to the current content, so we can place an ad there.
-		bypassMinBelow:
-			'h2,[data-spacefinder-type$="NumberedTitleBlockElement"]',
+		bypassMinBelow: mobileHeadingSelector,
 	},
 };
 

--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -132,13 +132,15 @@ const mobileOpponentSelectorRules = {
 		minAboveSlot: 35,
 		minBelowSlot: 200,
 		// Usually we don't want an ad right before videos, embeds and atoms etc. so that we don't break up related content too much. But if we have a heading above, anything above the heading won't be related to the current content, so we can place an ad there.
-		bypassMinBelow: mobileHeadingSelector,
+		bypassMinBelow:
+			'h2,[data-spacefinder-type$="NumberedTitleBlockElement"]',
 	},
 	[rightColumnOpponentSelector]: {
 		minAboveSlot: 35,
 		minBelowSlot: 200,
 		// Usually we don't want an ad right before videos, embeds and atoms etc. so that we don't break up related content too much. But if we have a heading above, anything above the heading won't be related to the current content, so we can place an ad there.
-		bypassMinBelow: mobileHeadingSelector,
+		bypassMinBelow:
+			'h2,[data-spacefinder-type$="NumberedTitleBlockElement"]',
 	},
 };
 

--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -1,7 +1,5 @@
 import { adSizes } from 'core';
 import { adSlotContainerClass } from 'core/create-ad-slot';
-import { isInVariantSynchronous } from 'experiments/ab';
-import { deeplyReadRightColumn } from 'experiments/tests/deeply-read-right-column';
 import { getCurrentBreakpoint } from 'lib/detect/detect-breakpoint';
 import type { SpacefinderRules } from './spacefinder';
 import { isInHighValueSection } from './utils';
@@ -24,11 +22,6 @@ const isPaidContent = window.guardian.config.page.isPaidContent;
 
 const hasShowcaseMainElement =
 	window.guardian.config.page.hasShowcaseMainElement;
-
-const isInDeeplyReadMostViewedVariant = isInVariantSynchronous(
-	deeplyReadRightColumn,
-	'deeply-read-and-most-viewed',
-);
 
 const minDistanceBetweenRightRailAds = 500;
 const minDistanceBetweenInlineAds = isInHighValueSection ? 500 : 750;
@@ -80,7 +73,7 @@ const desktopRightRailMinAbove = () => {
 	 * In special cases, inline2 can overlap the "Most viewed" island, so
 	 * we need to make an adjustment to move the inline2 further down the page
 	 */
-	if (isInDeeplyReadMostViewedVariant || isPaidContent || !hasImages) {
+	if (isPaidContent || !hasImages) {
 		return base + MOST_VIEWED_HEIGHT;
 	}
 

--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -1,0 +1,237 @@
+import { adSizes } from 'core';
+import { adSlotContainerClass } from 'core/create-ad-slot';
+import { isInVariantSynchronous } from 'experiments/ab';
+import { deeplyReadRightColumn } from 'experiments/tests/deeply-read-right-column';
+import {
+	getCurrentBreakpoint,
+	getCurrentTweakpoint,
+} from 'lib/detect/detect-breakpoint';
+import type { RuleSpacing, SpacefinderRules } from './spacefinder';
+import { isInHighValueSection } from './utils';
+
+const articleBodySelector = '.article-body-commercial-selector';
+
+const tweakpoint = getCurrentTweakpoint();
+const hasLeftCol = ['leftCol', 'wide'].includes(tweakpoint);
+
+let ignoreList = `:scope > :not(p):not(h2):not(ul):not(.${adSlotContainerClass}):not(#sign-in-gate):not(.sfdebug)`;
+if (hasLeftCol) {
+	ignoreList +=
+		':not([data-spacefinder-role="richLink"]):not([data-spacefinder-role="thumbnail"])';
+}
+
+/**
+ * As estimation of the height of the most viewed island.
+ * This appears from desktop breakpoints on the right-hand side.
+ * Knowing the height of the element is useful when
+ * calculating where to place ads in the right column.
+ */
+const MOST_VIEWED_HEIGHT = 600;
+
+const isImmersive = window.guardian.config.page.isImmersive;
+
+const hasImages = !!window.guardian.config.page.lightboxImages?.images.length;
+const isPaidContent = window.guardian.config.page.isPaidContent;
+
+const hasShowcaseMainElement =
+	window.guardian.config.page.hasShowcaseMainElement;
+
+const isInDeeplyReadMostViewedVariant = isInVariantSynchronous(
+	deeplyReadRightColumn,
+	'deeply-read-and-most-viewed',
+);
+
+const minDistanceBetweenRightRailAds = 500;
+const minDistanceBetweenInlineAds = isInHighValueSection ? 500 : 750;
+
+/**
+ * Rules to avoid inserting ads in the right rail too close to each other
+ **/
+const rightRailAdSlotContainerRules: Record<string, RuleSpacing> = {
+	[` .${adSlotContainerClass}`]: {
+		minAboveSlot: minDistanceBetweenRightRailAds,
+		minBelowSlot: minDistanceBetweenRightRailAds,
+	},
+};
+
+/**
+ * Rules to avoid inserting inline ads too close to each other
+ **/
+const inlineAdSlotContainerRules: Record<string, RuleSpacing> = {
+	[` .${adSlotContainerClass}`]: {
+		minAboveSlot: minDistanceBetweenInlineAds,
+		minBelowSlot: minDistanceBetweenInlineAds,
+	},
+};
+
+const desktopInline1: SpacefinderRules = {
+	bodySelector: articleBodySelector,
+	candidateSelector: ':scope > p, [data-spacefinder-role="nested"] > p',
+	minAbove: isImmersive ? 700 : 300,
+	minBelow: 300,
+	opponentSelectorRules: {
+		// don't place ads right after a heading
+		':scope > h2, [data-spacefinder-role="nested"] > h2': {
+			minAboveSlot: isInHighValueSection ? 150 : 5,
+			minBelowSlot: isInHighValueSection ? 0 : 190,
+		},
+		[`.${adSlotContainerClass}`]: {
+			minAboveSlot: 500,
+			minBelowSlot: 500,
+		},
+		[ignoreList]: {
+			minAboveSlot: 35,
+			minBelowSlot: 400,
+		},
+		'[data-spacefinder-role="immersive"]': {
+			minAboveSlot: 0,
+			minBelowSlot: 600,
+		},
+
+		// frontend only interactives
+		'figure.element--supporting': {
+			minAboveSlot: 100,
+			minBelowSlot: 0,
+		},
+	},
+};
+
+let desktopRightRailMinAbove = 1000;
+
+/**
+ * In special cases, inline2 can overlap the "Most viewed" island, so
+ * we need to make an adjustment to move the inline2 further down the page
+ */
+if (isInDeeplyReadMostViewedVariant || isPaidContent) {
+	desktopRightRailMinAbove += MOST_VIEWED_HEIGHT;
+}
+
+// Some old articles don't have a main image, which means the first paragraph is much higher
+if (!hasImages) {
+	desktopRightRailMinAbove += 600;
+} else if (hasShowcaseMainElement) {
+	desktopRightRailMinAbove += 100;
+}
+
+const desktopRightRail: SpacefinderRules = {
+	bodySelector: articleBodySelector,
+	candidateSelector: ':scope > p, [data-spacefinder-role="nested"] > p',
+	minAbove: desktopRightRailMinAbove,
+	minBelow: 300,
+	opponentSelectorRules: {
+		...rightRailAdSlotContainerRules,
+		'[data-spacefinder-role="immersive"]': {
+			minAboveSlot: 0,
+			minBelowSlot: 600,
+		},
+	},
+	/**
+	 * Filter out any candidates that are too close to the last winner
+	 * see https://github.com/guardian/commercial/tree/main/docs/spacefinder#avoiding-other-winning-candidates
+	 * for more information
+	 **/
+	filter: (candidate, lastWinner) => {
+		if (!lastWinner) {
+			return true;
+		}
+		const largestSizeForSlot = adSizes.halfPage.height;
+		const distanceBetweenAds =
+			candidate.top - lastWinner.top - largestSizeForSlot;
+		return distanceBetweenAds >= minDistanceBetweenRightRailAds;
+	},
+};
+
+const mobileMinDistanceFromArticleTop = 200;
+
+const mobileIgnoreList = `:not(p):not(h2):not(hr):not(.${adSlotContainerClass}):not(#sign-in-gate):not([data-spacefinder-type$="NumberedTitleBlockElement"])`;
+
+const mobileOpponentSelectorRules = {
+	// don't place ads right after a heading
+	':scope > h2, [data-spacefinder-role="nested"] > h2, :scope > [data-spacefinder-type$="NumberedTitleBlockElement"]':
+		{
+			minAboveSlot: 100,
+			minBelowSlot: 0,
+		},
+	...inlineAdSlotContainerRules,
+	// this is a catch-all for elements that are not covered by the above rules, these will generally be things like videos, embeds and atoms. minBelowSlot is higher to push ads a bit further down after these elements
+	[`:scope > ${mobileIgnoreList}, [data-spacefinder-role="nested"] > ${mobileIgnoreList}`]:
+		{
+			minAboveSlot: 35,
+			minBelowSlot: 200,
+			// Usually we don't want an ad right before videos, embeds and atoms etc. so that we don't break up related content too much. But if we have a heading above, anything above the heading won't be related to the current content, so we can place an ad there.
+			bypassMinBelow:
+				'h2,[data-spacefinder-type$="NumberedTitleBlockElement"]',
+		},
+};
+
+const mobileSubsequentInlineAds: SpacefinderRules = {
+	bodySelector: articleBodySelector,
+	candidateSelector:
+		':scope > p, :scope > h2, :scope > [data-spacefinder-type$="NumberedTitleBlockElement"], [data-spacefinder-role="nested"] > p',
+	minAbove: mobileMinDistanceFromArticleTop,
+	minBelow: 200,
+	opponentSelectorRules: mobileOpponentSelectorRules,
+	/**
+	 * Filter out any candidates that are too close to the last winner
+	 * see https://github.com/guardian/commercial/tree/main/docs/spacefinder#avoiding-other-winning-candidates
+	 * for more information
+	 **/
+	filter: (candidate, lastWinner) => {
+		if (!lastWinner) {
+			return true;
+		}
+		const distanceBetweenAds = candidate.top - lastWinner.top;
+		return distanceBetweenAds >= minDistanceBetweenInlineAds;
+	},
+};
+
+const mobileTopAboveNav: SpacefinderRules = {
+	bodySelector: articleBodySelector,
+	candidateSelector:
+		':scope > p, :scope > h2, :scope > [data-spacefinder-type$="NumberedTitleBlockElement"], [data-spacefinder-role="nested"] > p',
+	minAbove: mobileMinDistanceFromArticleTop,
+	minBelow: 200,
+	opponentSelectorRules: mobileOpponentSelectorRules,
+};
+
+const breakpoint = getCurrentBreakpoint();
+const isMobileOrTablet = breakpoint === 'mobile' || breakpoint === 'tablet';
+
+const inlineMerchandising: SpacefinderRules = {
+	bodySelector: articleBodySelector,
+	candidateSelector: ':scope > p',
+	minAbove: 300,
+	minBelow: 300,
+	opponentSelectorRules: {
+		':scope > .merch': {
+			minAboveSlot: 0,
+			minBelowSlot: 0,
+		},
+		':scope > header': {
+			minAboveSlot: isMobileOrTablet ? 300 : 700,
+			minBelowSlot: 0,
+		},
+		':scope > h2': {
+			minAboveSlot: 100,
+			minBelowSlot: 250,
+		},
+		':scope > #sign-in-gate': {
+			minAboveSlot: 0,
+			minBelowSlot: 400,
+		},
+		...inlineAdSlotContainerRules,
+		[`:scope > :not(p):not(h2):not(.${adSlotContainerClass}):not(#sign-in-gate):not(.sfdebug)`]:
+			{
+				minAboveSlot: 200,
+				minBelowSlot: 400,
+			},
+	},
+};
+
+export const rules = {
+	desktopInline1,
+	desktopRightRail,
+	mobileTopAboveNav,
+	mobileSubsequentInlineAds,
+	inlineMerchandising,
+};

--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -61,8 +61,12 @@ const desktopInline1: SpacefinderRules = {
 			minBelowSlot: 400,
 		},
 		[rightColumnOpponentSelector]: {
-			minAboveSlot: 35,
-			minBelowSlot: 400,
+			minAboveSlot: 0,
+			minBelowSlot: 600,
+		},
+		['[data-spacefinder-role="supporting"]']: {
+			minAboveSlot: 0,
+			minBelowSlot: 100,
 		},
 	},
 };


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Move spacefinder rules to their own file
Remove the use of the "catch-all" rules, aka the ones that look like:
```js
	let ignoreList = `:scope > :not(p):not(h2):not(ul):not(.${adSlotContainerClass}):not(#sign-in-gate):not(.sfdebug)`;
	if (hasLeftCol) {
		ignoreList +=
			':not([data-spacefinder-role="richLink"]):not([data-spacefinder-role="thumbnail"])';
	}
```

## Why?

What these selectors are doing is selecting elements that are not candidates or already have an opponents selector rule, effectively a "catch-all" for any other elements.

The behaviour (and the selector) is a little fuzzy and confusing, it would be better if we could reliably select all the elements we want to avoid.

Since all articles are rendered by DCR now, we know all the blocks/elements that can appear (https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/lib/renderElement.tsx), so we can more reliably select them.

We already have `data-spacefinder-role` on all blocks wrapped in a figure, which tells us which columns left or right the element expands into, [by adding it to the rest of elements](https://github.com/guardian/dotcom-rendering/pull/11919) (except candidate elements i.e. paragraphs and headings), we can use it to reliable select the elements/blocks to avoid.

The changes in this PR will replicate the current behaviour of avoiding most elements by 400px, which may not be optimal, but we can look into that in later PRs.