### PR TITLE
Delete mediator

### DIFF
--- a/.changeset/tiny-walls-fetch.md
+++ b/.changeset/tiny-walls-fetch.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Remove mediator

--- a/package.json
+++ b/package.json
@@ -110,8 +110,7 @@
 		"process": "^0.11.10",
 		"raven-js": "^3.27.2",
 		"tslib": "^2.6.2",
-		"web-vitals": "^4.2.1",
-		"wolfy87-eventemitter": "^5.2.9"
+		"web-vitals": "^4.2.1"
 	},
 	"prettier": "@guardian/prettier",
 	"lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ dependencies:
   web-vitals:
     specifier: ^4.2.1
     version: 4.2.3
-  wolfy87-eventemitter:
-    specifier: ^5.2.9
-    version: 5.2.9
 
 devDependencies:
   '@babel/cli':
@@ -9382,10 +9379,6 @@ packages:
   /wildcard@2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
     dev: true
-
-  /wolfy87-eventemitter@5.2.9:
-    resolution: {integrity: sha512-P+6vtWyuDw+MB01X7UeF8TaHBvbCovf4HPEMF/SV7BdDc1SMTiBy13SRD71lQh4ExFTG1d/WNzDGDCyOKSMblw==}
-    dev: false
 
   /wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}

--- a/src/insert/article-aside-adverts.spec.ts
+++ b/src/insert/article-aside-adverts.spec.ts
@@ -1,5 +1,4 @@
 import fastdom from '../utils/fastdom-promise';
-import { mediator as fakeMediator } from '../utils/mediator';
 import { init } from './article-aside-adverts';
 
 // This module removes sticky behaviour from ads in immersive article. Example below:
@@ -17,7 +16,6 @@ const mockMeasure = (mainColHeight: number, immersiveOffset: number) => {
 
 const sharedBeforeEach = (domSnippet: string) => () => {
 	jest.resetAllMocks();
-	fakeMediator.removeAllListeners();
 	window.guardian.config.page.isImmersive = false;
 	window.guardian.config.page.hasShowcaseMainElement = false;
 

--- a/src/insert/article-aside-adverts.ts
+++ b/src/insert/article-aside-adverts.ts
@@ -1,6 +1,5 @@
 import { $$ } from 'utils/$$';
 import fastdom from 'utils/fastdom-promise';
-import { mediator } from 'utils/mediator';
 
 const minArticleHeight = 1300;
 
@@ -104,8 +103,7 @@ export const init = (): Promise<void | boolean> => {
 			}
 			return adSlotsWithinRightCol[0];
 		})
-		.then((adSlot) => {
-			mediator.emit('page:defaultcommercial:right', adSlot);
+		.then(() => {
 			return true;
 		});
 };

--- a/src/insert/spacefinder/liveblog-adverts.spec.ts
+++ b/src/insert/spacefinder/liveblog-adverts.spec.ts
@@ -13,7 +13,6 @@ jest.mock('utils/report-error', () => ({
 jest.mock('lib/header-bidding/prebid/prebid', () => ({
 	requestBids: jest.fn(),
 }));
-jest.mock('utils/mediator');
 jest.mock('insert/spacefinder/space-filler', () => ({
 	spaceFiller: {
 		fillSpace: jest.fn(() => Promise.resolve(true)),

--- a/src/lib/creatives/page-skin.ts
+++ b/src/lib/creatives/page-skin.ts
@@ -4,7 +4,6 @@ import {
 	hasCrossedBreakpoint,
 	matchesBreakpoints,
 } from 'lib/detect/detect-breakpoint';
-import { mediator } from 'utils/mediator';
 
 const pageSkin = (): void => {
 	const bodyEl = document.body;
@@ -142,12 +141,6 @@ const pageSkin = (): void => {
 		},
 		false,
 	);
-
-	mediator.on('window:throttledResize', togglePageSkin);
-
-	if (hasPageSkin) {
-		mediator.on('window:throttledScroll', repositionSkins);
-	}
 };
 
 export { pageSkin };

--- a/src/lib/identity/api.ts
+++ b/src/lib/identity/api.ts
@@ -4,7 +4,6 @@ import type {
 	IDToken,
 } from '@guardian/identity-auth';
 import { getCookie } from '@guardian/libs';
-import { mediator } from 'utils/mediator';
 import type { CustomIdTokenClaims } from '../../types/global';
 
 // Types info coming from https://github.com/guardian/discussion-rendering/blob/fc14c26db73bfec8a04ff7a503ed9f90f1a1a8ad/src/types.ts
@@ -44,8 +43,6 @@ const cookieName = 'GU_U';
 
 const idApiRoot =
 	window.guardian.config.page.idApiUrl ?? '/ID_API_ROOT_URL_NOT_FOUND';
-
-mediator.emit('module:identity:api:loaded');
 
 const decodeBase64 = (str: string): string =>
 	decodeURIComponent(

--- a/src/utils/mediator.ts
+++ b/src/utils/mediator.ts
@@ -1,3 +1,0 @@
-import EventEmitter from 'wolfy87-eventemitter';
-
-export const mediator = new EventEmitter();


### PR DESCRIPTION
## What does this change?
Remove mediator

## Why?
It hasn't worked for some time, searching for the coresponding listeners or emitters in frontend often doesn't even find anything, we can safely get rid of this module and it's dependency now.