### PR TITLE
Fix husky hooks

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,6 +1,3 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 RED='\033[0;31m'
 ENDCOLOR='\033[0m'
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 pnpm npm-run-all 'precommit:*'

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,3 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 if [[ $currentBranch == "main" ]]
 then
 	echo "⚠️ You should not push to the \`main\` branch"


### PR DESCRIPTION
## What does this change?
For some reason I merged #1479 as it had all green ticks, but some lines in the husky hooks have been deprecated and no longer work https://github.com/typicode/husky/releases/tag/v9.1.1
and need to be removed

## Why?
Breaking CI