### PR TITLE
Add pageviewId to video progress logs behind consent check

### DIFF
--- a/.changeset/twenty-singers-deliver.md
+++ b/.changeset/twenty-singers-deliver.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Add pageview id to video interscroller logs

--- a/src/core/send-commercial-metrics.ts
+++ b/src/core/send-commercial-metrics.ts
@@ -313,4 +313,4 @@ export const _ = {
 };
 
 export type { Property, TimedEvent, Metric };
-export { bypassCommercialMetricsSampling, initCommercialMetrics };
+export { bypassCommercialMetricsSampling, initCommercialMetrics, checkConsent };


### PR DESCRIPTION
## Why?
There are way more progress reports than impressions, hopefully recording the `pageviewId` will uncover if we're getting duplicates

This code only executes when googletag is already loaded but for safety/paranoia have added the same consent check that commercial metrics uses.