### PR TITLE
Remove unused exports

### DIFF
--- a/.changeset/swift-jars-drop.md
+++ b/.changeset/swift-jars-drop.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Removed unused exports

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,74 +1,16 @@
-/* istanbul ignore file -- there's no point check this for test coverage */
-
-export { ias } from './third-party-tags/ias';
-export { permutive } from './third-party-tags/permutive';
-export { twitter } from './third-party-tags/twitter-uwt';
-export { inizio } from './third-party-tags/inizio';
-export { remarketing } from './third-party-tags/remarketing';
+export { isAdBlockInUse } from './detect-ad-blocker';
 export { EventTimer } from './event-timer';
+export { adSizes } from './ad-sizes';
+export * as constants from './constants';
 export {
 	bypassCommercialMetricsSampling,
 	initCommercialMetrics,
 } from './send-commercial-metrics';
-export type { ThirdPartyTag } from './types';
-export {
-	adSizes,
-	createAdSize,
-	getAdSize,
-	outstreamSizes,
-	slotSizeMappings,
-	standardAdSizes,
-} from './ad-sizes';
-export { isBreakpoint } from './lib/breakpoint';
-export type { Breakpoint } from './lib/breakpoint';
-export type {
-	SizeKeys,
-	AdSizeString,
-	AdSize,
-	SizeMapping,
-	SlotSizeMappings,
-	SlotName,
-} from './ad-sizes';
-export { isAdBlockInUse } from './detect-ad-blocker';
-export {
-	clearPermutiveSegments,
-	getPermutiveSegments,
-	getPermutivePFPSegments,
-} from './permutive';
-export { initTrackScrollDepth } from './track-scroll-depth';
-export { initTrackGpcSignal } from './track-gpc-signal';
-export { createAdSlot, concatSizeMappings } from '../core/create-ad-slot';
-export type {
-	AdsConfig,
-	AdsConfigBasic,
-	AdsConfigDisabled,
-	AdTargetingBuilder,
-	CustomParams,
-} from './types';
-export * as constants from './constants';
-export type { ContentTargeting } from './targeting/content';
-export { getContentTargeting } from './targeting/content';
-export type { PersonalisedTargeting } from './targeting/personalised';
-export { getPersonalisedTargeting } from './targeting/personalised';
-export type { SessionTargeting } from './targeting/session';
-export { getSessionTargeting } from './targeting/session';
-export type { SharedTargeting } from './targeting/shared';
-export { getSharedTargeting } from './targeting/shared';
-export type { ViewportTargeting } from './targeting/viewport';
-export { getViewportTargeting } from './targeting/viewport';
-export { pickTargetingValues } from './targeting/pick-targeting-values';
-export { init as initMessenger } from './messenger';
-export type {
-	RegisterListener,
-	RegisterPersistentListener,
-	RespondProxy,
-} from './messenger';
-export { postMessage } from './messenger/post-message';
 export { buildPageTargeting } from './targeting/build-page-targeting';
-export { buildPageTargetingConsentless } from './targeting/build-page-targeting-consentless';
-export type { PageTargeting } from './targeting/build-page-targeting';
-/* -- Vendor JavaScript -- */
-export { a9Apstag } from './__vendor/a9-apstag';
-export { ipsosMoriStub } from './__vendor/ipsos-mori';
-export { pubmatic } from './__vendor/pubmatic';
+export { postMessage } from './messenger/post-message';
 export { buildImaAdTagUrl } from './targeting/youtube-ima';
+export { getPermutivePFPSegments } from './permutive';
+export type { AdsConfigDisabled } from './types';
+export type { AdSize, SizeMapping, SlotName } from './ad-sizes';
+export type { PageTargeting } from './targeting/build-page-targeting';
+export type { AdsConfigCCPAorAus, AdsConfigTCFV2 } from './types';

--- a/src/init/consented/messenger.ts
+++ b/src/init/consented/messenger.ts
@@ -1,4 +1,4 @@
-import { initMessenger } from 'core';
+import { init as initMessenger } from 'core/messenger';
 import { init as background } from 'core/messenger/background';
 import { init as disableRefresh } from 'core/messenger/disable-refresh';
 import { init as fullwidth } from 'core/messenger/full-width';

--- a/src/init/consentless.ts
+++ b/src/init/consentless.ts
@@ -1,5 +1,5 @@
 import type { ConsentState } from '@guardian/libs';
-import { initMessenger } from 'core';
+import { init as initMessenger } from 'core/messenger';
 import { init as background } from 'core/messenger/background';
 import { init as resize } from 'core/messenger/resize';
 import { init as type } from 'core/messenger/type';

--- a/src/lib/header-bidding/prebid/improve-digital.spec.ts
+++ b/src/lib/header-bidding/prebid/improve-digital.spec.ts
@@ -1,4 +1,4 @@
-import { createAdSize } from 'core';
+import { createAdSize } from 'core/ad-sizes';
 import {
 	isInAuOrNz as isInAuOrNz_,
 	isInRow as isInRow_,

--- a/src/lib/header-bidding/prebid/magnite.spec.ts
+++ b/src/lib/header-bidding/prebid/magnite.spec.ts
@@ -1,4 +1,4 @@
-import { createAdSize } from 'core';
+import { createAdSize } from 'core/ad-sizes';
 import {
 	isInAuOrNz as isInAuOrNz_,
 	isInRow as isInRow_,


### PR DESCRIPTION
## What does this change?

Removes unused exports from the commercial repo.

This is a hangover from when `commercial-core` and `commercial` were two separate libraries and we would export from core into commercial. Since merging we can now remove any exported functions which were just for internal sharing and not used by other repositories.

I based the exports that we should keep on this search:
https://github.com/search?q=org%3Aguardian+%40guardian%2Fcommercial&type=code&p=1

Exports required for atoms-rendering were ignored as that is an archived project.

