### PR TITLE
Add a bigger rail min above for consentless ads

### DIFF
--- a/.changeset/shy-crabs-travel.md
+++ b/.changeset/shy-crabs-travel.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Fix inline2 overlapping most viewed for consentless ads

--- a/src/init/consentless/dynamic/article-body-adverts.ts
+++ b/src/init/consentless/dynamic/article-body-adverts.ts
@@ -24,7 +24,7 @@ const initArticleBodyAdverts = async (): Promise<void> => {
 	}
 
 	await addFirstInlineAd(fillConsentlessAdSlot).then(() =>
-		addSubsequentInlineAds(fillConsentlessAdSlot),
+		addSubsequentInlineAds(fillConsentlessAdSlot, true),
 	);
 };
 

--- a/src/insert/spacefinder/article.ts
+++ b/src/insert/spacefinder/article.ts
@@ -127,7 +127,10 @@ const addDesktopInline1 = (fillSlot: FillAdSlot): Promise<boolean> => {
 /**
  * Inserts all inline ads on desktop except for inline1.
  */
-const addDesktopRightRailAds = (fillSlot: FillAdSlot): Promise<boolean> => {
+const addDesktopRightRailAds = (
+	fillSlot: FillAdSlot,
+	isConsentless: boolean,
+): Promise<boolean> => {
 	const insertAds: SpacefinderWriter = async (paras) => {
 		const stickyContainerHeights = await computeStickyHeights(
 			paras,
@@ -177,11 +180,15 @@ const addDesktopRightRailAds = (fillSlot: FillAdSlot): Promise<boolean> => {
 		await Promise.all(slots);
 	};
 
-	return spaceFiller.fillSpace(rules.desktopRightRail, insertAds, {
-		waitForImages: true,
-		waitForInteractives: true,
-		pass: 'subsequent-inlines',
-	});
+	return spaceFiller.fillSpace(
+		rules.desktopRightRail(isConsentless),
+		insertAds,
+		{
+			waitForImages: true,
+			waitForInteractives: true,
+			pass: 'subsequent-inlines',
+		},
+	);
 };
 
 const addMobileTopAboveNav = (fillSlot: FillAdSlot): Promise<boolean> => {
@@ -249,13 +256,16 @@ const addFirstInlineAd = (fillSlot: FillAdSlot): Promise<boolean> => {
 	return addDesktopInline1(fillSlot);
 };
 
-const addSubsequentInlineAds = (fillSlot: FillAdSlot): Promise<boolean> => {
+const addSubsequentInlineAds = (
+	fillSlot: FillAdSlot,
+	isConsentless: boolean,
+): Promise<boolean> => {
 	const isMobile = getCurrentBreakpoint() === 'mobile';
 	if (isMobile) {
 		return addMobileSubsequentInlineAds(fillSlot);
 	}
 
-	return addDesktopRightRailAds(fillSlot);
+	return addDesktopRightRailAds(fillSlot, isConsentless);
 };
 
 /**
@@ -269,7 +279,7 @@ const init = async (fillAdSlot: FillAdSlot): Promise<void> => {
 
 	await addFirstInlineAd(fillAdSlot);
 
-	await addSubsequentInlineAds(fillAdSlot);
+	await addSubsequentInlineAds(fillAdSlot, false);
 
 	await initCarrot();
 };

--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -78,13 +78,13 @@ const desktopInline1: SpacefinderRules = {
 	},
 };
 
-const desktopRightRailMinAbove = () => {
+const desktopRightRailMinAbove = (isConsentless: boolean) => {
 	const base = 1000;
 	/**
 	 * In special cases, inline2 can overlap the "Most viewed" island, so
 	 * we need to make an adjustment to move the inline2 further down the page
 	 */
-	if (isPaidContent || !hasImages) {
+	if (isPaidContent || !hasImages || isConsentless) {
 		return base + MOST_VIEWED_HEIGHT;
 	}
 
@@ -94,31 +94,33 @@ const desktopRightRailMinAbove = () => {
 	return base;
 };
 
-const desktopRightRail: SpacefinderRules = {
-	bodySelector,
-	candidateSelector,
-	minDistanceFromTop: desktopRightRailMinAbove(),
-	minDistanceFromBottom: 300,
-	opponentSelectorRules: {
-		[rightColumnOpponentSelector]: {
-			marginBottom: 0,
-			marginTop: 600,
+const desktopRightRail = (isConsentless: boolean): SpacefinderRules => {
+	return {
+		bodySelector,
+		candidateSelector,
+		minDistanceFromTop: desktopRightRailMinAbove(isConsentless),
+		minDistanceFromBottom: 300,
+		opponentSelectorRules: {
+			[rightColumnOpponentSelector]: {
+				marginBottom: 0,
+				marginTop: 600,
+			},
 		},
-	},
-	/**
-	 * Filter out any candidates that are too close to the last winner
-	 * see https://github.com/guardian/commercial/tree/main/docs/spacefinder#avoiding-other-winning-candidates
-	 * for more information
-	 **/
-	filter: (candidate, lastWinner) => {
-		if (!lastWinner) {
-			return true;
-		}
-		const largestSizeForSlot = adSizes.halfPage.height;
-		const distanceBetweenAds =
-			candidate.top - lastWinner.top - largestSizeForSlot;
-		return distanceBetweenAds >= minDistanceBetweenRightRailAds;
-	},
+		/**
+		 * Filter out any candidates that are too close to the last winner
+		 * see https://github.com/guardian/commercial/tree/main/docs/spacefinder#avoiding-other-winning-candidates
+		 * for more information
+		 **/
+		filter: (candidate, lastWinner) => {
+			if (!lastWinner) {
+				return true;
+			}
+			const largestSizeForSlot = adSizes.halfPage.height;
+			const distanceBetweenAds =
+				candidate.top - lastWinner.top - largestSizeForSlot;
+			return distanceBetweenAds >= minDistanceBetweenRightRailAds;
+		},
+	};
 };
 
 const mobileMinDistanceFromArticleTop = 200;


### PR DESCRIPTION
## What does this change?
Adds a bigger `desktopRightRailMinAbove` for consentless ads.

## Why?
We've been seeing opt out inline2 ads overlapping the most viewed column, and this should fix it. The overlapping happens whenever an ad doesn't fill inline1, and the inline1 slot collapses. This happens pretty frequently for consentless ads.

## Screenshots
### Before
<img width="879" alt="Screenshot 2024-08-14 at 10 11 24" src="https://github.com/user-attachments/assets/9c767aa6-d986-4626-98f3-ad934053f3bf">

### After
<img width="888" alt="Screenshot 2024-08-14 at 10 11 07" src="https://github.com/user-attachments/assets/42977107-aab0-456e-831b-d491e374a1f7">

