### PR TITLE
increase min inline slots for desktop

### DIFF
--- a/playwright/fixtures/pages/articles.ts
+++ b/playwright/fixtures/pages/articles.ts
@@ -28,7 +28,7 @@ const articles: GuPage[] = [
 			path: '/environment/2020/oct/13/maverick-rewilders-endangered-species-extinction-conservation-uk-wildlife',
 		}),
 		name: 'inlineSlots',
-		expectedMinInlineSlotsOnDesktop: 11,
+		expectedMinInlineSlotsOnDesktop: 12,
 		expectedMinInlineSlotsOnMobile: 16,
 	},
 	{


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
This PR increases the `expectedMinInlineSlotsOnDesktop` value to reflect the increase in the inline ad slots.

This related to the PR opened in [DCR](https://github.com/guardian/dotcom-rendering/pull/12142)

## Why?
This change might be attributed to Spacefinder’s algorithm potentially being more lenient in its calculations regarding the spacing between ads.



| Test passing with 12 inline slots | Test failing with 13 min/max no. slots |
| ----------- | ---------- |
| <img width="1274" alt="Screenshot 2024-08-14 at 17 20 11" src="https://github.com/user-attachments/assets/36ae0f3b-bb59-44b4-a666-f4a44797c13e">| <img width="1279" alt="Screenshot 2024-08-14 at 17 20 48" src="https://github.com/user-attachments/assets/63a2d733-2aea-490e-83eb-1b887fe31fba"> |