### PR TITLE
Enforce relative imports when importing from core

### DIFF
--- a/.changeset/stupid-gifts-grab.md
+++ b/.changeset/stupid-gifts-grab.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Use relative imports when importing from core

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,18 @@ module.exports = {
 		'no-use-before-define': ['error', { functions: true, classes: true }],
 		'import/exports-last': 'error',
 		'no-else-return': 'error',
+		'no-restricted-imports': [
+			'error',
+			{
+				patterns: [
+					{
+						group: ['core/*'],
+						message:
+							'Paths starting with “core”, are forbidden. Please use a relative path instead',
+					},
+				],
+			},
+		],
 	},
 	overrides: [
 		{

--- a/playwright/tests/merchandising-high.spec.ts
+++ b/playwright/tests/merchandising-high.spec.ts
@@ -1,5 +1,5 @@
 import { test } from '@playwright/test';
-import { isDefined } from 'core/types';
+import { isDefined } from '../../src/core/types';
 import { breakpoints } from '../fixtures/breakpoints';
 import { articles, blogs } from '../fixtures/pages';
 import type { GuPage } from '../fixtures/pages/Page';

--- a/playwright/tests/merchandising.spec.ts
+++ b/playwright/tests/merchandising.spec.ts
@@ -1,5 +1,5 @@
 import { test } from '@playwright/test';
-import { isDefined } from 'core/types';
+import { isDefined } from '../../src/core/types';
 import { breakpoints } from '../fixtures/breakpoints';
 import { articles, blogs } from '../fixtures/pages';
 import type { GuPage } from '../fixtures/pages/Page';

--- a/playwright/tests/mostpop.spec.ts
+++ b/playwright/tests/mostpop.spec.ts
@@ -1,5 +1,5 @@
 import { test } from '@playwright/test';
-import { isDefined } from 'core/types';
+import { isDefined } from '../../src/core/types';
 import { testAtBreakpoints } from '../fixtures/breakpoints';
 import { articles, blogs } from '../fixtures/pages';
 import type { GuPage } from '../fixtures/pages/Page';

--- a/src/core/lib/video-interscroller-progress.ts
+++ b/src/core/lib/video-interscroller-progress.ts
@@ -1,5 +1,5 @@
 import { once } from 'lodash-es';
-import { checkConsent as checkConsentForReporting } from 'core/send-commercial-metrics';
+import { checkConsent as checkConsentForReporting } from '../send-commercial-metrics';
 
 const endpoint = window.guardian.config.page.isDev
 	? '//logs.code.dev-guardianapis.com/log'

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -1,14 +1,14 @@
 import { isObject } from '@guardian/libs';
-import {
-	initVideoProgressReporting,
-	updateVideoProgress,
-} from 'core/lib/video-interscroller-progress';
-import type { RegisterListener } from 'core/messenger';
 import fastdom from 'utils/fastdom-promise';
 import {
 	renderAdvertLabel,
 	renderStickyScrollForMoreLabel,
 } from '../../events/render-advert-label';
+import {
+	initVideoProgressReporting,
+	updateVideoProgress,
+} from '../lib/video-interscroller-progress';
+import type { RegisterListener } from '../messenger';
 
 const isGallery = window.guardian.config.page.contentType === 'Gallery';
 

--- a/src/core/messenger/disable-refresh.ts
+++ b/src/core/messenger/disable-refresh.ts
@@ -1,5 +1,5 @@
-import type { RegisterListener } from 'core/messenger';
 import { dfpEnv } from '../../lib/dfp/dfp-env';
+import type { RegisterListener } from '../messenger';
 
 // This message is intended to be used with a DFP creative wrapper.
 // For reference, the wrapper will post a message, with an iFrameId, like so:

--- a/src/core/messenger/full-width.ts
+++ b/src/core/messenger/full-width.ts
@@ -1,6 +1,6 @@
 import { isBoolean } from '@guardian/libs';
 import fastdom from 'fastdom';
-import type { RegisterListener } from 'core/messenger';
+import type { RegisterListener } from '../messenger';
 
 const fullWidth = (fullWidth: boolean, slotContainer: HTMLElement) =>
 	fastdom.mutate(() => {

--- a/src/core/messenger/get-page-targeting.ts
+++ b/src/core/messenger/get-page-targeting.ts
@@ -1,4 +1,4 @@
-import type { RegisterListener } from 'core/messenger';
+import type { RegisterListener } from '../messenger';
 
 /**
  * Register a listener for iframes to request shared ad targeting

--- a/src/core/messenger/get-page-url.ts
+++ b/src/core/messenger/get-page-url.ts
@@ -1,4 +1,4 @@
-import type { RegisterListener } from 'core/messenger';
+import type { RegisterListener } from '../messenger';
 
 const init = (register: RegisterListener): void => {
 	register(

--- a/src/core/messenger/get-stylesheet.ts
+++ b/src/core/messenger/get-stylesheet.ts
@@ -1,5 +1,5 @@
 import { isObject } from '@guardian/libs';
-import type { RegisterListener } from 'core/messenger';
+import type { RegisterListener } from '../messenger';
 
 interface StylesheetSpecs {
 	selector: string;

--- a/src/core/messenger/measure-ad-load.ts
+++ b/src/core/messenger/measure-ad-load.ts
@@ -1,6 +1,6 @@
 import { isObject, isString } from '@guardian/libs';
-import { EventTimer } from 'core/event-timer';
-import type { RegisterListener } from 'core/messenger';
+import { EventTimer } from '../event-timer';
+import type { RegisterListener } from '../messenger';
 
 // This message is intended to be used with a GAM creative wrapper.
 // For reference, the wrapper will post a message, like so:

--- a/src/core/messenger/passback-refresh.ts
+++ b/src/core/messenger/passback-refresh.ts
@@ -1,7 +1,7 @@
 import { isString } from '@guardian/libs';
-import type { RegisterListener } from 'core/messenger';
 import { refreshAdvert } from '../../display/load-advert';
 import { getAdvertById } from '../../lib/dfp/get-advert-by-id';
+import type { RegisterListener } from '../messenger';
 
 const passbackRefresh = (specs: string, adSlot: HTMLElement) => {
 	const advert = getAdvertById(adSlot.id);

--- a/src/core/messenger/passback.ts
+++ b/src/core/messenger/passback.ts
@@ -1,11 +1,11 @@
 import { log } from '@guardian/libs';
 import { breakpoints } from '@guardian/source/foundations';
-import { adSizes } from 'core/ad-sizes';
-import type { RegisterListener } from 'core/messenger';
 import { getCurrentBreakpoint } from 'lib/detect/detect-breakpoint';
 import { getAdvertById } from 'lib/dfp/get-advert-by-id';
 import fastdom from 'utils/fastdom-promise';
 import { adSlotIdPrefix } from '../../lib/dfp/dfp-env-globals';
+import { adSizes } from '../ad-sizes';
+import type { RegisterListener } from '../messenger';
 
 type PassbackMessagePayload = { source: string };
 

--- a/src/core/messenger/resize.ts
+++ b/src/core/messenger/resize.ts
@@ -1,6 +1,6 @@
 import { isObject, isString } from '@guardian/libs';
-import type { RegisterListener } from 'core/messenger';
 import fastdom from 'utils/fastdom-promise';
+import type { RegisterListener } from '../messenger';
 
 interface Styles {
 	width?: string;

--- a/src/core/messenger/scroll.ts
+++ b/src/core/messenger/scroll.ts
@@ -1,8 +1,8 @@
-import type { RegisterListener } from 'core/messenger';
 import type { Viewport } from 'lib/detect/detect-viewport';
 import { getViewport } from 'lib/detect/detect-viewport';
 import { addEventListener } from 'lib/events';
 import fastdom from 'utils/fastdom-promise';
+import type { RegisterListener } from '../messenger';
 
 type Respond = (...args: unknown[]) => void;
 

--- a/src/core/messenger/type.ts
+++ b/src/core/messenger/type.ts
@@ -1,6 +1,6 @@
 import { isString } from '@guardian/libs';
-import type { RegisterListener } from 'core/messenger';
 import fastdom from 'utils/fastdom-promise';
+import type { RegisterListener } from '../messenger';
 
 const setType = (adSlotType: string, adSlot: Element) =>
 	fastdom.mutate(() => {

--- a/src/core/messenger/viewport.ts
+++ b/src/core/messenger/viewport.ts
@@ -1,7 +1,7 @@
-import type { RegisterPersistentListener, RespondProxy } from 'core/messenger';
 import { getViewport } from 'lib/detect/detect-viewport';
 import type { Viewport } from 'lib/detect/detect-viewport';
 import fastdom from 'utils/fastdom-promise';
+import type { RegisterPersistentListener, RespondProxy } from '../messenger';
 
 type IFrameMapValue = {
 	node: HTMLIFrameElement;

--- a/src/define/Advert.spec.ts
+++ b/src/define/Advert.spec.ts
@@ -1,5 +1,5 @@
-import type * as AdSizesType from 'core/ad-sizes';
-import { slotSizeMappings as slotSizeMappings_ } from 'core/ad-sizes';
+import type * as AdSizesType from '../core/ad-sizes';
+import { slotSizeMappings as slotSizeMappings_ } from '../core/ad-sizes';
 import { _, Advert, findSmallestAdHeightForSlot } from './Advert';
 
 const { getSlotSizeMapping } = _;

--- a/src/define/Advert.ts
+++ b/src/define/Advert.ts
@@ -1,13 +1,13 @@
 import { breakpoints as sourceBreakpoints } from '@guardian/source/foundations';
-import type { AdSize, SizeMapping, SlotName } from 'core/ad-sizes';
+import fastdom from 'utils/fastdom-promise';
 import {
 	createAdSize,
 	findAppliedSizesForBreakpoint,
 	slotSizeMappings,
-} from 'core/ad-sizes';
-import { concatSizeMappings } from 'core/create-ad-slot';
-import type { Breakpoint } from 'core/lib/breakpoint';
-import fastdom from 'utils/fastdom-promise';
+} from '../core/ad-sizes';
+import type { AdSize, SizeMapping, SlotName } from '../core/ad-sizes';
+import { concatSizeMappings } from '../core/create-ad-slot';
+import type { Breakpoint } from '../core/lib/breakpoint';
 import { breakpointNameToAttribute } from '../lib/breakpoint-name-to-attribute';
 import type { HeaderBiddingSize } from '../lib/header-bidding/prebid-types';
 import { buildGoogletagSizeMapping, defineSlot } from './define-slot';

--- a/src/define/create-advert.ts
+++ b/src/define/create-advert.ts
@@ -1,5 +1,5 @@
 import { log } from '@guardian/libs';
-import type { SizeMapping } from 'core/ad-sizes';
+import type { SizeMapping } from '../core/ad-sizes';
 import { reportError } from '../utils/report-error';
 import { Advert } from './Advert';
 

--- a/src/define/define-slot.spec.ts
+++ b/src/define/define-slot.spec.ts
@@ -1,6 +1,6 @@
-import type { SizeMapping } from 'core/ad-sizes';
-import { adSizes, createAdSize } from 'core/ad-sizes';
 import { toGoogleTagSize } from 'utils/googletag-ad-size';
+import type { SizeMapping } from '../core/ad-sizes';
+import { adSizes, createAdSize } from '../core/ad-sizes';
 import {
 	buildGoogletagSizeMapping,
 	collectSizes,

--- a/src/define/define-slot.ts
+++ b/src/define/define-slot.ts
@@ -1,9 +1,9 @@
 import { breakpoints as sourceBreakpoints } from '@guardian/source/foundations';
 import { once } from 'lodash-es';
 import { EventTimer } from 'core';
-import type { SizeMapping, SlotName } from 'core/ad-sizes';
 import { toGoogleTagSize } from 'utils/googletag-ad-size';
 import { getUrlVars } from 'utils/url';
+import type { SizeMapping, SlotName } from '../core/ad-sizes';
 import { initSlotIas } from './init-slot-ias';
 
 const breakpointViewports: Record<keyof SizeMapping, [number, number]> = {

--- a/src/display/load-advert.ts
+++ b/src/display/load-advert.ts
@@ -1,5 +1,5 @@
 import fastdom from 'fastdom';
-import { EventTimer } from 'core/event-timer';
+import { EventTimer } from '../core/event-timer';
 import type { Advert } from '../define/Advert';
 import { stripDfpAdPrefixFrom } from '../lib/header-bidding/utils';
 import { refreshBidsForAd, requestBidsForAd } from './request-bids';

--- a/src/display/request-bids.ts
+++ b/src/display/request-bids.ts
@@ -1,4 +1,4 @@
-import type { AdSize } from 'core/ad-sizes';
+import type { AdSize } from '../core/ad-sizes';
 import type { Advert } from '../define/Advert';
 import { a9 } from '../lib/header-bidding/a9/a9';
 import { prebid } from '../lib/header-bidding/prebid/prebid';

--- a/src/events/on-slot-load.ts
+++ b/src/events/on-slot-load.ts
@@ -1,4 +1,4 @@
-import { postMessage } from 'core/messenger/post-message';
+import { postMessage } from '../core/messenger/post-message';
 import { getAdvertById } from '../lib/dfp/get-advert-by-id';
 
 const host = `${window.location.protocol}//${window.location.host}`;

--- a/src/events/on-slot-render.ts
+++ b/src/events/on-slot-render.ts
@@ -1,6 +1,6 @@
 import { isString } from '@guardian/libs';
-import type { AdSize } from 'core/ad-sizes';
-import { createAdSize } from 'core/ad-sizes';
+import type { AdSize } from '../core/ad-sizes';
+import { createAdSize } from '../core/ad-sizes';
 import { getAdvertById } from '../lib/dfp/get-advert-by-id';
 import { reportError } from '../utils/report-error';
 import { emptyAdvert } from './empty-advert';

--- a/src/events/on-slot-viewable.ts
+++ b/src/events/on-slot-viewable.ts
@@ -1,9 +1,9 @@
 import { log } from '@guardian/libs';
 import { EventTimer } from 'core';
-import { outstreamSizes } from 'core/ad-sizes';
-import { AD_LABEL_HEIGHT } from 'core/constants/ad-label-height';
 import fastdom from 'utils/fastdom-promise';
 import { getUrlVars } from 'utils/url';
+import { outstreamSizes } from '../core/ad-sizes';
+import { AD_LABEL_HEIGHT } from '../core/constants/ad-label-height';
 import type { Advert } from '../define/Advert';
 import { isAdSize } from '../define/Advert';
 import { enableLazyLoad } from '../display/lazy-load';

--- a/src/events/render-advert.ts
+++ b/src/events/render-advert.ts
@@ -1,6 +1,6 @@
-import { adSizes } from 'core/ad-sizes';
 import { $$ } from 'utils/$$';
 import fastdom from 'utils/fastdom-promise';
+import { adSizes } from '../core/ad-sizes';
 import type { Advert } from '../define/Advert';
 import { getAdIframe } from '../lib/dfp/get-ad-iframe';
 import { reportError } from '../utils/report-error';

--- a/src/experiments/utils.ts
+++ b/src/experiments/utils.ts
@@ -1,5 +1,5 @@
 import { bypassCoreWebVitalsSampling } from '@guardian/core-web-vitals';
-import { bypassCommercialMetricsSampling } from 'core/send-commercial-metrics';
+import { bypassCommercialMetricsSampling } from '../core/send-commercial-metrics';
 
 export const bypassMetricsSampling = (): void => {
 	void bypassCommercialMetricsSampling();

--- a/src/init/consented.ts
+++ b/src/init/consented.ts
@@ -1,5 +1,4 @@
 import { log } from '@guardian/libs';
-import { EventTimer } from 'core/event-timer';
 import { adFreeSlotRemove } from 'init/consented/ad-free-slot-remove';
 import { init as initComscore } from 'init/consented/comscore';
 import { initFillSlotListener } from 'init/consented/fill-slot-listener';
@@ -19,6 +18,7 @@ import { init as setAdTestInLabelsCookie } from 'init/shared/set-adtest-in-label
 import { init as prepareAdVerification } from 'lib/ad-verification/prepare-ad-verification';
 import { commercialFeatures } from 'lib/commercial-features';
 import { adSlotIdPrefix } from 'lib/dfp/dfp-env-globals';
+import { EventTimer } from '../core/event-timer';
 import { reportError } from '../utils/report-error';
 import { catchErrorsAndReport } from '../utils/robust';
 import { initDfpListeners } from './consented/dfp-listeners';

--- a/src/init/consented/ipsos-mori.ts
+++ b/src/init/consented/ipsos-mori.ts
@@ -5,7 +5,7 @@ import {
 	log,
 	onConsent,
 } from '@guardian/libs';
-import { ipsosMoriStub } from 'core/__vendor/ipsos-mori';
+import { ipsosMoriStub } from '../../core/__vendor/ipsos-mori';
 
 const loadIpsosScript = (locale: 'au' | 'uk') => {
 	ipsosMoriStub();

--- a/src/init/consented/messenger.ts
+++ b/src/init/consented/messenger.ts
@@ -1,17 +1,17 @@
-import { init as initMessenger } from 'core/messenger';
-import { init as background } from 'core/messenger/background';
-import { init as disableRefresh } from 'core/messenger/disable-refresh';
-import { init as fullwidth } from 'core/messenger/full-width';
-import { init as initGetPageTargeting } from 'core/messenger/get-page-targeting';
-import { init as initGetPageUrl } from 'core/messenger/get-page-url';
-import { init as getStyles } from 'core/messenger/get-stylesheet';
-import { init as initMeasureAdLoad } from 'core/messenger/measure-ad-load';
-import { init as passback } from 'core/messenger/passback';
-import { init as passbackRefresh } from 'core/messenger/passback-refresh';
-import { init as resize } from 'core/messenger/resize';
-import { init as scroll } from 'core/messenger/scroll';
-import { init as type } from 'core/messenger/type';
-import { init as viewport } from 'core/messenger/viewport';
+import { init as initMessenger } from '../../core/messenger';
+import { init as background } from '../../core/messenger/background';
+import { init as disableRefresh } from '../../core/messenger/disable-refresh';
+import { init as fullwidth } from '../../core/messenger/full-width';
+import { init as initGetPageTargeting } from '../../core/messenger/get-page-targeting';
+import { init as initGetPageUrl } from '../../core/messenger/get-page-url';
+import { init as getStyles } from '../../core/messenger/get-stylesheet';
+import { init as initMeasureAdLoad } from '../../core/messenger/measure-ad-load';
+import { init as passback } from '../../core/messenger/passback';
+import { init as passbackRefresh } from '../../core/messenger/passback-refresh';
+import { init as resize } from '../../core/messenger/resize';
+import { init as scroll } from '../../core/messenger/scroll';
+import { init as type } from '../../core/messenger/type';
+import { init as viewport } from '../../core/messenger/viewport';
 
 /**
  * Messenger gets to skip the promise chain and run immediately.

--- a/src/init/consented/prepare-a9.ts
+++ b/src/init/consented/prepare-a9.ts
@@ -1,9 +1,9 @@
 import { getConsentFor, log, onConsent } from '@guardian/libs';
 import { once } from 'lodash-es';
-import { a9Apstag } from 'core/__vendor/a9-apstag';
 import { commercialFeatures } from 'lib/commercial-features';
 import { isGoogleProxy } from 'lib/detect/detect-google-proxy';
 import { isInCanada } from 'utils/geo-utils';
+import { a9Apstag } from '../../core/__vendor/a9-apstag';
 import { a9 } from '../../lib/header-bidding/a9/a9';
 import { shouldIncludeOnlyA9 } from '../../lib/header-bidding/utils';
 

--- a/src/init/consented/prepare-googletag.spec.ts
+++ b/src/init/consented/prepare-googletag.spec.ts
@@ -1,9 +1,9 @@
 import type { ConsentState } from '@guardian/libs';
 import { getConsentFor, loadScript, onConsent } from '@guardian/libs';
-import type * as AdSizesType from 'core/ad-sizes';
 import { commercialFeatures } from 'lib/commercial-features';
 import _config from 'lib/config';
 import { getCurrentBreakpoint as getCurrentBreakpoint_ } from 'lib/detect/detect-breakpoint';
+import type * as AdSizesType from '../../core/ad-sizes';
 import { loadAdvert } from '../../display/load-advert';
 import { dfpEnv } from '../../lib/dfp/dfp-env';
 import { init as prepareGoogletag } from './prepare-googletag';

--- a/src/init/consented/prepare-googletag.ts
+++ b/src/init/consented/prepare-googletag.ts
@@ -1,9 +1,9 @@
 import type { ConsentState } from '@guardian/libs';
 import { getConsentFor, loadScript, log, onConsent } from '@guardian/libs';
-import { EventTimer } from 'core/event-timer';
 import { getPageTargeting } from 'lib/build-page-targeting';
 import { commercialFeatures } from 'lib/commercial-features';
 import { getGoogleTagId, isUserLoggedInOktaRefactor } from 'lib/identity/api';
+import { EventTimer } from '../../core/event-timer';
 import { removeSlots } from './remove-slots';
 import { fillStaticAdvertSlots } from './static-ad-slots';
 

--- a/src/init/consented/prepare-permutive.ts
+++ b/src/init/consented/prepare-permutive.ts
@@ -1,5 +1,5 @@
-import type { Edition } from 'core/types';
 import type { Config, PageConfig, Permutive, UserConfig } from 'types/global';
+import type { Edition } from '../../core/types';
 import { reportError } from '../../utils/report-error';
 
 interface PermutivePageConfig {

--- a/src/init/consented/static-ad-slots.ts
+++ b/src/init/consented/static-ad-slots.ts
@@ -1,6 +1,4 @@
 import { isNonNullable, log } from '@guardian/libs';
-import type { SizeMapping } from 'core/ad-sizes';
-import { adSizes, createAdSize } from 'core/ad-sizes';
 import { isUserInVariant } from 'experiments/ab';
 import { mpuWhenNoEpic } from 'experiments/tests/mpu-when-no-epic';
 import { setupPrebidOnce } from 'init/consented/prepare-prebid';
@@ -8,6 +6,8 @@ import { removeDisabledSlots } from 'init/consented/remove-slots';
 import { commercialFeatures } from 'lib/commercial-features';
 import { getCurrentBreakpoint } from 'lib/detect/detect-breakpoint';
 import { isInUk, isInUsa } from 'utils/geo-utils';
+import { adSizes, createAdSize } from '../../core/ad-sizes';
+import type { SizeMapping } from '../../core/ad-sizes';
 import { createAdvert } from '../../define/create-advert';
 import { displayAds } from '../../display/display-ads';
 import { displayLazyAds } from '../../display/display-lazy-ads';

--- a/src/init/consented/third-party-tags.ts
+++ b/src/init/consented/third-party-tags.ts
@@ -1,13 +1,13 @@
 /* A regionalised container for all the commercial tags. */
 
 import { getConsentFor, onConsent } from '@guardian/libs';
-import { ias } from 'core/third-party-tags/ias';
-import { inizio } from 'core/third-party-tags/inizio';
-import { permutive } from 'core/third-party-tags/permutive';
-import { remarketing } from 'core/third-party-tags/remarketing';
-import { twitter } from 'core/third-party-tags/twitter-uwt';
 import { commercialFeatures } from 'lib/commercial-features';
 import type { ThirdPartyTag } from 'types/global';
+import { ias } from '../../core/third-party-tags/ias';
+import { inizio } from '../../core/third-party-tags/inizio';
+import { permutive } from '../../core/third-party-tags/permutive';
+import { remarketing } from '../../core/third-party-tags/remarketing';
+import { twitter } from '../../core/third-party-tags/twitter-uwt';
 import { imrWorldwide } from '../../lib/third-party-tags/imr-worldwide';
 import { imrWorldwideLegacy } from '../../lib/third-party-tags/imr-worldwide-legacy';
 import fastdom from '../../utils/fastdom-promise';

--- a/src/init/consented/track-gpc-signal.ts
+++ b/src/init/consented/track-gpc-signal.ts
@@ -1,6 +1,6 @@
 import type { ConsentState } from '@guardian/libs';
 import { log, onConsent } from '@guardian/libs';
-import { initTrackGpcSignal } from 'core/track-gpc-signal';
+import { initTrackGpcSignal } from '../../core/track-gpc-signal';
 
 /**
  * Initialise gpc signal tracking

--- a/src/init/consented/track-scroll-depth.ts
+++ b/src/init/consented/track-scroll-depth.ts
@@ -1,5 +1,5 @@
 import { log, onConsent } from '@guardian/libs';
-import { initTrackScrollDepth } from 'core/track-scroll-depth';
+import { initTrackScrollDepth } from '../../core/track-scroll-depth';
 
 /**
  * Initialise scroll depth / velocity tracking if user has consented to relevant purposes.

--- a/src/init/consentless.ts
+++ b/src/init/consentless.ts
@@ -1,8 +1,4 @@
 import type { ConsentState } from '@guardian/libs';
-import { init as initMessenger } from 'core/messenger';
-import { init as background } from 'core/messenger/background';
-import { init as resize } from 'core/messenger/resize';
-import { init as type } from 'core/messenger/type';
 import { initArticleBodyAdverts } from 'init/consentless/dynamic/article-body-adverts';
 import { initExclusionSlot } from 'init/consentless/dynamic/exclusion-slot';
 import { initFixedSlots } from 'init/consentless/init-fixed-slots';
@@ -10,6 +6,10 @@ import { initConsentless } from 'init/consentless/prepare-ootag';
 import { reloadPageOnConsentChange } from 'init/shared/reload-page-on-consent-change';
 import { init as setAdTestCookie } from 'init/shared/set-adtest-cookie';
 import { init as setAdTestInLabelsCookie } from 'init/shared/set-adtest-in-labels-cookie';
+import { init as initMessenger } from '../core/messenger';
+import { init as background } from '../core/messenger/background';
+import { init as resize } from '../core/messenger/resize';
+import { init as type } from '../core/messenger/type';
 
 const bootConsentless = async (consentState: ConsentState): Promise<void> => {
 	const consentlessModuleList = [

--- a/src/init/consentless/dynamic/exclusion-slot.ts
+++ b/src/init/consentless/dynamic/exclusion-slot.ts
@@ -1,5 +1,5 @@
-import { createAdSlot } from 'core/create-ad-slot';
 import fastdom from 'utils/fastdom-promise';
+import { createAdSlot } from '../../../core/create-ad-slot';
 import { defineSlot } from '../define-slot';
 
 /**

--- a/src/init/consentless/prepare-ootag.ts
+++ b/src/init/consentless/prepare-ootag.ts
@@ -1,10 +1,10 @@
 import type { ConsentState } from '@guardian/libs';
 import { loadScript, log } from '@guardian/libs';
-import { buildPageTargetingConsentless } from 'core/targeting/build-page-targeting-consentless';
 import { getVariant } from 'experiments/ab';
 import { optOutFrequencyCap } from 'experiments/tests/opt-out-frequency-cap';
 import { commercialFeatures } from 'lib/commercial-features';
 import { isUserLoggedInOktaRefactor } from 'lib/identity/api';
+import { buildPageTargetingConsentless } from '../../core/targeting/build-page-targeting-consentless';
 
 const frequencyCapTimeoutFromVariant = (variant: string): number => {
 	if (!variant.startsWith('timeout-')) {

--- a/src/insert/comments-expanded-advert.ts
+++ b/src/insert/comments-expanded-advert.ts
@@ -1,12 +1,12 @@
 import { log } from '@guardian/libs';
-import { adSizes } from 'core/ad-sizes';
-import { AD_LABEL_HEIGHT } from 'core/constants/ad-label-height';
-import { createAdSlot } from 'core/create-ad-slot';
 import { commercialFeatures } from 'lib/commercial-features';
 import { getBreakpoint } from 'lib/detect/detect-breakpoint';
 import { getViewport } from 'lib/detect/detect-viewport';
 import { dfpEnv } from 'lib/dfp/dfp-env';
 import { getAdvertById } from 'lib/dfp/get-advert-by-id';
+import { adSizes } from '../core/ad-sizes';
+import { AD_LABEL_HEIGHT } from '../core/constants/ad-label-height';
+import { createAdSlot } from '../core/create-ad-slot';
 import fastdom from '../utils/fastdom-promise';
 import { fillDynamicAdSlot } from './fill-dynamic-advert-slot';
 

--- a/src/insert/fill-dynamic-advert-slot.ts
+++ b/src/insert/fill-dynamic-advert-slot.ts
@@ -1,5 +1,5 @@
 import { log } from '@guardian/libs';
-import type { SizeMapping } from 'core/ad-sizes';
+import type { SizeMapping } from '../core/ad-sizes';
 import type { Advert } from '../define/Advert';
 import { createAdvert } from '../define/create-advert';
 import { enableLazyLoad } from '../display/lazy-load';

--- a/src/insert/fixures.ts
+++ b/src/insert/fixures.ts
@@ -1,8 +1,8 @@
-import { AD_LABEL_HEIGHT } from 'core/constants';
-import { createAdSlot, wrapSlotInContainer } from 'core/create-ad-slot';
 import { commercialFeatures } from 'lib/commercial-features';
 import { getBreakpoint } from 'lib/detect/detect-breakpoint';
 import { getViewport } from 'lib/detect/detect-viewport';
+import { AD_LABEL_HEIGHT } from '../core/constants';
+import { createAdSlot, wrapSlotInContainer } from '../core/create-ad-slot';
 import fastdom from '../utils/fastdom-promise';
 import { fillDynamicAdSlot } from './fill-dynamic-advert-slot';
 

--- a/src/insert/high-merch.ts
+++ b/src/insert/high-merch.ts
@@ -1,5 +1,5 @@
-import { createAdSlot, wrapSlotInContainer } from 'core/create-ad-slot';
 import { commercialFeatures } from 'lib/commercial-features';
+import { createAdSlot, wrapSlotInContainer } from '../core/create-ad-slot';
 import fastdom from '../utils/fastdom-promise';
 
 /**

--- a/src/insert/mobile-crossword-banner.ts
+++ b/src/insert/mobile-crossword-banner.ts
@@ -1,4 +1,4 @@
-import { createAdSlot, wrapSlotInContainer } from 'core/create-ad-slot';
+import { createAdSlot, wrapSlotInContainer } from '../core/create-ad-slot';
 import fastdom from '../utils/fastdom-promise';
 import { fillDynamicAdSlot } from './fill-dynamic-advert-slot';
 

--- a/src/insert/mobile-sticky.ts
+++ b/src/insert/mobile-sticky.ts
@@ -1,4 +1,4 @@
-import { createAdSlot } from 'core/create-ad-slot';
+import { createAdSlot } from '../core/create-ad-slot';
 import { shouldIncludeMobileSticky } from '../lib/header-bidding/utils';
 import fastdom from '../utils/fastdom-promise';
 import { fillDynamicAdSlot } from './fill-dynamic-advert-slot';

--- a/src/insert/spacefinder/article.ts
+++ b/src/insert/spacefinder/article.ts
@@ -1,15 +1,15 @@
-import type { AdSize, SizeMapping } from 'core/ad-sizes';
-import { adSizes } from 'core/ad-sizes';
-import type { ContainerOptions } from 'core/create-ad-slot';
-import {
-	adSlotContainerClass,
-	createAdSlot,
-	wrapSlotInContainer,
-} from 'core/create-ad-slot';
 import { spaceFiller } from 'insert/spacefinder/space-filler';
 import type { SpacefinderWriter } from 'insert/spacefinder/spacefinder';
 import { commercialFeatures } from 'lib/commercial-features';
 import { getCurrentBreakpoint } from 'lib/detect/detect-breakpoint';
+import type { AdSize, SizeMapping } from '../../core/ad-sizes';
+import { adSizes } from '../../core/ad-sizes';
+import type { ContainerOptions } from '../../core/create-ad-slot';
+import {
+	adSlotContainerClass,
+	createAdSlot,
+	wrapSlotInContainer,
+} from '../../core/create-ad-slot';
 import fastdom from '../../utils/fastdom-promise';
 import { computeStickyHeights, insertHeightStyles } from '../sticky-inlines';
 import { initCarrot } from './carrot-traffic-driver';

--- a/src/insert/spacefinder/carrot-traffic-driver.ts
+++ b/src/insert/spacefinder/carrot-traffic-driver.ts
@@ -1,4 +1,3 @@
-import { createAdSlot } from 'core/create-ad-slot';
 import { spaceFiller } from 'insert/spacefinder/space-filler';
 import type {
 	SpacefinderRules,
@@ -6,6 +5,7 @@ import type {
 } from 'insert/spacefinder/spacefinder';
 import { commercialFeatures } from 'lib/commercial-features';
 import { getCurrentTweakpoint } from 'lib/detect/detect-breakpoint';
+import { createAdSlot } from '../../core/create-ad-slot';
 import fastdom from '../../utils/fastdom-promise';
 import { fillDynamicAdSlot } from '../fill-dynamic-advert-slot';
 

--- a/src/insert/spacefinder/liveblog-adverts.ts
+++ b/src/insert/spacefinder/liveblog-adverts.ts
@@ -1,6 +1,4 @@
 import { log } from '@guardian/libs';
-import { adSizes } from 'core/ad-sizes';
-import { createAdSlot } from 'core/create-ad-slot';
 import { fillDynamicAdSlot } from 'insert/fill-dynamic-advert-slot';
 import { spaceFiller } from 'insert/spacefinder/space-filler';
 import type {
@@ -12,6 +10,8 @@ import type {
 import { commercialFeatures } from 'lib/commercial-features';
 import { getCurrentBreakpoint } from 'lib/detect/detect-breakpoint';
 import fastdom from 'utils/fastdom-promise';
+import { adSizes } from '../../core/ad-sizes';
+import { createAdSlot } from '../../core/create-ad-slot';
 
 /**
  * Maximum number of inline ads to display on the page

--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -1,5 +1,5 @@
 import { adSizes } from 'core';
-import { adSlotContainerClass } from 'core/create-ad-slot';
+import { adSlotContainerClass } from '../../core/create-ad-slot';
 import type { OpponentSelectorRules, SpacefinderRules } from './spacefinder';
 import { isInHighValueSection } from './utils';
 

--- a/src/lib/ad-verification/prepare-ad-verification.ts
+++ b/src/lib/ad-verification/prepare-ad-verification.ts
@@ -1,7 +1,7 @@
 import { loadScript, log } from '@guardian/libs';
-import { EventTimer } from 'core/event-timer';
-import { bypassCommercialMetricsSampling } from 'core/send-commercial-metrics';
 import type { ConfiantCallback } from 'types/global';
+import { EventTimer } from '../../core/event-timer';
+import { bypassCommercialMetricsSampling } from '../../core/send-commercial-metrics';
 import { refreshAdvert } from '../../display/load-advert';
 import { getAdvertById } from '../dfp/get-advert-by-id';
 import { stripDfpAdPrefixFrom } from '../header-bidding/utils';

--- a/src/lib/build-page-targeting.spec.ts
+++ b/src/lib/build-page-targeting.spec.ts
@@ -1,5 +1,5 @@
 import type { ConsentState } from '@guardian/libs';
-import { buildPageTargeting as buildPageTargeting_ } from 'core/targeting/build-page-targeting';
+import { buildPageTargeting as buildPageTargeting_ } from '../core/targeting/build-page-targeting';
 import { getPageTargeting } from './build-page-targeting';
 import { isUserLoggedInOktaRefactor } from './identity/api';
 

--- a/src/lib/build-page-targeting.ts
+++ b/src/lib/build-page-targeting.ts
@@ -1,9 +1,9 @@
 import type { ConsentState } from '@guardian/libs';
 import { log } from '@guardian/libs';
 import { once } from 'lodash-es';
-import type { PageTargeting } from 'core/targeting/build-page-targeting';
-import { buildPageTargeting } from 'core/targeting/build-page-targeting';
 import { getParticipations } from 'experiments/ab';
+import type { PageTargeting } from '../core/targeting/build-page-targeting';
+import { buildPageTargeting } from '../core/targeting/build-page-targeting';
 import { commercialFeatures } from './commercial-features';
 import { removeFalsyValues } from './header-bidding/utils';
 

--- a/src/lib/dfp/should-refresh.spec.ts
+++ b/src/lib/dfp/should-refresh.spec.ts
@@ -1,4 +1,4 @@
-import { adSizes, createAdSize } from 'core/ad-sizes';
+import { adSizes, createAdSize } from '../../core/ad-sizes';
 import { Advert } from '../../define/Advert';
 import { shouldRefresh } from './should-refresh';
 

--- a/src/lib/dfp/should-refresh.ts
+++ b/src/lib/dfp/should-refresh.ts
@@ -1,5 +1,5 @@
-import type { AdSizeString } from 'core/ad-sizes';
-import { outstreamSizes } from 'core/ad-sizes';
+import type { AdSizeString } from '../../core/ad-sizes';
+import { outstreamSizes } from '../../core/ad-sizes';
 import type { Advert } from '../../define/Advert';
 
 /**

--- a/src/lib/header-bidding/prebid-types.ts
+++ b/src/lib/header-bidding/prebid-types.ts
@@ -1,4 +1,4 @@
-import type { AdSize } from 'core/ad-sizes';
+import type { AdSize } from '../../core/ad-sizes';
 
 export type HeaderBiddingSize = AdSize;
 

--- a/src/lib/header-bidding/prebid/appnexus.spec.ts
+++ b/src/lib/header-bidding/prebid/appnexus.spec.ts
@@ -1,10 +1,10 @@
-import { createAdSize } from 'core/ad-sizes';
 import {
 	isInAuOrNz as isInAuOrNz_,
 	isInRow as isInRow_,
 	isInUk as isInUk_,
 	isInUsa as isInUsa_,
 } from 'utils/geo-utils';
+import { createAdSize } from '../../../core/ad-sizes';
 import {
 	containsBillboard as containsBillboard_,
 	containsBillboardNotLeaderboard as containsBillboardNotLeaderboard_,

--- a/src/lib/header-bidding/prebid/appnexus.ts
+++ b/src/lib/header-bidding/prebid/appnexus.ts
@@ -1,6 +1,6 @@
-import type { PageTargeting } from 'core/targeting/build-page-targeting';
 import { buildAppNexusTargetingObject } from 'lib/build-page-targeting';
 import { isInAuOrNz, isInRow } from 'utils/geo-utils';
+import type { PageTargeting } from '../../../core/targeting/build-page-targeting';
 import type { HeaderBiddingSize } from '../prebid-types';
 import {
 	containsBillboardNotLeaderboard,

--- a/src/lib/header-bidding/prebid/bid-config.spec.ts
+++ b/src/lib/header-bidding/prebid/bid-config.spec.ts
@@ -1,5 +1,3 @@
-import { createAdSize } from 'core/ad-sizes';
-import type { PageTargeting } from 'core/targeting/build-page-targeting';
 import { isUserInVariant as isUserInVariant_ } from 'experiments/ab';
 import config from 'lib/config';
 import {
@@ -9,6 +7,8 @@ import {
 	isInUsa as isInUsa_,
 	isInUsOrCa as isInUsOrCa_,
 } from 'utils/geo-utils';
+import { createAdSize } from '../../../core/ad-sizes';
+import type { PageTargeting } from '../../../core/targeting/build-page-targeting';
 import type { HeaderBiddingSize, PrebidBidder } from '../prebid-types';
 import {
 	containsBillboard as containsBillboard_,

--- a/src/lib/header-bidding/prebid/bid-config.ts
+++ b/src/lib/header-bidding/prebid/bid-config.ts
@@ -1,5 +1,4 @@
 import { log } from '@guardian/libs';
-import type { PageTargeting } from 'core/targeting/build-page-targeting';
 import {
 	buildAppNexusTargeting,
 	buildAppNexusTargetingObject,
@@ -14,6 +13,7 @@ import {
 	isInUsOrCa,
 } from 'utils/geo-utils';
 import { pbTestNameMap } from 'utils/url';
+import type { PageTargeting } from '../../../core/targeting/build-page-targeting';
 import type {
 	BidderCode,
 	HeaderBiddingSize,

--- a/src/lib/header-bidding/prebid/improve-digital.spec.ts
+++ b/src/lib/header-bidding/prebid/improve-digital.spec.ts
@@ -1,10 +1,10 @@
-import { createAdSize } from 'core/ad-sizes';
 import {
 	isInAuOrNz as isInAuOrNz_,
 	isInRow as isInRow_,
 	isInUk as isInUk_,
 	isInUsOrCa as isInUsOrCa_,
 } from 'utils/geo-utils';
+import { createAdSize } from '../../../core/ad-sizes';
 import { getBreakpointKey as getBreakpointKey_ } from '../utils';
 import {
 	getImprovePlacementId,

--- a/src/lib/header-bidding/prebid/magnite.spec.ts
+++ b/src/lib/header-bidding/prebid/magnite.spec.ts
@@ -1,10 +1,10 @@
-import { createAdSize } from 'core/ad-sizes';
 import {
 	isInAuOrNz as isInAuOrNz_,
 	isInRow as isInRow_,
 	isInUk as isInUk_,
 	isInUsOrCa as isInUsOrCa_,
 } from 'utils/geo-utils';
+import { createAdSize } from '../../../core/ad-sizes';
 import { getBreakpointKey as getBreakpointKey_ } from '../utils';
 import { getMagniteSiteId, getMagniteZoneId } from './magnite';
 

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -1,16 +1,16 @@
 import type { ConsentFramework } from '@guardian/libs';
 import { isString, log, onConsent } from '@guardian/libs';
 import { flatten } from 'lodash-es';
-import { pubmatic } from 'core/__vendor/pubmatic';
-import type { AdSize } from 'core/ad-sizes';
-import { createAdSize } from 'core/ad-sizes';
-import { PREBID_TIMEOUT } from 'core/constants/prebid-timeout';
-import { EventTimer } from 'core/event-timer';
-import type { PageTargeting } from 'core/targeting/build-page-targeting';
 import type { Advert } from 'define/Advert';
 import { getPageTargeting } from 'lib/build-page-targeting';
 import { getAdvertById } from 'lib/dfp/get-advert-by-id';
 import { isUserLoggedInOktaRefactor } from 'lib/identity/api';
+import { pubmatic } from '../../../core/__vendor/pubmatic';
+import type { AdSize } from '../../../core/ad-sizes';
+import { createAdSize } from '../../../core/ad-sizes';
+import { PREBID_TIMEOUT } from '../../../core/constants/prebid-timeout';
+import { EventTimer } from '../../../core/event-timer';
+import type { PageTargeting } from '../../../core/targeting/build-page-targeting';
 import type {
 	BidderCode,
 	HeaderBiddingSlot,

--- a/src/lib/header-bidding/prebid/price-config.ts
+++ b/src/lib/header-bidding/prebid/price-config.ts
@@ -1,4 +1,4 @@
-import { adSizes } from 'core/ad-sizes';
+import { adSizes } from '../../../core/ad-sizes';
 
 export type PrebidPriceGranularity = {
 	buckets: Array<{

--- a/src/lib/header-bidding/slot-config.spec.ts
+++ b/src/lib/header-bidding/slot-config.spec.ts
@@ -1,5 +1,5 @@
-import type { SizeMapping } from 'core/ad-sizes';
-import { adSizes, createAdSize } from 'core/ad-sizes';
+import type { SizeMapping } from '../../core/ad-sizes';
+import { adSizes, createAdSize } from '../../core/ad-sizes';
 import { Advert } from '../../define/Advert';
 import { getHeaderBiddingAdSlots } from './slot-config';
 import { getBreakpointKey, shouldIncludeMobileSticky } from './utils';

--- a/src/lib/header-bidding/slot-config.ts
+++ b/src/lib/header-bidding/slot-config.ts
@@ -1,7 +1,7 @@
-import type { AdSize } from 'core/ad-sizes';
-import { adSizes, createAdSize } from 'core/ad-sizes';
 import type { Advert } from 'define/Advert';
 import { isInUk } from 'utils/geo-utils';
+import type { AdSize } from '../../core/ad-sizes';
+import { adSizes, createAdSize } from '../../core/ad-sizes';
 import type {
 	HeaderBiddingSizeKey,
 	HeaderBiddingSizeMapping,

--- a/src/lib/header-bidding/utils.spec.ts
+++ b/src/lib/header-bidding/utils.spec.ts
@@ -1,5 +1,4 @@
 import type { CountryCode } from '@guardian/libs';
-import { createAdSize } from 'core/ad-sizes';
 import { isUserInVariant as isUserInVariant_ } from 'experiments/ab';
 import {
 	getCurrentTweakpoint as getCurrentTweakpoint_,
@@ -8,6 +7,7 @@ import {
 import type { SourceBreakpoint } from 'lib/detect/detect-breakpoint';
 import { _ } from 'utils/geo-utils';
 import { getCountryCode as getCountryCode_ } from 'utils/geolocation';
+import { createAdSize } from '../../core/ad-sizes';
 import {
 	getBreakpointKey,
 	getLargestSize,

--- a/src/lib/header-bidding/utils.ts
+++ b/src/lib/header-bidding/utils.ts
@@ -1,6 +1,5 @@
 import { isString } from '@guardian/libs';
 import { once } from 'lodash-es';
-import { createAdSize } from 'core/ad-sizes';
 import {
 	getCurrentTweakpoint,
 	matchesBreakpoints,
@@ -14,6 +13,7 @@ import {
 	isInUsOrCa,
 } from 'utils/geo-utils';
 import { pbTestNameMap } from 'utils/url';
+import { createAdSize } from '../../core/ad-sizes';
 import type { HeaderBiddingSize } from './prebid-types';
 
 type StringManipulation = (a: string, b: string) => string;

--- a/src/utils/googletag-ad-size.ts
+++ b/src/utils/googletag-ad-size.ts
@@ -1,4 +1,4 @@
-import type { AdSize } from 'core/ad-sizes';
+import type { AdSize } from '../core/ad-sizes';
 
 export const toGoogleTagSize = (size: AdSize): googletag.SingleSize => {
 	// not using width and height here as to maintain compatibility with plain arrays


### PR DESCRIPTION
## What does this change?
Adds an eslint rule to ban non-relative imports from core and replaces all instances with relative imports.

## Why?
We had [an issue where non relative imports were causing build failures](https://github.com/guardian/commercial/pull/1541#discussion_r1786255802), so moving to relative imports is sensible as our best practice.

There are a few folders we need to do this for - I'm going to split the changes into several separate PRs for my own sanity and to make reviewing (hopefully) easier. I felt like 74 files changed just from replacing imports of core was bulky enough for 1 PR without the other updates too!