### PR TITLE
Add background, type and resize messenger for consentless

### DIFF
--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -212,6 +212,7 @@ const setupBackground = async (
 				adSlot.style.height = '85vh';
 				adSlot.style.marginBottom = '12px';
 				adSlot.style.position = 'relative';
+				adSlot.style.width = '100%';
 			}
 
 			void renderAdvertLabel(adSlot, interscrollerTemplateId);

--- a/src/init/consentless.ts
+++ b/src/init/consentless.ts
@@ -1,4 +1,8 @@
 import type { ConsentState } from '@guardian/libs';
+import { initMessenger } from 'core';
+import { init as background } from 'core/messenger/background';
+import { init as resize } from 'core/messenger/resize';
+import { init as type } from 'core/messenger/type';
 import { initArticleBodyAdverts } from 'init/consentless/dynamic/article-body-adverts';
 import { initExclusionSlot } from 'init/consentless/dynamic/exclusion-slot';
 import { initFixedSlots } from 'init/consentless/init-fixed-slots';
@@ -6,9 +10,11 @@ import { initConsentless } from 'init/consentless/prepare-ootag';
 import { reloadPageOnConsentChange } from 'init/shared/reload-page-on-consent-change';
 import { init as setAdTestCookie } from 'init/shared/set-adtest-cookie';
 import { init as setAdTestInLabelsCookie } from 'init/shared/set-adtest-in-labels-cookie';
+import { reportError } from 'utils/report-error';
 
 const bootConsentless = async (consentState: ConsentState): Promise<void> => {
 	const consentlessModuleList = [
+		initMessenger([background, resize, type], [], reportError),
 		setAdTestCookie(),
 		setAdTestInLabelsCookie(),
 		initConsentless(consentState),


### PR DESCRIPTION
## What does this change?
Adds background, type and resize message listeners for consentless ads. Also adds `width: 100%` to interscrollers ads so that they display properly in consentless (GAM ads already have this from the `ad-slot--fluid` class).

## Why?
This change enables the interscroller ad to work in consentless mode. You can test locally using `?adtest=dap_interscroller`. See screenshot of test creative:

<img width="354" alt="Screenshot 2024-08-20 at 11 45 23" src="https://github.com/user-attachments/assets/c99271f0-a2b4-4d9f-915c-5904d68a0979">
