### PR TITLE
conditionally render ad labels with data-show-label attribute

### DIFF
--- a/.changeset/gold-rules-joke.md
+++ b/.changeset/gold-rules-joke.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+centre ad label for ad slots

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -184,6 +184,8 @@ const setupBackground = async (
 		specs.scrollType,
 	);
 
+	const nativeTemplateId = 11885667;
+
 	return fastdom.mutate(() => {
 		setBackgroundStyles(specs, background);
 
@@ -210,7 +212,7 @@ const setupBackground = async (
 				adSlot.style.position = 'relative';
 			}
 
-			void renderAdvertLabel(adSlot);
+			void renderAdvertLabel(adSlot, nativeTemplateId);
 			void renderStickyScrollForMoreLabel(backgroundParent);
 
 			isDCR && renderBottomLine(background, backgroundParent);

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -184,7 +184,7 @@ const setupBackground = async (
 		specs.scrollType,
 	);
 
-	const nativeTemplateId = 11885667;
+	const interscrollerTemplateId = 11885667;
 
 	return fastdom.mutate(() => {
 		setBackgroundStyles(specs, background);
@@ -212,7 +212,7 @@ const setupBackground = async (
 				adSlot.style.position = 'relative';
 			}
 
-			void renderAdvertLabel(adSlot, nativeTemplateId);
+			void renderAdvertLabel(adSlot, interscrollerTemplateId);
 			void renderStickyScrollForMoreLabel(backgroundParent);
 
 			isDCR && renderBottomLine(background, backgroundParent);

--- a/src/events/render-advert-label.spec.ts
+++ b/src/events/render-advert-label.spec.ts
@@ -61,11 +61,11 @@ describe('shouldRenderLabel', () => {
 		});
 	});
 
-	it('does NOT render an ad label for fluid ads', async () => {
+	it('renders an ad label for fluid ads', async () => {
 		createAd(adverts['fluid']);
 		return renderAdvertLabel(getAd()).then(() => {
 			const ad = getAd();
-			expect(shouldRenderLabel(ad)).toBeFalsy();
+			expect(shouldRenderLabel(ad)).toBeTruthy();
 		});
 	});
 

--- a/src/events/render-advert-label.spec.ts
+++ b/src/events/render-advert-label.spec.ts
@@ -1,4 +1,8 @@
-import { renderAdvertLabel, shouldRenderLabel } from './render-advert-label';
+import {
+	renderAdvertLabel,
+	shouldRenderLabel,
+	templatesWithoutLabels,
+} from './render-advert-label';
 
 jest.mock('lib/commercial-features', () => ({
 	commercialFeatures: {},
@@ -45,75 +49,86 @@ describe('shouldRenderLabel', () => {
 		document.body.innerHTML = '';
 	});
 
+	const testCreativeTemplateId = 1234567;
+
 	it('renders an ad label for normal ads', async () => {
 		createAd(adverts['withLabel']);
-		return renderAdvertLabel(getAd()).then(() => {
+		return renderAdvertLabel(getAd(), testCreativeTemplateId).then(() => {
 			const ad = getAd();
-			expect(shouldRenderLabel(ad)).toBeTruthy();
+			expect(shouldRenderLabel(ad, testCreativeTemplateId)).toBeTruthy();
 		});
 	});
 
 	it('renders an ad label for interscroller ads', async () => {
 		createAd(adverts['interscroller']);
-		return renderAdvertLabel(getAd()).then(() => {
+		return renderAdvertLabel(getAd(), testCreativeTemplateId).then(() => {
 			const ad = getAd();
-			expect(shouldRenderLabel(ad)).toBeTruthy();
+			expect(shouldRenderLabel(ad, testCreativeTemplateId)).toBeTruthy();
 		});
 	});
 
 	it('renders an ad label for fluid ads', async () => {
 		createAd(adverts['fluid']);
-		return renderAdvertLabel(getAd()).then(() => {
+		return renderAdvertLabel(getAd(), testCreativeTemplateId).then(() => {
 			const ad = getAd();
-			expect(shouldRenderLabel(ad)).toBeTruthy();
+			expect(shouldRenderLabel(ad, testCreativeTemplateId)).toBeTruthy();
 		});
+	});
+
+	it('does NOT render an ad label for an ad with an excluded nativeStyleId', async () => {
+		for (const nativeAdId of templatesWithoutLabels) {
+			createAd(adverts['fluid']);
+			await renderAdvertLabel(getAd(), nativeAdId);
+			const ad = getAd();
+			expect(shouldRenderLabel(ad, nativeAdId)).toBeFalsy();
+		}
 	});
 
 	it('does NOT render an ad label for collapsed ads', async () => {
 		createAd(adverts['collapse']);
-		return renderAdvertLabel(getAd()).then(() => {
+		return renderAdvertLabel(getAd(), testCreativeTemplateId).then(() => {
 			const ad = getAd();
-			expect(shouldRenderLabel(ad)).toBeFalsy();
+			expect(shouldRenderLabel(ad, testCreativeTemplateId)).toBeFalsy();
 		});
 	});
 
 	it('renders an ad label when data label attribute is true', async () => {
 		createAd(adverts['dataLabelTrue']);
-		return renderAdvertLabel(getAd()).then(() => {
+		return renderAdvertLabel(getAd(), testCreativeTemplateId).then(() => {
 			const ad = getAd();
-			expect(shouldRenderLabel(ad)).toBeTruthy();
+			expect(shouldRenderLabel(ad, testCreativeTemplateId)).toBeTruthy();
 		});
 	});
 
 	it('does NOT render an ad label when data label attribute is false', async () => {
 		createAd(adverts['dataLabelFalse']);
-		return renderAdvertLabel(getAd()).then(() => {
+		return renderAdvertLabel(getAd(), testCreativeTemplateId).then(() => {
 			const ad = getAd();
-			expect(shouldRenderLabel(ad)).toBeFalsy();
+			expect(shouldRenderLabel(ad, testCreativeTemplateId)).toBeFalsy();
 		});
 	});
 
 	it('Will not add a label to frame ads', async () => {
 		createAd(adverts['frame']);
-		return renderAdvertLabel(getAd()).then(() => {
+		return renderAdvertLabel(getAd(), testCreativeTemplateId).then(() => {
 			const ad = getAd();
-			expect(shouldRenderLabel(ad)).toBeFalsy();
+			expect(shouldRenderLabel(ad, testCreativeTemplateId)).toBeFalsy();
 		});
 	});
 
 	it('Will not add a label to an ad slot with a hidden u-h class', async () => {
 		createAd(adverts['uh']);
-		return renderAdvertLabel(getAd()).then(() => {
+		return renderAdvertLabel(getAd(), testCreativeTemplateId).then(() => {
 			const ad = getAd();
-			expect(shouldRenderLabel(ad)).toBeFalsy();
+			expect(shouldRenderLabel(ad, testCreativeTemplateId)).toBeFalsy();
 		});
 	});
 
 	it('When the ad is top above nav and the label is NOT toggleable, render the label dynamically', async () => {
 		createAd(adverts['topAboveNav']);
-		return renderAdvertLabel(getAd()).then(() => {
+		return renderAdvertLabel(getAd(), testCreativeTemplateId).then(() => {
 			const ad = getAd();
-			expect(shouldRenderLabel(ad)).toBeTruthy();
+			expect(shouldRenderLabel(ad, testCreativeTemplateId)).toBeTruthy();
 		});
 	});
 });

--- a/src/events/render-advert-label.spec.ts
+++ b/src/events/render-advert-label.spec.ts
@@ -50,6 +50,7 @@ describe('shouldRenderLabel', () => {
 	});
 
 	const testCreativeTemplateId = 1234567;
+	const interscrollerTemplateId = 11885667;
 
 	it('renders an ad label for normal ads', async () => {
 		createAd(adverts['withLabel']);
@@ -61,9 +62,9 @@ describe('shouldRenderLabel', () => {
 
 	it('renders an ad label for interscroller ads', async () => {
 		createAd(adverts['interscroller']);
-		return renderAdvertLabel(getAd(), testCreativeTemplateId).then(() => {
+		return renderAdvertLabel(getAd(), interscrollerTemplateId).then(() => {
 			const ad = getAd();
-			expect(shouldRenderLabel(ad, testCreativeTemplateId)).toBeTruthy();
+			expect(shouldRenderLabel(ad, interscrollerTemplateId)).toBeTruthy();
 		});
 	});
 

--- a/src/events/render-advert-label.spec.ts
+++ b/src/events/render-advert-label.spec.ts
@@ -54,9 +54,9 @@ describe('shouldRenderLabel', () => {
 
 	it('renders an ad label for normal ads', async () => {
 		createAd(adverts['withLabel']);
-		return renderAdvertLabel(getAd(), testCreativeTemplateId).then(() => {
+		return renderAdvertLabel(getAd()).then(() => {
 			const ad = getAd();
-			expect(shouldRenderLabel(ad, testCreativeTemplateId)).toBeTruthy();
+			expect(shouldRenderLabel(ad)).toBeTruthy();
 		});
 	});
 
@@ -87,49 +87,49 @@ describe('shouldRenderLabel', () => {
 
 	it('does NOT render an ad label for collapsed ads', async () => {
 		createAd(adverts['collapse']);
-		return renderAdvertLabel(getAd(), testCreativeTemplateId).then(() => {
+		return renderAdvertLabel(getAd()).then(() => {
 			const ad = getAd();
-			expect(shouldRenderLabel(ad, testCreativeTemplateId)).toBeFalsy();
+			expect(shouldRenderLabel(ad)).toBeFalsy();
 		});
 	});
 
 	it('renders an ad label when data label attribute is true', async () => {
 		createAd(adverts['dataLabelTrue']);
-		return renderAdvertLabel(getAd(), testCreativeTemplateId).then(() => {
+		return renderAdvertLabel(getAd()).then(() => {
 			const ad = getAd();
-			expect(shouldRenderLabel(ad, testCreativeTemplateId)).toBeTruthy();
+			expect(shouldRenderLabel(ad)).toBeTruthy();
 		});
 	});
 
 	it('does NOT render an ad label when data label attribute is false', async () => {
 		createAd(adverts['dataLabelFalse']);
-		return renderAdvertLabel(getAd(), testCreativeTemplateId).then(() => {
+		return renderAdvertLabel(getAd()).then(() => {
 			const ad = getAd();
-			expect(shouldRenderLabel(ad, testCreativeTemplateId)).toBeFalsy();
+			expect(shouldRenderLabel(ad)).toBeFalsy();
 		});
 	});
 
 	it('Will not add a label to frame ads', async () => {
 		createAd(adverts['frame']);
-		return renderAdvertLabel(getAd(), testCreativeTemplateId).then(() => {
+		return renderAdvertLabel(getAd()).then(() => {
 			const ad = getAd();
-			expect(shouldRenderLabel(ad, testCreativeTemplateId)).toBeFalsy();
+			expect(shouldRenderLabel(ad)).toBeFalsy();
 		});
 	});
 
 	it('Will not add a label to an ad slot with a hidden u-h class', async () => {
 		createAd(adverts['uh']);
-		return renderAdvertLabel(getAd(), testCreativeTemplateId).then(() => {
+		return renderAdvertLabel(getAd()).then(() => {
 			const ad = getAd();
-			expect(shouldRenderLabel(ad, testCreativeTemplateId)).toBeFalsy();
+			expect(shouldRenderLabel(ad)).toBeFalsy();
 		});
 	});
 
 	it('When the ad is top above nav and the label is NOT toggleable, render the label dynamically', async () => {
 		createAd(adverts['topAboveNav']);
-		return renderAdvertLabel(getAd(), testCreativeTemplateId).then(() => {
+		return renderAdvertLabel(getAd()).then(() => {
 			const ad = getAd();
-			expect(shouldRenderLabel(ad, testCreativeTemplateId)).toBeTruthy();
+			expect(shouldRenderLabel(ad)).toBeTruthy();
 		});
 	});
 });

--- a/src/events/render-advert-label.ts
+++ b/src/events/render-advert-label.ts
@@ -7,24 +7,20 @@ import { getCookie } from '@guardian/libs';
 import fastdom from 'utils/fastdom-promise';
 import crossIcon from '../../static/svg/icon/cross.svg';
 
-const CAPI_SINGLE_PAIDFOR = 10077207;
-const CAPI_MULTIPLE_PAIDFOR = 10069167;
-const EVENTS_API_MULTIPLE_STYLE = 12317037;
-const CAPI_MULTIPLE_HOSTED = 10070487;
-const MANUAL_MULTIPLE = 10063287;
+const templatesWithoutLabels = [
+	10077207, // CAPI_MULTIPLE_HOSTED
+	10069167, // CAPI_MULTIPLE_PAIDFOR
+	12317037, // EVENTS_MULTIPLE
+	10070487, // CAPI_SINGLE_PAIDFOR
+	10063287, // MANUAL_MULTIPLE
+];
 
 const shouldRenderLabel = (
 	adSlotNode: HTMLElement,
 	creativeTemplateId: number,
 ): boolean => {
-	if (
-		creativeTemplateId === CAPI_SINGLE_PAIDFOR ||
-		creativeTemplateId === CAPI_MULTIPLE_PAIDFOR ||
-		creativeTemplateId === EVENTS_API_MULTIPLE_STYLE ||
-		creativeTemplateId === CAPI_MULTIPLE_HOSTED ||
-		creativeTemplateId === MANUAL_MULTIPLE
-	) {
-		return true;
+	if (templatesWithoutLabels.includes(creativeTemplateId)) {
+		return false;
 	}
 	if (
 		adSlotNode.classList.contains('ad-slot--frame') ||
@@ -105,7 +101,6 @@ const renderAdvertLabel = (
 ): Promise<Promise<void>> => {
 	return fastdom.measure(() => {
 		if (shouldRenderLabel(adSlotNode, creativeTemplateId)) {
-			///here
 			const renderAdTestLabel = shouldRenderAdTestLabel(adSlotNode);
 			const adTestClearExists =
 				adSlotNode.parentNode?.firstElementChild

--- a/src/events/render-advert-label.ts
+++ b/src/events/render-advert-label.ts
@@ -19,7 +19,10 @@ const shouldRenderLabel = (
 	adSlotNode: HTMLElement,
 	creativeTemplateId?: number,
 ): boolean => {
-	if (templatesWithoutLabels.includes(creativeTemplateId ?? 0)) {
+	if (
+		creativeTemplateId &&
+		templatesWithoutLabels.includes(creativeTemplateId)
+	) {
 		return false;
 	}
 	if (

--- a/src/events/render-advert-label.ts
+++ b/src/events/render-advert-label.ts
@@ -7,7 +7,25 @@ import { getCookie } from '@guardian/libs';
 import fastdom from 'utils/fastdom-promise';
 import crossIcon from '../../static/svg/icon/cross.svg';
 
-const shouldRenderLabel = (adSlotNode: HTMLElement): boolean => {
+const CAPI_SINGLE_PAIDFOR = 10077207;
+const CAPI_MULTIPLE_PAIDFOR = 10069167;
+const EVENTS_API_MULTIPLE_STYLE = 12317037;
+const CAPI_MULTIPLE_HOSTED = 10070487;
+const MANUAL_MULTIPLE = 10063287;
+
+const shouldRenderLabel = (
+	adSlotNode: HTMLElement,
+	creativeTemplateId: number,
+): boolean => {
+	if (
+		creativeTemplateId === CAPI_SINGLE_PAIDFOR ||
+		creativeTemplateId === CAPI_MULTIPLE_PAIDFOR ||
+		creativeTemplateId === EVENTS_API_MULTIPLE_STYLE ||
+		creativeTemplateId === CAPI_MULTIPLE_HOSTED ||
+		creativeTemplateId === MANUAL_MULTIPLE
+	) {
+		return true;
+	}
 	if (
 		adSlotNode.classList.contains('ad-slot--frame') ||
 		adSlotNode.classList.contains('ad-slot--gc') ||
@@ -81,9 +99,13 @@ const createAdTestCookieRemovalLink = (): HTMLElement => {
 	return adTestCookieRemovalLink;
 };
 
-const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<Promise<void>> => {
+const renderAdvertLabel = (
+	adSlotNode: HTMLElement,
+	creativeTemplateId: number,
+): Promise<Promise<void>> => {
 	return fastdom.measure(() => {
-		if (shouldRenderLabel(adSlotNode)) {
+		if (shouldRenderLabel(adSlotNode, creativeTemplateId)) {
+			///here
 			const renderAdTestLabel = shouldRenderAdTestLabel(adSlotNode);
 			const adTestClearExists =
 				adSlotNode.parentNode?.firstElementChild
@@ -100,7 +122,6 @@ const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<Promise<void>> => {
 
 			return fastdom.mutate(() => {
 				adSlotNode.setAttribute('data-label-show', 'true');
-				adSlotNode.setAttribute('my-test-one', 'true');
 				adSlotNode.setAttribute('ad-label-text', adLabelContent);
 				// Remove this once new `ad-slot-container--centre-slot` class is in place
 				if (

--- a/src/events/render-advert-label.ts
+++ b/src/events/render-advert-label.ts
@@ -17,9 +17,9 @@ const templatesWithoutLabels = [
 
 const shouldRenderLabel = (
 	adSlotNode: HTMLElement,
-	creativeTemplateId: number,
+	creativeTemplateId?: number,
 ): boolean => {
-	if (templatesWithoutLabels.includes(creativeTemplateId)) {
+	if (templatesWithoutLabels.includes(creativeTemplateId ?? 0)) {
 		return false;
 	}
 	if (
@@ -97,7 +97,7 @@ const createAdTestCookieRemovalLink = (): HTMLElement => {
 
 const renderAdvertLabel = (
 	adSlotNode: HTMLElement,
-	creativeTemplateId: number,
+	creativeTemplateId?: number,
 ): Promise<Promise<void>> => {
 	return fastdom.measure(() => {
 		if (shouldRenderLabel(adSlotNode, creativeTemplateId)) {

--- a/src/events/render-advert-label.ts
+++ b/src/events/render-advert-label.ts
@@ -9,14 +9,6 @@ import crossIcon from '../../static/svg/icon/cross.svg';
 
 const shouldRenderLabel = (adSlotNode: HTMLElement): boolean => {
 	if (
-		adSlotNode.classList.contains('ad-slot--fluid') &&
-		!adSlotNode.classList.contains('ad-slot--interscroller') &&
-		!adSlotNode.classList.contains('ad-slot--article-end')
-	) {
-		return false;
-	}
-
-	if (
 		adSlotNode.classList.contains('ad-slot--frame') ||
 		adSlotNode.classList.contains('ad-slot--gc') ||
 		adSlotNode.classList.contains('u-h') ||
@@ -108,6 +100,7 @@ const renderAdvertLabel = (adSlotNode: HTMLElement): Promise<Promise<void>> => {
 
 			return fastdom.mutate(() => {
 				adSlotNode.setAttribute('data-label-show', 'true');
+				adSlotNode.setAttribute('my-test-one', 'true');
 				adSlotNode.setAttribute('ad-label-text', adLabelContent);
 				// Remove this once new `ad-slot-container--centre-slot` class is in place
 				if (

--- a/src/events/render-advert-label.ts
+++ b/src/events/render-advert-label.ts
@@ -174,4 +174,9 @@ const renderStickyScrollForMoreLabel = (
 		adSlotNode.appendChild(scrollForMoreLabel);
 	});
 
-export { renderAdvertLabel, renderStickyScrollForMoreLabel, shouldRenderLabel };
+export {
+	renderAdvertLabel,
+	renderStickyScrollForMoreLabel,
+	shouldRenderLabel,
+	templatesWithoutLabels,
+};

--- a/src/events/render-advert.ts
+++ b/src/events/render-advert.ts
@@ -187,7 +187,8 @@ const renderAdvert = (
 
 	return getAdIframe(advert.node)
 		.then((isRendered) => {
-			const creativeTemplateId = slotRenderEndedEvent.creativeTemplateId;
+			const creativeTemplateId =
+				slotRenderEndedEvent.creativeTemplateId ?? undefined;
 			const callSizeCallback = () => {
 				if (advert.size) {
 					/**
@@ -215,9 +216,7 @@ const renderAdvert = (
 					: Promise.resolve();
 
 			return callSizeCallback()
-				.then(() =>
-					renderAdvertLabel(advert.node, creativeTemplateId ?? 0),
-				)
+				.then(() => renderAdvertLabel(advert.node, creativeTemplateId))
 				.then(() => addContainerClass(advert.node, isRendered))
 				.then(addRenderedClass)
 				.then(() => isRendered);

--- a/src/events/render-advert.ts
+++ b/src/events/render-advert.ts
@@ -187,6 +187,7 @@ const renderAdvert = (
 
 	return getAdIframe(advert.node)
 		.then((isRendered) => {
+			const creativeTemplateId = slotRenderEndedEvent.creativeTemplateId;
 			const callSizeCallback = () => {
 				if (advert.size) {
 					/**
@@ -214,7 +215,9 @@ const renderAdvert = (
 					: Promise.resolve();
 
 			return callSizeCallback()
-				.then(() => renderAdvertLabel(advert.node))
+				.then(() =>
+					renderAdvertLabel(advert.node, creativeTemplateId ?? 0),
+				)
 				.then(() => addContainerClass(advert.node, isRendered))
 				.then(addRenderedClass)
 				.then(() => isRendered);


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->


## What does this change?

This PR is part of a bigger project to remove the Native ad-labels at inception from commercial templates: related PR.

Currently the logic which decides if an label should be rendered lies here in the Commercial bundle. This logic will applies a `data-label-show='true'` class attribute to the `adSlotNode`.

This will enable the CSS set out in [DCR](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/src/components/AdSlot.web.tsx#L118), to apply the ad label styling.

## Why?
The AdSlots are added to the article server-side rendered (in DCR). The CSS for rendering the Ad label is also server-side rendered and targets .ad-slot[data-label-show='true']:not(.ad-slot--interscroller)::before.

The commercial bundle dynamically adds the data-label-show='true' attribute, handled by the shouldRenderLabel function.

The "Advertisement" label has been removed from the Native ads in commercial-templates as part of [this PR](https://github.com/guardian/commercial-templates/pull/394).

When the commercial code detects sizeCallbacks[adSizes.fluid.toString()] (Native ads), it adds the class. However, there is one Native style ad slot where we do not want to add the Ad Label. Instead of removing the ad-slot--fluid class, this is handled in the shouldRenderLabel function.

Logic has been added to not add a label for these Native Format ID's defined in GAM.

| From GAM Native Format ID |
|------------|
|<img width="1097" alt="Screenshot 2024-08-02 at 10 41 04" src="https://github.com/user-attachments/assets/1068ecf1-840c-45e6-98ad-0ac8bf2cada6"> | 
|<img width="556" alt="Screenshot 2024-08-02 at 11 11 57" src="https://github.com/user-attachments/assets/ae489d4b-435a-4bce-810a-f5dcee888a0d"> |

- 10077207, // CAPI_MULTIPLE_HOSTED
- 10069167, // CAPI_MULTIPLE_PAIDFOR
- 12317037, // EVENTS_MULTIPLE
- 10070487, // CAPI_SINGLE_PAIDFOR
- 10063287, // MANUAL_MULTIPLE

It is only the in house fabric we add that we want labels to be added to.
## Images

| Before | After |
|----------|----------|
|<img width="1011" alt="Screenshot 2024-07-26 at 14 39 29" src="https://github.com/user-attachments/assets/912a9325-2e1c-4824-b95e-b0c86df91135">|<img width="933" alt="Screenshot 2024-07-26 at 14 35 17" src="https://github.com/user-attachments/assets/dd631b64-96c7-4220-8fab-a60aa7601865"> | 

### Example of merchandising advert not rendering an ad label with 

| Merchandising slot | adSlotNode Native ID CAPI_SINGLE_PAIDFOR |
|----------|----------|
| ![Screenshot 2024-08-06 at 14 12 20](https://github.com/user-attachments/assets/21ca7895-ab8a-4eaa-898f-0db9a3c00296)| ![Screenshot 2024-08-06 at 14 13 42](https://github.com/user-attachments/assets/e935f1fd-7e6b-4113-a55d-20538b66a4c2)|

