### PR TITLE
Set Spacefinder inline1 optimisation test to 5%

### DIFF
--- a/.changeset/dirty-otters-trade.md
+++ b/.changeset/dirty-otters-trade.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Set Spacefinder test to 5%

--- a/src/experiments/tests/optimise-spacefinder-inline.ts
+++ b/src/experiments/tests/optimise-spacefinder-inline.ts
@@ -5,7 +5,7 @@ export const optimiseSpacefinderInline: ABTest = {
 	author: '@commercial-dev',
 	start: '2024-08-08',
 	expiry: '2024-09-13',
-	audience: 0 / 100,
+	audience: 5 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',
 	successMeasure: '',

--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -64,7 +64,7 @@ const desktopInline1: SpacefinderRules = {
 			marginTop: isInInlineSpacefinderOptimisationTest ? 200 : 400,
 		},
 		[leftColumnOpponentSelector]: {
-			marginBottom: isInInlineSpacefinderOptimisationTest ? 0 : 35,
+			marginBottom: isInInlineSpacefinderOptimisationTest ? 50 : 35,
 			marginTop: isInInlineSpacefinderOptimisationTest ? 100 : 400,
 		},
 		[rightColumnOpponentSelector]: {


### PR DESCRIPTION
## What does this change?
Sets the Spacefinder inline1 margins optimisation test to 5% as recommended by D&I. Also updates the richLink bottom margin to 50px to look better on tablet display.

## Why?
It's time for the test to go live.

## Images of rich link margin change
### Before
<img width="521" alt="Screenshot 2024-08-21 at 17 30 19" src="https://github.com/user-attachments/assets/14568140-ca70-4450-b1de-7b73a7b82845">

### After
<img width="520" alt="Screenshot 2024-08-21 at 17 30 05" src="https://github.com/user-attachments/assets/37f15289-9abb-46b8-ae8b-15d81368f431">
