### PR TITLE
Add richLink and thumbnail back into mobile Spacefinder rules

### DIFF
--- a/.changeset/silly-spoons-serve.md
+++ b/.changeset/silly-spoons-serve.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Add Spacefinder rules for rich links and thumbnails on mobile

--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -140,7 +140,7 @@ const mobileOpponentSelectorRules: OpponentSelectorRules = {
 		marginBottom: minDistanceBetweenInlineAds,
 		marginTop: minDistanceBetweenInlineAds,
 	},
-	[inlineOpponentSelector]: {
+	[`${inlineOpponentSelector},${leftColumnOpponentSelector}`]: {
 		marginBottom: 35,
 		marginTop: 200,
 		// Usually we don't want an ad right before videos, embeds and atoms etc. so that we don't break up related content too much. But if we have a heading above, anything above the heading won't be related to the current content, so we can place an ad there.


### PR DESCRIPTION
## What does this change?
Adds rules for richLink and thumbnail for mobile devices.

## Why?
I split out richLink and thumbnail opponents into their own selector in this PR https://github.com/guardian/commercial/pull/1517/files#diff-9927c8b2a268d783c13c5a6b48574f33753beefe080178bc7a5e199b53fe48a6R32 but forgot to add that new selector for mobile rules as well.

## Images
### Before
<img width="326" alt="Screenshot 2024-08-28 at 11 40 26" src="https://github.com/user-attachments/assets/81fd2ac7-eb83-40ca-bd61-472c3f2d98cc">

### After
<img width="322" alt="Screenshot 2024-08-28 at 11 40 44" src="https://github.com/user-attachments/assets/1f191bbf-b436-4eb8-8ebf-e9635ba1b875">

### Before
<img width="325" alt="Screenshot 2024-08-28 at 11 39 30" src="https://github.com/user-attachments/assets/cf4bb668-e1ff-4950-b6cf-f2bf66e68fc8">

### After
<img width="325" alt="Screenshot 2024-08-28 at 11 39 52" src="https://github.com/user-attachments/assets/fb46e64c-f635-4abd-af0f-cdaa63b8d5d3">

