### PR TITLE
Add Spacefinder inline1 desktop margin changes behind a 0% test

### DIFF
--- a/.changeset/blue-wombats-wave.md
+++ b/.changeset/blue-wombats-wave.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Add a test for new spacefinder margin values

--- a/src/experiments/tests/optimise-spacefinder-inline.ts
+++ b/src/experiments/tests/optimise-spacefinder-inline.ts
@@ -1,0 +1,28 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const optimiseSpacefinderInline: ABTest = {
+	id: 'optimiseSpacefinderInline',
+	author: '@commercial-dev',
+	start: '2024-08-08',
+	expiry: '2024-09-13',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: '',
+	successMeasure: '',
+	description: 'Test new spacefinder rules for inline1 ads on desktop.',
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+	canRun: () => true,
+};

--- a/src/experiments/tests/optimise-spacefinder-inline.ts
+++ b/src/experiments/tests/optimise-spacefinder-inline.ts
@@ -1,7 +1,7 @@
 import type { ABTest } from '@guardian/ab-core';
 
 export const optimiseSpacefinderInline: ABTest = {
-	id: 'optimiseSpacefinderInline',
+	id: 'OptimiseSpacefinderInline',
 	author: '@commercial-dev',
 	start: '2024-08-08',
 	expiry: '2024-09-13',

--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -1,5 +1,7 @@
 import { adSizes } from 'core';
 import { adSlotContainerClass } from 'core/create-ad-slot';
+import { isUserInVariant } from 'experiments/ab';
+import { optimiseSpacefinderInline } from 'experiments/tests/optimise-spacefinder-inline';
 import type { OpponentSelectorRules, SpacefinderRules } from './spacefinder';
 import { isInHighValueSection } from './utils';
 
@@ -27,18 +29,20 @@ const minDistanceBetweenInlineAds = isInHighValueSection ? 500 : 750;
 
 const candidateSelector = ':scope > p, [data-spacefinder-role="nested"] > p';
 
+const leftColumnOpponentSelector = ['richLink', 'thumbnail']
+	.map((role) => `[data-spacefinder-role="${role}"]`)
+	.join(',');
 const rightColumnOpponentSelector = '[data-spacefinder-role="immersive"]';
-const inlineOpponentSelector = [
-	'inline',
-	'supporting',
-	'showcase',
-	'thumbnail',
-	'richLink',
-]
+const inlineOpponentSelector = ['inline', 'supporting', 'showcase']
 	.map((role) => `[data-spacefinder-role="${role}"]`)
 	.join(',');
 
 const headingSelector = `:scope > h2, [data-spacefinder-role="nested"] > h2, :scope > h3, [data-spacefinder-role="nested"] > h3`;
+
+const isInInlineSpacefinderOptimisationTest = isUserInVariant(
+	optimiseSpacefinderInline,
+	'variant',
+);
 
 const desktopInline1: SpacefinderRules = {
 	bodySelector,
@@ -57,11 +61,15 @@ const desktopInline1: SpacefinderRules = {
 		},
 		[inlineOpponentSelector]: {
 			marginBottom: 35,
-			marginTop: 400,
+			marginTop: isInInlineSpacefinderOptimisationTest ? 200 : 400,
+		},
+		[leftColumnOpponentSelector]: {
+			marginBottom: isInInlineSpacefinderOptimisationTest ? 0 : 35,
+			marginTop: isInInlineSpacefinderOptimisationTest ? 100 : 400,
 		},
 		[rightColumnOpponentSelector]: {
 			marginBottom: 0,
-			marginTop: 600,
+			marginTop: isInInlineSpacefinderOptimisationTest ? 150 : 600,
 		},
 		['[data-spacefinder-role="supporting"]']: {
 			marginBottom: 0,


### PR DESCRIPTION
## What does this change?
Adds some potential spacefinder optimisations for the desktop inline1 slot behind a 0% test. This rule set has some pretty large margins that we're convinced need to be so cautious. We want to AB test these changes to see if they boost ad ratio, so we're popping them behind a 0% test for now.

More detailed examples of each change are given below.

### Rich links
These are currently avoided in exactly the same way as an inline image, which seems overly strict. By relaxing the rules we can improve the placement of inline1 significantly and it still looks fine.

#### Before:
No inline1 appeared on this whole article because the paragraphs were considered too close to the rich link
<img width="712" alt="Screenshot 2024-08-08 at 12 28 46" src="https://github.com/user-attachments/assets/647965fc-9a87-4429-9523-2b0a6097bb99">

#### After:
Inline1 appears, and I think this looks absolutely fine with the rich link still
<img width="597" alt="Screenshot 2024-08-08 at 12 30 44" src="https://github.com/user-attachments/assets/d4e86e67-3ea4-4820-a989-5df5c6dd42cf">

### Thumbnails
Rule changes now mean that ads can appear underneath thumbnail images. They still can't overlap, but it allows inline1 to appear higher up on a lot of articles - especially recipes which use thumbnail images a lot.

#### Before:
<img width="698" alt="Screenshot 2024-08-08 at 12 22 03" src="https://github.com/user-attachments/assets/a0c90225-9bb8-421c-ad3d-08c9badae4a9">

#### After:
<img width="711" alt="Screenshot 2024-08-08 at 12 21 44" src="https://github.com/user-attachments/assets/f234eb7a-614a-4f1f-b240-dea8c5f72f29">

### Immersives
At the moment we set a 600px margin on immersive elements (images that span into the right column). This means that on picture essays, we don't really get inline 1 ads. By reducing the margin, we should be able to introduce inline1 ads into some picture essays.

#### Before:
<img width="976" alt="Screenshot 2024-08-08 at 16 08 21" src="https://github.com/user-attachments/assets/e0ad6f5f-df57-460b-92c2-3d18f8327d8c">

#### After:
<img width="707" alt="Screenshot 2024-08-08 at 16 07 59" src="https://github.com/user-attachments/assets/de9af5c1-e240-4aaa-a021-9440d6ed3cf4">

### Inlines
By reducing the margin from 400 to 200 we can get a few more inline1 ads, without them being overly close to other inline elements.

#### Before:
The newsletter sign up block is too close for an inline1 to be inserted on this article.
<img width="875" alt="Screenshot 2024-08-08 at 18 13 41" src="https://github.com/user-attachments/assets/d76e41f2-3d3e-49b5-a975-584cbfcda1b8">

#### After:
<img width="963" alt="Screenshot 2024-08-08 at 18 13 22" src="https://github.com/user-attachments/assets/c5c1abeb-a676-4233-b497-5fc46e12f6d1">


