### PR TITLE
Add new 371x660 prebid size

### DIFF
--- a/.changeset/red-bats-grow.md
+++ b/.changeset/red-bats-grow.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Add new 371x660 size to prebid

--- a/playwright/lib/util.ts
+++ b/playwright/lib/util.ts
@@ -175,7 +175,7 @@ const waitForSlot = async (page: Page, slot: string, waitForIframe = true) => {
 
 	if (waitForIframe) {
 		// iframe locator
-		const iframe = page.locator(`${slotId} iframe`);
+		const iframe = page.locator(`${slotId} iframe:first-child`);
 		// wait for the iframe
 		await iframe.waitFor({ state: 'visible', timeout: 120000 });
 	}

--- a/src/core/ad-sizes.ts
+++ b/src/core/ad-sizes.ts
@@ -90,6 +90,7 @@ type SizeKeys =
 	| 'outstreamMobile'
 	| 'portrait'
 	| 'portraitInterstitial'
+	| 'pubmaticInterscroller'
 	| 'skyscraper'
 	| 'sponsorLogo';
 
@@ -158,6 +159,7 @@ const proprietaryAdSizes = {
 	fluid: createAdSize(0, 0),
 	googleCard: createAdSize(300, 274),
 	outOfPage: createAdSize(1, 1),
+	pubmaticInterscroller: createAdSize(371, 660), // pubmatic only mobile size
 };
 
 /**

--- a/src/events/render-advert.ts
+++ b/src/events/render-advert.ts
@@ -90,6 +90,11 @@ sizeCallbacks[adSizes.outstreamMobile.toString()] = (advert: Advert) =>
 sizeCallbacks[adSizes.googleCard.toString()] = (advert: Advert) =>
 	advert.updateExtraSlotClasses('ad-slot--gc');
 
+sizeCallbacks[adSizes.pubmaticInterscroller.toString()] = (advert: Advert) => {
+	advert.shouldRefresh = false;
+	return Promise.resolve();
+};
+
 /**
  * Out of page adverts - creatives that aren't directly shown on the page - need to be hidden,
  * and their containers closed up.

--- a/src/insert/spacefinder/article.ts
+++ b/src/insert/spacefinder/article.ts
@@ -204,7 +204,7 @@ const additionalMobileAndTabletInlineSizes = (index: number) => {
 			],
 		};
 	}
-	return {};
+	return undefined;
 };
 
 const addMobileAndTabletInlineAds = (

--- a/src/insert/spacefinder/article.ts
+++ b/src/insert/spacefinder/article.ts
@@ -191,6 +191,22 @@ const addDesktopRightRailAds = (
 	);
 };
 
+const additionalMobileAndTabletInlineSizes = (index: number) => {
+	if (index === 1) {
+		return {
+			mobile: [adSizes.portraitInterstitial],
+		};
+	} else if (index === 2) {
+		return {
+			mobile: [
+				adSizes.portraitInterstitial,
+				adSizes.pubmaticInterscroller,
+			],
+		};
+	}
+	return {};
+};
+
 const addMobileAndTabletInlineAds = (
 	fillSlot: FillAdSlot,
 	currentBreakpoint: ReturnType<typeof getCurrentBreakpoint>,
@@ -209,12 +225,7 @@ const addMobileAndTabletInlineAds = (
 			return fillSlot(
 				name,
 				slot,
-				// Add the mobile portrait interstitial size to inline1 and inline2
-				i == 1 || i == 2
-					? {
-							mobile: [adSizes.portraitInterstitial],
-						}
-					: undefined,
+				additionalMobileAndTabletInlineSizes(i),
 			);
 		});
 		await Promise.all(slots);

--- a/src/lib/header-bidding/prebid/bid-config.ts
+++ b/src/lib/header-bidding/prebid/bid-config.ts
@@ -498,6 +498,13 @@ const pubmaticBidder = (slotSizes: HeaderBiddingSize[]): PrebidBidder => {
 		bidParams: (slotId: string): PrebidPubmaticParams => ({
 			publisherId: getPubmaticPublisherId(),
 			adSlot: stripDfpAdPrefixFrom(slotId),
+			placementId:
+				slotId === 'dfp-ad--inline2' &&
+				slotSizes.find(
+					(size) => size.width === 371 && size.height === 660,
+				)
+					? 'seenthis_guardian_371x660'
+					: undefined,
 		}),
 	};
 

--- a/src/lib/header-bidding/slot-config.spec.ts
+++ b/src/lib/header-bidding/slot-config.spec.ts
@@ -171,6 +171,7 @@ describe('getPrebidAdSlots', () => {
 		expect(hbSlots[0]?.sizes).toEqual([
 			createAdSize(300, 250),
 			createAdSize(320, 480),
+			createAdSize(371, 660),
 		]);
 	});
 

--- a/src/lib/header-bidding/slot-config.ts
+++ b/src/lib/header-bidding/slot-config.ts
@@ -158,7 +158,11 @@ const getSlots = (): HeaderBiddingSizeMapping => {
 				: [adSizes.mpu],
 			tablet: [adSizes.mpu],
 			mobile: isArticle
-				? [adSizes.mpu, adSizes.portraitInterstitial]
+				? [
+						adSizes.mpu,
+						adSizes.portraitInterstitial,
+						adSizes.pubmaticInterscroller,
+					]
 				: [adSizes.mpu],
 		},
 		mostpop: {


### PR DESCRIPTION
## What does this change?
This is a new size that run through pubmatic via prebid.js in the inline2 slot on articles.

The new size is not allowed to refresh, which is handled in the size callbacks; or display after a slot is refreshed which is handled by negatively targeting the `refreshed` custom targeting param.


New line items have been set up in Ad Manager.