### PR TITLE
Log line item id as well as creative id for interscroller video progress tracking

### DIFF
--- a/.changeset/seven-zoos-thank.md
+++ b/.changeset/seven-zoos-thank.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Update intercsroller progress tracking

--- a/src/core/lib/video-interscroller-progress.ts
+++ b/src/core/lib/video-interscroller-progress.ts
@@ -1,13 +1,12 @@
 import { once } from 'lodash-es';
-import { EventTimer } from 'core/event-timer';
 import { checkConsent as checkConsentForReporting } from 'core/send-commercial-metrics';
-import { bypassMetricsSampling } from 'experiments/utils';
 
 const endpoint = window.guardian.config.page.isDev
 	? '//logs.code.dev-guardianapis.com/log'
 	: '//logs.guardianapis.com/log';
 
-let creativeId: number | undefined;
+let creativeId: number;
+let lineItemId: number;
 let progress: number = 0;
 
 const sendProgress = once(() => {
@@ -20,7 +19,8 @@ const sendProgress = once(() => {
 		body: JSON.stringify({
 			label: 'commercial.interscroller.videoProgress',
 			properties: [
-				{ name: 'id', value: creativeId },
+				{ name: 'creativeId', value: creativeId },
+				{ name: 'lineItemId', value: lineItemId },
 				{ name: 'progress', value: progress },
 				{
 					name: 'pageviewId',
@@ -44,22 +44,18 @@ const sendProgressOnUnloadViaLogs = async () => {
 	}
 };
 
-const initVideoProgressReporting = (gamCreativeId: number) => {
+const initVideoProgressReporting = (
+	gamCreativeId: number,
+	gamLineItemId: number,
+) => {
 	creativeId = gamCreativeId;
-
-	EventTimer.get().setProperty('videoInterscrollerCreativeId', creativeId);
-
-	bypassMetricsSampling();
+	lineItemId = gamLineItemId;
 
 	void sendProgressOnUnloadViaLogs();
 };
 
 const updateVideoProgress = (updatedProgress: number) => {
 	progress = updatedProgress;
-	EventTimer.get().setProperty(
-		'videoInterscrollerPercentageProgress',
-		updatedProgress,
-	);
 };
 
 export { initVideoProgressReporting, updateVideoProgress };

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -244,10 +244,14 @@ const setupBackground = async (
 						const creativeTemplateId =
 							slot.getResponseInformation()?.creativeTemplateId;
 						if (creativeTemplateId === 11885667) {
-							return (
-								slot.getResponseInformation()?.creativeId ??
-								undefined
-							);
+							const creativeId =
+								slot.getResponseInformation()?.creativeId;
+							const lineItemId =
+								slot.getResponseInformation()?.lineItemId;
+
+							if (creativeId && lineItemId) {
+								return { creativeId, lineItemId };
+							}
 						}
 					}
 					return undefined;
@@ -271,10 +275,13 @@ const setupBackground = async (
 
 				observer.observe(backgroundParent);
 
-				const creativeId = getCreativeId();
+				const creativeInfo = getCreativeId();
 
-				if (creativeId) {
-					initVideoProgressReporting(creativeId);
+				if (creativeInfo) {
+					initVideoProgressReporting(
+						creativeInfo.creativeId,
+						creativeInfo.lineItemId,
+					);
 				}
 
 				video.ontimeupdate = function () {


### PR DESCRIPTION
## What does this change?
Log line item id as well as creative id for interscroller video progress tracking

Stop reporting via commercial metrics and rely soley on the logging endpoint

## Why?
DAP want to run reports based on the line item id