### PR TITLE
Refactor metrics bypassing

### DIFF
--- a/.changeset/brave-peaches-confess.md
+++ b/.changeset/brave-peaches-confess.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Refactor metrics bypassing

--- a/src/core/send-commercial-metrics.ts
+++ b/src/core/send-commercial-metrics.ts
@@ -185,20 +185,17 @@ function gatherMetricsOnPageUnload(): void {
 }
 
 const listener = (e: Event): void => {
-	switch (e.type) {
-		case 'visibilitychange':
-			if (
-				document.visibilityState === 'hidden' &&
-				window.guardian.config.shouldSendCommercialMetrics === true
-			) {
+	if (window.guardian.config.shouldSendCommercialMetrics === true) {
+		switch (e.type) {
+			case 'visibilitychange':
+				if (document.visibilityState === 'hidden') {
+					gatherMetricsOnPageUnload();
+				}
+				return;
+			case 'pagehide':
 				gatherMetricsOnPageUnload();
-			}
-			return;
-		case 'pagehide':
-			if (window.guardian.config.shouldSendCommercialMetrics === true) {
-				gatherMetricsOnPageUnload();
-			}
-			return;
+				return;
+		}
 	}
 };
 

--- a/src/core/send-commercial-metrics.ts
+++ b/src/core/send-commercial-metrics.ts
@@ -282,7 +282,7 @@ async function initCommercialMetrics({
 
 	const userIsInSamplingGroup = Math.random() <= sampling;
 
-	if (userIsInSamplingGroup) {
+	if (isDev || userIsInSamplingGroup) {
 		const consented = await checkConsent();
 		if (consented) {
 			window.guardian.config.shouldSendCommercialMetrics = true;

--- a/src/core/send-commercial-metrics.ts
+++ b/src/core/send-commercial-metrics.ts
@@ -282,7 +282,7 @@ async function initCommercialMetrics({
 
 	const userIsInSamplingGroup = Math.random() <= sampling;
 
-	if (isDev || userIsInSamplingGroup) {
+	if (userIsInSamplingGroup) {
 		const consented = await checkConsent();
 		if (consented) {
 			window.guardian.config.shouldSendCommercialMetrics = true;

--- a/src/core/send-commercial-metrics.ts
+++ b/src/core/send-commercial-metrics.ts
@@ -187,12 +187,17 @@ function gatherMetricsOnPageUnload(): void {
 const listener = (e: Event): void => {
 	switch (e.type) {
 		case 'visibilitychange':
-			if (document.visibilityState === 'hidden') {
+			if (
+				document.visibilityState === 'hidden' &&
+				window.guardian.config.shouldSendCommercialMetrics === true
+			) {
 				gatherMetricsOnPageUnload();
 			}
 			return;
 		case 'pagehide':
-			gatherMetricsOnPageUnload();
+			if (window.guardian.config.shouldSendCommercialMetrics === true) {
+				gatherMetricsOnPageUnload();
+			}
 			return;
 	}
 };
@@ -232,7 +237,7 @@ async function bypassCommercialMetricsSampling(): Promise<void> {
 	const consented = await checkConsent();
 
 	if (consented) {
-		addVisibilityListeners();
+		window.guardian.config.shouldSendCommercialMetrics = true;
 	} else {
 		log('commercial', "Metrics won't be sent because consent wasn't given");
 	}
@@ -267,6 +272,7 @@ async function initCommercialMetrics({
 	setEndpoint(isDev);
 	setDevProperties(isDev);
 	setAdBlockerProperties(adBlockerInUse);
+	addVisibilityListeners();
 
 	if (window.guardian.config.commercialMetricsInitialised) {
 		return false;
@@ -279,7 +285,7 @@ async function initCommercialMetrics({
 	if (isDev || userIsInSamplingGroup) {
 		const consented = await checkConsent();
 		if (consented) {
-			addVisibilityListeners();
+			window.guardian.config.shouldSendCommercialMetrics = true;
 			return true;
 		}
 		log('commercial', "Metrics won't be sent because consent wasn't given");
@@ -296,6 +302,7 @@ export const _ = {
 	transformToObjectEntries,
 	reset: (): void => {
 		window.guardian.config.commercialMetricsInitialised = false;
+		window.guardian.config.shouldSendCommercialMetrics = false;
 		commercialMetricsPayload = {
 			page_view_id: undefined,
 			browser_id: undefined,

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -154,6 +154,7 @@ interface Config {
 		pageViewId: string;
 	};
 	page: PageConfig;
+	shouldSendCommercialMetrics?: boolean;
 	stage: Stage;
 	switches: Record<string, boolean | undefined>;
 	tests?: {


### PR DESCRIPTION
## What does this change?
Refactors the metrics bypass functionality to make it easier to read and work with.

## Why?
At the moment, metrics are sent when either a `visibilitychange` or `pagehide` event listener fires. The event listeners are added when someone is in the dev environment (eg testing locally or on CODE) and when someone is in the sampling group. The `bypassCommercialMetricsSampling` function works by adding the event listeners when called.

This isn't what you would intuitively expect the `bypassCommercialMetricsSampling` function to do. It also means that listeners could be coming from DCR or from commercial, which might be harder to trace and debug.

Instead, this PR refactors the code to add listeners as part of the `initCommercialMetrics` function. This means listeners only get added in one place, at one time. Now, if someone is in the dev environment, in the sampling group, or calls the `bypassCommercialMetricsSampling` function, a property is set on the window, called `shouldSendCommercialMetrics`. This means we can set the value from DCR or the commercial code, and share the state.

Now when the event listener fires, we check if the `shouldSendCommercialMetrics` value on the window is true. If so, we send the metrics.

I think this implementation is easier to read, and should be easier to work with and debug in future. Hopefully it should also mean that the bypassing works from the commercial code as expected now.