### PR TITLE
Check for videos as well as images when setting inline2 min above

### DIFF
--- a/.changeset/witty-falcons-camp.md
+++ b/.changeset/witty-falcons-camp.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Check for article video as well as images when deciding min above for inline2

--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -20,7 +20,8 @@ const isImmersive = window.guardian.config.page.isImmersive;
 
 const hasImagesOrVideo =
 	!!window.guardian.config.page.lightboxImages?.images.length ||
-	window.guardian.config.page.hasYoutubeAtom;
+	window.guardian.config.page.hasYouTubeAtom;
+
 const isPaidContent = window.guardian.config.page.isPaidContent;
 
 const hasShowcaseMainElement =
@@ -86,7 +87,7 @@ const desktopRightRailMinAbove = (isConsentless: boolean) => {
 	 * In special cases, inline2 can overlap the "Most viewed" island, so
 	 * we need to make an adjustment to move the inline2 further down the page
 	 */
-	if (isPaidContent || hasImagesOrVideo || isConsentless) {
+	if (isPaidContent || !hasImagesOrVideo || isConsentless) {
 		return base + MOST_VIEWED_HEIGHT;
 	}
 

--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -18,7 +18,9 @@ const MOST_VIEWED_HEIGHT = 600;
 
 const isImmersive = window.guardian.config.page.isImmersive;
 
-const hasImages = !!window.guardian.config.page.lightboxImages?.images.length;
+const hasImagesOrVideo =
+	!!window.guardian.config.page.lightboxImages?.images.length ||
+	window.guardian.config.page.hasYoutubeAtom;
 const isPaidContent = window.guardian.config.page.isPaidContent;
 
 const hasShowcaseMainElement =
@@ -84,7 +86,7 @@ const desktopRightRailMinAbove = (isConsentless: boolean) => {
 	 * In special cases, inline2 can overlap the "Most viewed" island, so
 	 * we need to make an adjustment to move the inline2 further down the page
 	 */
-	if (isPaidContent || !hasImages || isConsentless) {
+	if (isPaidContent || hasImagesOrVideo || isConsentless) {
 		return base + MOST_VIEWED_HEIGHT;
 	}
 

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -103,7 +103,7 @@ interface PageConfig extends CommercialPageConfig {
 	frontendAssetsFullURL?: string; // only in DCR
 	hasPageSkin: boolean; // https://github.com/guardian/frontend/blob/b952f6b9/common/app/views/support/JavaScriptPage.scala#L48
 	hasShowcaseMainElement: boolean;
-	hasYoutubeAtom: boolean;
+	hasYouTubeAtom: boolean;
 	headline: string;
 	host: string;
 	idApiUrl?: string;

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -103,6 +103,7 @@ interface PageConfig extends CommercialPageConfig {
 	frontendAssetsFullURL?: string; // only in DCR
 	hasPageSkin: boolean; // https://github.com/guardian/frontend/blob/b952f6b9/common/app/views/support/JavaScriptPage.scala#L48
 	hasShowcaseMainElement: boolean;
+	hasYoutubeAtom: boolean;
 	headline: string;
 	host: string;
 	idApiUrl?: string;


### PR DESCRIPTION
## What does this change?
Check for videos as well as images before increasing the min above for inline2.

## Why?
Articles with no images can still have a video, which means we don't need the extra buffer on the min above for inline2. By checking if we have a video atom, we should be able to improve ad ratio a bit on articles with videos but no images.

## Images
### Before
<img width="732" alt="Screenshot 2024-08-27 at 17 46 43" src="https://github.com/user-attachments/assets/4f46a8ec-3d5e-460b-9f68-2d1f2d02db4d">

### After
<img width="547" alt="Screenshot 2024-08-27 at 17 46 27" src="https://github.com/user-attachments/assets/4d4a2af1-9b25-4a0f-a61d-f56f5dbf144b">
