### PR TITLE
Don't add advertisement labels to Hosted By ads served by opt out

### DIFF
--- a/.changeset/wise-schools-bathe.md
+++ b/.changeset/wise-schools-bathe.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Add labels for Hosted By template ads on opt out

--- a/src/init/consentless/define-slot.ts
+++ b/src/init/consentless/define-slot.ts
@@ -39,6 +39,10 @@ const defineSlot = (
 			slot.classList.add('ad-slot--native');
 		}
 
+		if (optOutExt.tags.includes('HOSTEDBY')) {
+			slot.classList.add('ad-slot--hostedby');
+		}
+
 		void renderConsentlessAdvertLabel(slot);
 	};
 

--- a/src/init/consentless/render-advert-label.ts
+++ b/src/init/consentless/render-advert-label.ts
@@ -10,6 +10,7 @@ const shouldRenderConsentlessLabel = (adSlotNode: HTMLElement): boolean => {
 		adSlotNode.classList.contains('ad-slot--frame') ||
 		adSlotNode.classList.contains('ad-slot--gc') ||
 		adSlotNode.classList.contains('u-h') ||
+		adSlotNode.classList.contains('ad-slot--hostedby') ||
 		// set for out-of-page (1x1) and empty (2x2) ads
 		adSlotNode.classList.contains('ad-slot--collapse') ||
 		adSlotNode.getAttribute('data-label') === 'false'


### PR DESCRIPTION
## What does this change?
Adds a class to opt out ads with the `HOSTEDBY` tag. If this class is present on an ad, we don't attach an ad label.

## Why?
We'd like to start serving more native templates on opt out, so we need to remove the label from certain templates.

### Before:

<img width="1444" alt="Screenshot 2024-07-10 at 16 00 49" src="https://github.com/guardian/commercial/assets/108270776/d982974a-a1d3-4818-bc6c-85fe2ddfe30b">

### After:

<img width="1497" alt="Screenshot 2024-07-10 at 15 36 55" src="https://github.com/guardian/commercial/assets/108270776/2832bcae-b835-4720-a122-2c9470411e89">
