### PR TITLE
Only execute sendProgress once

### DIFF
--- a/.changeset/bright-bobcats-lie.md
+++ b/.changeset/bright-bobcats-lie.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Wrap interscroller progress callback with once

--- a/src/core/lib/video-interscroller-progress.ts
+++ b/src/core/lib/video-interscroller-progress.ts
@@ -1,3 +1,4 @@
+import { once } from 'lodash-es';
 import { EventTimer } from 'core/event-timer';
 import { checkConsent as checkConsentForReporting } from 'core/send-commercial-metrics';
 import { bypassMetricsSampling } from 'experiments/utils';
@@ -9,7 +10,7 @@ const endpoint = window.guardian.config.page.isDev
 let creativeId: number | undefined;
 let progress: number = 0;
 
-const sendProgress = () => {
+const sendProgress = once(() => {
 	if (!creativeId || !progress) {
 		return;
 	}
@@ -31,7 +32,7 @@ const sendProgress = () => {
 		cache: 'no-store',
 		mode: 'no-cors',
 	});
-};
+});
 
 const sendProgressOnUnloadViaLogs = async () => {
 	if (await checkConsentForReporting()) {


### PR DESCRIPTION
## What does this change?
Wraps `sendProgress` in `once()`.

## Why?
This should mean it only gets executed once. At the moment, we think it can be called twice by the two different event listeners. Hopefully this should reduce the duplicate log entries we see.
