### PR TITLE
Add more variants to frequencyCap test for testing timeout

### DIFF
--- a/.changeset/odd-adults-hang.md
+++ b/.changeset/odd-adults-hang.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Add more variants to frequencycap test for testing timeout

--- a/src/experiments/ab.ts
+++ b/src/experiments/ab.ts
@@ -112,3 +112,9 @@ export const isUserInVariant = (test: ABTest, variantId: string): boolean => {
 	const ab = init();
 	return ab.isUserInVariant(test.id, variantId);
 };
+
+export const getVariant = (test: ABTest): string | undefined => {
+	const participations = getParticipations();
+
+	return participations[test.id]?.variant;
+};

--- a/src/experiments/tests/opt-out-frequency-cap.ts
+++ b/src/experiments/tests/opt-out-frequency-cap.ts
@@ -23,6 +23,54 @@ export const optOutFrequencyCap: ABTest = {
 				/* no-op */
 			},
 		},
+		{
+			id: 'timeout-0',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'timeout-10',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'timeout-15',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'timeout-20',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'timeout-25',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'timeout-30',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'timeout-50',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'timeout-100',
+			test: (): void => {
+				/* no-op */
+			},
+		},
 	],
 	canRun: () => true,
 };

--- a/src/init/consentless/prepare-ootag.ts
+++ b/src/init/consentless/prepare-ootag.ts
@@ -22,17 +22,17 @@ function initConsentless(consentState: ConsentState): Promise<void> {
 			queue: [],
 		};
 
-		const frequencyCapVariant = getVariant(optOutFrequencyCap);
-
-		const isInFrequencyCapTest =
-			frequencyCapVariant !== undefined &&
-			frequencyCapVariant !== 'control';
-
 		window.ootag.queue.push(function () {
 			// Ensures Opt Out logs are namespaced under Commercial
 			window.ootag.logger = (...args: unknown[]) => {
 				log('commercial', '[Opt Out Ads]', ...args);
 			};
+
+			const frequencyCapVariant = getVariant(optOutFrequencyCap);
+
+			const isInFrequencyCapTest =
+				frequencyCapVariant !== undefined &&
+				frequencyCapVariant !== 'control';
 
 			const timeoutFrequencyCappingMS = isInFrequencyCapTest
 				? frequencyCapTimeoutFromVariant(frequencyCapVariant)

--- a/src/init/consentless/prepare-ootag.ts
+++ b/src/init/consentless/prepare-ootag.ts
@@ -1,10 +1,18 @@
 import type { ConsentState } from '@guardian/libs';
 import { loadScript, log } from '@guardian/libs';
 import { buildPageTargetingConsentless } from 'core/targeting/build-page-targeting-consentless';
-import { isUserInVariant } from 'experiments/ab';
+import { getVariant } from 'experiments/ab';
 import { optOutFrequencyCap } from 'experiments/tests/opt-out-frequency-cap';
 import { commercialFeatures } from 'lib/commercial-features';
 import { isUserLoggedInOktaRefactor } from 'lib/identity/api';
+
+const frequencyCapTimeoutFromVariant = (variant: string): number => {
+	if (!variant.startsWith('timeout-')) {
+		return 0;
+	}
+	const timeout = variant.replace('timeout-', '');
+	return parseInt(timeout, 10);
+};
 
 function initConsentless(consentState: ConsentState): Promise<void> {
 	return new Promise((resolve) => {
@@ -14,16 +22,21 @@ function initConsentless(consentState: ConsentState): Promise<void> {
 			queue: [],
 		};
 
-		const isInFrequencyCapTest = isUserInVariant(
-			optOutFrequencyCap,
-			'variant',
-		);
+		const frequencyCapVariant = getVariant(optOutFrequencyCap);
+
+		const isInFrequencyCapTest =
+			frequencyCapVariant !== undefined &&
+			frequencyCapVariant !== 'control';
 
 		window.ootag.queue.push(function () {
 			// Ensures Opt Out logs are namespaced under Commercial
 			window.ootag.logger = (...args: unknown[]) => {
 				log('commercial', '[Opt Out Ads]', ...args);
 			};
+
+			const timeoutFrequencyCappingMS = isInFrequencyCapTest
+				? frequencyCapTimeoutFromVariant(frequencyCapVariant)
+				: undefined;
 
 			window.ootag.initializeOo({
 				publisher: 33,
@@ -34,6 +47,7 @@ function initConsentless(consentState: ConsentState): Promise<void> {
 				frequencyScript: isInFrequencyCapTest
 					? 'https://frequencycappingwithoutpersonaldata.com/script/iframe'
 					: undefined,
+				timeoutFrequencyCappingMS,
 			});
 
 			void isUserLoggedInOktaRefactor().then((isSignedIn) => {

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -330,6 +330,7 @@ interface OptOutInitializeOptions {
 	lazyLoading?: { fractionInView?: number; viewPortMargin?: string };
 	noRequestsOnPageLoad?: 0 | 1;
 	frequencyScript?: string;
+	timeoutFrequencyCappingMS?: number;
 	debug_forceCap?: number;
 }
 


### PR DESCRIPTION
## What does this change?
Add more variants to frequencyCap test for testing timeout

## Why?
We would like to manually test the timeout values in prod