### PR TITLE
Adjust minAbove for articles with video but no images

### DIFF
--- a/.changeset/great-humans-approve.md
+++ b/.changeset/great-humans-approve.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Add extra 100px to minAbove for articles with video but no images

--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -18,9 +18,9 @@ const MOST_VIEWED_HEIGHT = 600;
 
 const isImmersive = window.guardian.config.page.isImmersive;
 
-const hasImagesOrVideo =
-	!!window.guardian.config.page.lightboxImages?.images.length ||
-	window.guardian.config.page.hasYouTubeAtom;
+const hasImages = !!window.guardian.config.page.lightboxImages?.images.length;
+
+const hasVideo = window.guardian.config.page.hasYouTubeAtom;
 
 const isPaidContent = window.guardian.config.page.isPaidContent;
 
@@ -87,11 +87,11 @@ const desktopRightRailMinAbove = (isConsentless: boolean) => {
 	 * In special cases, inline2 can overlap the "Most viewed" island, so
 	 * we need to make an adjustment to move the inline2 further down the page
 	 */
-	if (isPaidContent || !hasImagesOrVideo || isConsentless) {
+	if (isPaidContent || (!hasImages && !hasVideo) || isConsentless) {
 		return base + MOST_VIEWED_HEIGHT;
 	}
 
-	if (hasShowcaseMainElement) {
+	if (hasShowcaseMainElement || (!hasImages && hasVideo)) {
 		return base + 100;
 	}
 	return base;


### PR DESCRIPTION
## What does this change?
Add an extra 100px to minAbove for articles with video but no images.

## Why?
On some articles with video but no images, the inline2 ad was overlapping with most viewed at certain breakpoints. I could only replicate on one article of this type at one breakpoint, so hopefully 100px should be enough.

Before:
<img width="576" alt="Screenshot 2024-08-29 at 10 42 02" src="https://github.com/user-attachments/assets/e1b195c8-0c66-4116-a5e4-f05746cd13e5">

After:
<img width="578" alt="Screenshot 2024-08-29 at 10 37 34" src="https://github.com/user-attachments/assets/b69f7f50-0fc4-4378-a478-03b4ec958acf">

