### PR TITLE
Temporary downgrade to @guardian/prebid.js@8.52.0-6

### DIFF
--- a/.changeset/tender-wasps-worry.md
+++ b/.changeset/tender-wasps-worry.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Temporary downgrade to @guardian/prebid.js@8.52.0-6

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
 	},
 	"dependencies": {
 		"@changesets/cli": "^2.26.2",
-		"@guardian/prebid.js": "8.52.0-7",
+		"@guardian/prebid.js": "8.52.0-6",
 		"@octokit/core": "^6.1.2",
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^2.26.2
     version: 2.27.7
   '@guardian/prebid.js':
-    specifier: 8.52.0-7
-    version: 8.52.0-7(babel-core@7.0.0-bridge.0)(tslib@2.7.0)(typescript@5.5.3)
+    specifier: 8.52.0-6
+    version: 8.52.0-6(babel-core@7.0.0-bridge.0)(tslib@2.7.0)(typescript@5.5.3)
   '@octokit/core':
     specifier: ^6.1.2
     version: 6.1.2
@@ -1981,8 +1981,8 @@ packages:
       tslib: 2.7.0
       typescript: 5.5.3
 
-  /@guardian/prebid.js@8.52.0-7(babel-core@7.0.0-bridge.0)(tslib@2.7.0)(typescript@5.5.3):
-    resolution: {integrity: sha512-RWg8vyyfZccrqRXu5w+nnghsskYCHkLWQqXdFh1iSadYRU+exuNcynxStKdzUZdPNnh8aUyEuMIoaZXHmEZEYg==}
+  /@guardian/prebid.js@8.52.0-6(babel-core@7.0.0-bridge.0)(tslib@2.7.0)(typescript@5.5.3):
+    resolution: {integrity: sha512-YBsPkX5XxHSVNWw1PDX4c6WArH7e5FOomFM59QVIDuWNqrI2vyORvN7df2JukiDvCBxVggGUc1n77Lub2jstZw==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@babel/core': 7.25.2


### PR DESCRIPTION
## What does this change?

Temporary downgrade to @guardian/prebid.js@8.52.0-6 so we don't make requests to /hb while we put back the backend routes
