### PR TITLE
Check user is a member of Guardian org for beta releases

### DIFF
--- a/.changeset/angry-books-look.md
+++ b/.changeset/angry-books-look.md
@@ -1,5 +1,0 @@
----
-'@guardian/commercial': patch
----
-
-amend permissions for beta releases

--- a/.changeset/angry-books-look.md
+++ b/.changeset/angry-books-look.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+amend permissions for beta releases

--- a/.github/workflows/beta-release-on-label.yml
+++ b/.github/workflows/beta-release-on-label.yml
@@ -22,13 +22,6 @@ jobs:
           organization: guardian
           username: ${{ github.actor }}
           token: ${{ secrets.GITHUB_TOKEN }}
-    # steps:
-    #   - name: 'Check if user has admin access'
-    #     uses: 'lannonbr/repo-permission-check-action@2.0.2'
-    #     with:
-    #       permission: 'admin'
-    #     env:
-    #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     name: '@guardian/commercial'

--- a/.github/workflows/beta-release-on-label.yml
+++ b/.github/workflows/beta-release-on-label.yml
@@ -15,12 +15,20 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.label.name == '[beta] @guardian/commercial'
     steps:
-      - name: 'Check if user has admin access'
-        uses: 'lannonbr/repo-permission-check-action@2.0.2'
+      - name: Check if organization member
+        id: is_organization_member
+        uses: JamesSingleton/is-organization-member@1.0.0
         with:
-          permission: 'admin'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          organization: guardian
+          username: ${{ github.actor }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+    # steps:
+    #   - name: 'Check if user has admin access'
+    #     uses: 'lannonbr/repo-permission-check-action@2.0.2'
+    #     with:
+    #       permission: 'admin'
+    #     env:
+    #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     name: '@guardian/commercial'


### PR DESCRIPTION
## What does this change?

This enables all members of the Guardian org to release beta versions of the commercial bundle.

## Why?

Restricting beta release permissions only to repo admins is a little too narrow- sometimes it's useful for people outside the team to be able to make quick releases.
