### PR TITLE
remove debug_forceCap from the frequency cap test

### DIFF
--- a/.changeset/sharp-melons-flash.md
+++ b/.changeset/sharp-melons-flash.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+remove debug_forceCap

--- a/src/init/consentless/prepare-ootag.ts
+++ b/src/init/consentless/prepare-ootag.ts
@@ -34,7 +34,6 @@ function initConsentless(consentState: ConsentState): Promise<void> {
 				frequencyScript: isInFrequencyCapTest
 					? 'https://frequencycappingwithoutpersonaldata.com/script/iframe'
 					: undefined,
-				debug_forceCap: isInFrequencyCapTest ? 1 : undefined,
 			});
 
 			void isUserLoggedInOktaRefactor().then((isSignedIn) => {


### PR DESCRIPTION
## Why?
it's not needed as capping is available in the opt out UI.
