### PR TITLE
Remove `commercial/api/hb` endpoint via `@guardian/prebid.js@8.52.0-6`

### DIFF
--- a/.changeset/tame-cheetahs-fry.md
+++ b/.changeset/tame-cheetahs-fry.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Remove commercial/api/hb endpoint

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
 	},
 	"dependencies": {
 		"@changesets/cli": "^2.26.2",
-		"@guardian/prebid.js": "8.52.0-5",
+		"@guardian/prebid.js": "8.52.0-6",
 		"@octokit/core": "^6.1.2",
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^2.26.2
     version: 2.27.7
   '@guardian/prebid.js':
-    specifier: 8.52.0-5
-    version: 8.52.0-5(babel-core@7.0.0-bridge.0)(tslib@2.7.0)(typescript@5.5.3)
+    specifier: 8.52.0-6
+    version: 8.52.0-6(babel-core@7.0.0-bridge.0)(tslib@2.7.0)(typescript@5.5.3)
   '@octokit/core':
     specifier: ^6.1.2
     version: 6.1.2
@@ -1981,8 +1981,8 @@ packages:
       tslib: 2.7.0
       typescript: 5.5.3
 
-  /@guardian/prebid.js@8.52.0-5(babel-core@7.0.0-bridge.0)(tslib@2.7.0)(typescript@5.5.3):
-    resolution: {integrity: sha512-aGzq0o4zjFd7UNSOXV1YqQqp2du+B53knuvPqhwvITM0rMMYYGEG+A25BRSPQPgfdXSPYuYxaxWgVDZ1l78fZw==}
+  /@guardian/prebid.js@8.52.0-6(babel-core@7.0.0-bridge.0)(tslib@2.7.0)(typescript@5.5.3):
+    resolution: {integrity: sha512-YBsPkX5XxHSVNWw1PDX4c6WArH7e5FOomFM59QVIDuWNqrI2vyORvN7df2JukiDvCBxVggGUc1n77Lub2jstZw==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@babel/core': 7.25.2


### PR DESCRIPTION
## What does this change?

Remove `commercial/api/hb` endpoint via an update to `@guardian/prebid.js@8.52.0-6`

See:
https://github.com/guardian/Prebid.js/pull/159
https://github.com/guardian/platform/pull/1625
https://github.com/guardian/frontend/pull/27506

## Why?

The `/hb` endpoint powers the header bidding dashboard in Frontend but it is no longer used so we can remove all associated code.
