### PR TITLE
Add opt out frequency capping behind test for debugging

### DIFF
--- a/.changeset/lovely-seas-knock.md
+++ b/.changeset/lovely-seas-knock.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Add opt out frequency capping behind test for debugging

--- a/src/experiments/ab-tests.ts
+++ b/src/experiments/ab-tests.ts
@@ -1,5 +1,6 @@
 import type { ABTest } from '@guardian/ab-core';
 import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
+import { optOutFrequencyCap } from './tests/opt-out-frequency-cap';
 
 /**
  * You only need to add tests to this file if the code you are testing is here in
@@ -9,4 +10,5 @@ import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
 export const concurrentTests: ABTest[] = [
 	// one test per line
 	mpuWhenNoEpic,
+	optOutFrequencyCap,
 ];

--- a/src/experiments/tests/opt-out-frequency-cap.ts
+++ b/src/experiments/tests/opt-out-frequency-cap.ts
@@ -1,0 +1,28 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const optOutFrequencyCap: ABTest = {
+	id: 'optOutFrequencyCap',
+	author: '@commercial-dev',
+	start: '2024-07-18',
+	expiry: '2024-09-30',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: '',
+	successMeasure: '',
+	description: 'Test frequency capping feature of Opt Out.',
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+	canRun: () => true,
+};

--- a/src/experiments/tests/opt-out-frequency-cap.ts
+++ b/src/experiments/tests/opt-out-frequency-cap.ts
@@ -3,8 +3,8 @@ import type { ABTest } from '@guardian/ab-core';
 export const optOutFrequencyCap: ABTest = {
 	id: 'optOutFrequencyCap',
 	author: '@commercial-dev',
-	start: '2024-07-18',
-	expiry: '2024-09-30',
+	start: '2024-08-01',
+	expiry: '2024-08-30',
 	audience: 0 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',

--- a/src/init/consentless/prepare-ootag.ts
+++ b/src/init/consentless/prepare-ootag.ts
@@ -1,6 +1,8 @@
 import type { ConsentState } from '@guardian/libs';
 import { loadScript, log } from '@guardian/libs';
 import { buildPageTargetingConsentless } from 'core/targeting/build-page-targeting-consentless';
+import { isUserInVariant } from 'experiments/ab';
+import { optOutFrequencyCap } from 'experiments/tests/opt-out-frequency-cap';
 import { commercialFeatures } from 'lib/commercial-features';
 import { isUserLoggedInOktaRefactor } from 'lib/identity/api';
 
@@ -11,6 +13,11 @@ function initConsentless(consentState: ConsentState): Promise<void> {
 		window.ootag = {
 			queue: [],
 		};
+
+		const isInFrequencyCapTest = isUserInVariant(
+			optOutFrequencyCap,
+			'variant',
+		);
 
 		window.ootag.queue.push(function () {
 			// Ensures Opt Out logs are namespaced under Commercial
@@ -24,6 +31,10 @@ function initConsentless(consentState: ConsentState): Promise<void> {
 				noLogging: 1,
 				alwaysNoConsent: 1,
 				noRequestsOnPageLoad: 1,
+				frequencyScript: isInFrequencyCapTest
+					? 'https://frequencycappingwithoutpersonaldata.com/script/iframe'
+					: undefined,
+				debug_forceCap: isInFrequencyCapTest ? 1 : undefined,
 			});
 
 			void isUserLoggedInOktaRefactor().then((isSignedIn) => {

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -330,6 +330,8 @@ interface OptOutInitializeOptions {
 	noLogging?: 0 | 1;
 	lazyLoading?: { fractionInView?: number; viewPortMargin?: string };
 	noRequestsOnPageLoad?: 0 | 1;
+	frequencyScript?: string;
+	debug_forceCap?: number;
 }
 
 interface OptOutResponse {


### PR DESCRIPTION
## What does this change?
Add opt out frequency capping behind a 0% test

Switch PR here https://github.com/guardian/frontend/pull/27377

## Why?
Opt out would like to review it, it's also not working as far as I can see, so hopefully they can shed some light!