### PR TITLE
Return highest priority line item if it has a priority of 4 or less

### DIFF
--- a/src/elements-manager/find-creative.ts
+++ b/src/elements-manager/find-creative.ts
@@ -19,6 +19,17 @@ const pickLineItem = (lineItems: LineItem[]) => {
 		(a, b) => 1 / a.priority - 1 / b.priority,
 	);
 
+	const highestPriorityLineItem = sortedLineItems[-1];
+
+	// Takeovers have a priority of 4 or less, so if the highest priority
+	// line item has a priority of 4 or less, we should return that
+	if (
+		highestPriorityLineItem !== undefined &&
+		highestPriorityLineItem.priority < 5
+	) {
+		return highestPriorityLineItem;
+	}
+
 	const randomNumber = Math.random() * randomMultiplier;
 
 	let accumulator = 0;

--- a/src/elements-manager/find-creative.ts
+++ b/src/elements-manager/find-creative.ts
@@ -6,6 +6,7 @@ import { findLineItems, type LineItem } from './line-items';
  * LineItems have a priority from 1 to 16, with 1 being the highest priority.
  * This function will pick a line item from the list of line items to display using weighted random selection.
  * The higher the priority, the more likely the line item will be picked.
+ * If a sponsorship level priority is present, the highest priority line item will be served.
  * @param lineItems
  */
 const pickLineItem = (lineItems: LineItem[]) => {


### PR DESCRIPTION
## What does this change?
Adds an if statement to the `pickLineItem` function to return the highest priority line item if there is a sponsorship or takeover targeting the page.

## Why?
This will make sure that GEM respects takeover campaigns when they're eligible to serve, instead of serving another advert.