### PR TITLE
Check if googletag is undefined before getting creative id

### DIFF
--- a/.changeset/dull-olives-fly.md
+++ b/.changeset/dull-olives-fly.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Check that googletag is defined before using it to find creative id

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -237,22 +237,26 @@ const setupBackground = async (
 				background.appendChild(video);
 
 				const getCreativeId = () => {
-					const slots = googletag.pubads().getSlots();
+					if (typeof googletag !== 'undefined') {
+						const slots = googletag.pubads().getSlots();
 
-					for (const slot of slots) {
-						const creativeTemplateId =
-							slot.getResponseInformation()?.creativeTemplateId;
-						if (creativeTemplateId === 11885667) {
-							const creativeId =
-								slot.getResponseInformation()?.creativeId;
-							const lineItemId =
-								slot.getResponseInformation()?.lineItemId;
+						for (const slot of slots) {
+							const creativeTemplateId =
+								slot.getResponseInformation()
+									?.creativeTemplateId;
+							if (creativeTemplateId === 11885667) {
+								const creativeId =
+									slot.getResponseInformation()?.creativeId;
+								const lineItemId =
+									slot.getResponseInformation()?.lineItemId;
 
-							if (creativeId && lineItemId) {
-								return { creativeId, lineItemId };
+								if (creativeId && lineItemId) {
+									return { creativeId, lineItemId };
+								}
 							}
 						}
 					}
+
 					return undefined;
 				};
 


### PR DESCRIPTION
## What does this change?
Fixes a bug where we're trying to access googletag on the page even if we're in opt out mode.

<img width="376" alt="Screenshot 2024-09-10 at 14 20 55" src="https://github.com/user-attachments/assets/4f980df8-898f-4151-8793-977678fcee3b">

## Why?
Reduces uncaught errors.