### PR TITLE
Merge first and subsequent inline ad functions

### DIFF
--- a/src/init/consentless/dynamic/article-body-adverts.ts
+++ b/src/init/consentless/dynamic/article-body-adverts.ts
@@ -1,8 +1,5 @@
 import type { FillAdSlot } from 'insert/spacefinder/article';
-import {
-	addFirstInlineAd,
-	addSubsequentInlineAds,
-} from 'insert/spacefinder/article';
+import { addInlineAds } from 'insert/spacefinder/article';
 import { commercialFeatures } from 'lib/commercial-features';
 import { getCurrentBreakpoint } from 'lib/detect/detect-breakpoint';
 import { defineSlot } from '../define-slot';
@@ -23,9 +20,7 @@ const initArticleBodyAdverts = async (): Promise<void> => {
 		return;
 	}
 
-	await addFirstInlineAd(fillConsentlessAdSlot).then(() =>
-		addSubsequentInlineAds(fillConsentlessAdSlot, true),
-	);
+	await addInlineAds(fillConsentlessAdSlot, true);
 };
 
 export { initArticleBodyAdverts };

--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -154,7 +154,7 @@ const mobileOpponentSelectorRules: OpponentSelectorRules = {
 	},
 };
 
-const mobileSubsequentInlineAds: SpacefinderRules = {
+const mobileInlines: SpacefinderRules = {
 	bodySelector,
 	candidateSelector: mobileCandidateSelector,
 	minDistanceFromTop: mobileMinDistanceFromArticleTop,
@@ -174,17 +174,8 @@ const mobileSubsequentInlineAds: SpacefinderRules = {
 	},
 };
 
-const mobileTopAboveNav: SpacefinderRules = {
-	bodySelector,
-	candidateSelector: mobileCandidateSelector,
-	minDistanceFromTop: mobileMinDistanceFromArticleTop,
-	minDistanceFromBottom: 200,
-	opponentSelectorRules: mobileOpponentSelectorRules,
-};
-
 export const rules = {
 	desktopInline1,
 	desktopRightRail,
-	mobileTopAboveNav,
-	mobileSubsequentInlineAds,
+	mobileInlines,
 };

--- a/src/insert/spacefinder/spacefinder.ts
+++ b/src/insert/spacefinder/spacefinder.ts
@@ -88,9 +88,8 @@ type SpacefinderWriter = (paras: HTMLElement[]) => Promise<void>;
 
 type SpacefinderPass =
 	| 'inline1'
-	| 'mobile-top-above-nav'
 	| 'subsequent-inlines'
-	| 'mobile-subsequent-inlines'
+	| 'mobile-inlines'
 	| 'carrot';
 
 type SpacefinderOptions = {


### PR DESCRIPTION
## What does this change?
Merge the `addFirstInlineAd` and `addSubsequentInlineAds` functions into one function.

## Why?
Now that inline-merch has been deleted, we no longer need to separate the code to add inline ads into inline1 and subsequent inlines. This results in less lines of code and things being a bit easier to read.
