### PR TITLE
spacefinder should avoid h3's

### DIFF
--- a/.changeset/seven-yaks-ring.md
+++ b/.changeset/seven-yaks-ring.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+spacefinder should avoid h3 headings

--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -39,7 +39,7 @@ const inlineOpponentSelector = [
 	.map((role) => `[data-spacefinder-role="${role}"]`)
 	.join(',');
 
-const headingSelector = ':scope > h2, [data-spacefinder-role="nested"] > h2';
+const headingSelector = `:scope > h2, [data-spacefinder-role="nested"] > h2, :scope > h3, [data-spacefinder-role="nested"] > h3`;
 
 const desktopInline1: SpacefinderRules = {
 	bodySelector,
@@ -119,8 +119,7 @@ const mobileMinDistanceFromArticleTop = 200;
 const mobileCandidateSelector =
 	':scope > p, :scope > h2, :scope > [data-spacefinder-type$="NumberedTitleBlockElement"], [data-spacefinder-role="nested"] > p';
 
-const mobileHeadingSelector =
-	':scope > h2, [data-spacefinder-role="nested"] > h2, :scope > [data-spacefinder-type$="NumberedTitleBlockElement"]';
+const mobileHeadingSelector = `${headingSelector}, :scope > [data-spacefinder-type$="NumberedTitleBlockElement"]`;
 
 const mobileOpponentSelectorRules = {
 	// don't place ads right after a heading

--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -49,7 +49,7 @@ const desktopInline1: SpacefinderRules = {
 	opponentSelectorRules: {
 		// don't place ads right after a heading
 		[headingSelector]: {
-			minAboveSlot: isInHighValueSection ? 150 : 5,
+			minAboveSlot: 150,
 			minBelowSlot: isInHighValueSection ? 0 : 190,
 		},
 		[adSlotContainerSelector]: {

--- a/src/insert/spacefinder/spacefinder.ts
+++ b/src/insert/spacefinder/spacefinder.ts
@@ -318,9 +318,9 @@ const testCandidate = (
 	}
 
 	const isOpponentBelow =
-		opponent.bottom > candidate.bottom && opponent.top > candidate.bottom;
+		opponent.bottom > candidate.bottom && opponent.top >= candidate.bottom;
 	const isOpponentAbove =
-		opponent.top < candidate.top && opponent.bottom < candidate.top;
+		opponent.top < candidate.top && opponent.bottom <= candidate.top;
 
 	// this can happen when the an opponent like an image or interactive is floated right
 	const opponentOverlaps =


### PR DESCRIPTION
## What does this change?
avoid h3 the same as we do for h2's

## Why?
I've spotted `h3`'s in the wild that are not being avoided since #1458, I think a `data-spacefinder-role="heading"` might be more suitable but can follow up with that.