### PR TITLE
[GEM] Only fill slot via gem if opt out response empty

### DIFF
--- a/src/commercial.ts
+++ b/src/commercial.ts
@@ -1,6 +1,6 @@
-// import { getConsentFor, onConsent } from '@guardian/libs';
-// import { commercialFeatures } from 'lib/commercial-features';
+import { getConsentFor, onConsent } from '@guardian/libs';
 import { initElementsManager } from 'init/elements-manager';
+import { commercialFeatures } from 'lib/commercial-features';
 
 const { frontendAssetsFullURL, page } = window.guardian.config;
 
@@ -17,28 +17,33 @@ __webpack_public_path__ = decideAssetsPath();
 /**
  * Choose whether to launch Googletag or Opt Out tag (ootag) based on consent state
  */
-// void (async () => {
-// 	const consentState = await onConsent();
-// 	// Only load the Opt Out tag if:
-// 	// - Opt Out switch is on
-// 	// - in TCF region
-// 	// - no consent for Googletag
-// 	// - the user is not a subscriber
-// 	if (
-// 		window.guardian.config.switches.optOutAdvertising &&
-// 		consentState.tcfv2 &&
-// 		!getConsentFor('googletag', consentState) &&
-// 		!commercialFeatures.adFree
-// 	) {
-// 		void import(
-// 			/* webpackChunkName: "consentless" */
-// 			'./init/consentless'
-// 		).then(({ bootConsentless }) => bootConsentless(consentState));
-// 	} else {
-// 		void import(
-// 			/* webpackChunkName: "consented" */
-// 			'./init/consented'
-// 		).then(({ bootCommercialWhenReady }) => bootCommercialWhenReady());
-// 	}
-// })();
-void initElementsManager();
+void (async () => {
+	const params = new URLSearchParams(window.location.search);
+	if (params.has('forcegem')) {
+		await initElementsManager();
+		await
+	}
+
+	const consentState = await onConsent();
+	// Only load the Opt Out tag if:
+	// - Opt Out switch is on
+	// - in TCF region
+	// - no consent for Googletag
+	// - the user is not a subscriber
+	if (
+		window.guardian.config.switches.optOutAdvertising &&
+		consentState.tcfv2 &&
+		!getConsentFor('googletag', consentState) &&
+		!commercialFeatures.adFree
+	) {
+		void import(
+			/* webpackChunkName: "consentless" */
+			'./init/consentless'
+		).then(({ bootConsentless }) => bootConsentless(consentState));
+	} else {
+		void import(
+			/* webpackChunkName: "consented" */
+			'./init/consented'
+		).then(({ bootCommercialWhenReady }) => bootCommercialWhenReady());
+	}
+})();

--- a/src/commercial.ts
+++ b/src/commercial.ts
@@ -1,5 +1,8 @@
 import { getConsentFor, onConsent } from '@guardian/libs';
-import { initElementsManager } from 'init/elements-manager';
+import {
+	fillAdSlots as gemFillAdSlots,
+	initElementsManager,
+} from 'init/elements-manager';
 import { commercialFeatures } from 'lib/commercial-features';
 
 const { frontendAssetsFullURL, page } = window.guardian.config;
@@ -21,7 +24,8 @@ void (async () => {
 	const params = new URLSearchParams(window.location.search);
 	if (params.has('forcegem')) {
 		await initElementsManager();
-		await
+		await gemFillAdSlots();
+		return;
 	}
 
 	const consentState = await onConsent();

--- a/src/elements-manager/elements-manager.ts
+++ b/src/elements-manager/elements-manager.ts
@@ -202,7 +202,7 @@ class Ad {
 		});
 	}
 
-	public async display() {
+	public async display(): Promise<boolean> {
 		const targeting: PageTargeting = {
 			...this.elementsManager.pageTargeting,
 			...this.targeting,
@@ -230,7 +230,7 @@ class Ad {
 
 		if (!creative) {
 			log('commercial', `No creative found for ${this.name}`);
-			return;
+			return false;
 		}
 
 		const { assetUrl, destinationUrl, size, type } = creative;
@@ -239,7 +239,7 @@ class Ad {
 
 		// 2x2 is a special size that means "no ad"
 		if (size[0] === 2 && size[1] === 2) {
-			return;
+			return true;
 		}
 
 		const addElements = this.addElements(
@@ -253,7 +253,7 @@ class Ad {
 
 		this.isRendered = true;
 
-		return addElements;
+		return addElements.then(() => true);
 	}
 }
 

--- a/src/elements-manager/find-creative.test.ts
+++ b/src/elements-manager/find-creative.test.ts
@@ -41,7 +41,9 @@ describe('pickLineItem', () => {
 			(a, b) => b[1] - a[1],
 		);
 
-		const sortedPrioritiesValues = sortedPriorities.map((x) => x[0]);
+		const sortedPrioritiesValues = sortedPriorities
+			.map((x) => x[0])
+			.sort((a, b) => +a - +b);
 
 		expect(sortedPrioritiesValues).toEqual(
 			Object.keys(priorityCounts).sort((a, b) => +a - +b),

--- a/src/init/consentless/define-slot.ts
+++ b/src/init/consentless/define-slot.ts
@@ -1,7 +1,8 @@
 import { log } from '@guardian/libs';
-import fastdom from 'fastdom';
 import { removeSlotFromDom } from 'events/empty-advert';
+import { getElementsManager } from 'init/elements-manager';
 import type { OptOutFilledCallback } from 'types/global';
+import fastdom from 'utils/fastdom-promise';
 import { renderConsentlessAdvertLabel } from './render-advert-label';
 
 /**
@@ -48,8 +49,18 @@ const defineSlot = (
 
 	const emptyCallback = () => {
 		log('commercial', `Empty consentless ${slotId}`);
-		fastdom.mutate(() => {
-			removeSlotFromDom(slot);
+
+		void fastdom.mutate(() => {
+			void (async () => {
+				const didDisplay = await getElementsManager()
+					.createAdvert(slotName, slot)
+					.display();
+
+				if (didDisplay) {
+					return;
+				}
+				removeSlotFromDom(slot);
+			})();
 		});
 	};
 

--- a/src/init/consentless/define-slot.ts
+++ b/src/init/consentless/define-slot.ts
@@ -1,6 +1,6 @@
 import { log } from '@guardian/libs';
 import { removeSlotFromDom } from 'events/empty-advert';
-import { getElementsManager } from 'init/elements-manager';
+import { initElementsManager } from 'init/elements-manager';
 import type { OptOutFilledCallback } from 'types/global';
 import fastdom from 'utils/fastdom-promise';
 import { renderConsentlessAdvertLabel } from './render-advert-label';
@@ -52,7 +52,8 @@ const defineSlot = (
 
 		void fastdom.mutate(() => {
 			void (async () => {
-				const didDisplay = await getElementsManager()
+				const elementsManager = await initElementsManager();
+				const didDisplay = await elementsManager
 					.createAdvert(slotName, slot)
 					.display();
 

--- a/src/init/elements-manager.ts
+++ b/src/init/elements-manager.ts
@@ -4,7 +4,13 @@ import { ElementsManager } from 'elements-manager/elements-manager';
 import { getPageTargeting } from 'lib/build-page-targeting';
 import { isUserLoggedInOktaRefactor } from 'lib/identity/api';
 
+let elementsManager: ElementsManager | undefined;
+
 const initElementsManager = async (): Promise<void> => {
+	if(elementsManager) {
+		return;
+	}
+
 	const [consentState, isSignedIn] = await Promise.all([
 		onConsent(),
 		isUserLoggedInOktaRefactor(),
@@ -12,13 +18,31 @@ const initElementsManager = async (): Promise<void> => {
 
 	const pageTargeting = getPageTargeting(consentState, isSignedIn);
 
-	const elementsManager = ElementsManager.init(pageTargeting);
-
-	const staticAdverts = elementsManager.createStaticAdverts();
-
-	void Promise.all(staticAdverts.map((ad) => ad.display()));
-
-	void initArticleBodyAdverts();
+	elementsManager = ElementsManager.init(pageTargeting);
 };
 
-export { initElementsManager };
+const getElementsManager = (): ElementsManager => {
+	if (!elementsManager) {
+		throw new Error('ElementsManager not initialised');
+	}
+
+	return elementsManager;
+}
+
+/**
+ * Use the ElementsManager to fill all ad slots on the page
+ * Only used via a url parameter, usually slots are filled when opt out does not have an ad
+ */
+const fillAdSlots = async (): Promise<void> => {
+	const staticAdverts = getElementsManager().createStaticAdverts();
+
+  const fillStatic = Promise.all(staticAdverts.map((ad) => ad.display()));
+
+  const fillDynamic = initArticleBodyAdverts();
+
+  await Promise.all([fillStatic, fillDynamic]);
+}
+
+
+
+export { initElementsManager, getElementsManager, fillAdSlots };

--- a/src/init/elements-manager.ts
+++ b/src/init/elements-manager.ts
@@ -7,7 +7,7 @@ import { isUserLoggedInOktaRefactor } from 'lib/identity/api';
 let elementsManager: ElementsManager | undefined;
 
 const initElementsManager = async (): Promise<ElementsManager> => {
-	if(elementsManager) {
+	if (elementsManager) {
 		return elementsManager;
 	}
 
@@ -28,7 +28,7 @@ const getElementsManager = (): ElementsManager => {
 	}
 
 	return elementsManager;
-}
+};
 
 /**
  * Use the ElementsManager to fill all ad slots on the page
@@ -37,13 +37,11 @@ const getElementsManager = (): ElementsManager => {
 const fillAdSlots = async (): Promise<void> => {
 	const staticAdverts = getElementsManager().createStaticAdverts();
 
-  const fillStatic = Promise.all(staticAdverts.map((ad) => ad.display()));
+	const fillStatic = Promise.all(staticAdverts.map((ad) => ad.display()));
 
-  const fillDynamic = initArticleBodyAdverts();
+	const fillDynamic = initArticleBodyAdverts();
 
-  await Promise.all([fillStatic, fillDynamic]);
-}
-
-
+	await Promise.all([fillStatic, fillDynamic]);
+};
 
 export { initElementsManager, getElementsManager, fillAdSlots };

--- a/src/init/elements-manager.ts
+++ b/src/init/elements-manager.ts
@@ -6,9 +6,9 @@ import { isUserLoggedInOktaRefactor } from 'lib/identity/api';
 
 let elementsManager: ElementsManager | undefined;
 
-const initElementsManager = async (): Promise<void> => {
+const initElementsManager = async (): Promise<ElementsManager> => {
 	if(elementsManager) {
-		return;
+		return elementsManager;
 	}
 
 	const [consentState, isSignedIn] = await Promise.all([
@@ -19,6 +19,7 @@ const initElementsManager = async (): Promise<void> => {
 	const pageTargeting = getPageTargeting(consentState, isSignedIn);
 
 	elementsManager = ElementsManager.init(pageTargeting);
+	return elementsManager;
 };
 
 const getElementsManager = (): ElementsManager => {


### PR DESCRIPTION
_Merging into #1470 not main_
## What does this change?
Only run elements manager if the opt out response is empty or if the url param `forcegem` is present