### PR TITLE
Ban non-relative imports from utils

### DIFF
--- a/.changeset/strong-tigers-return.md
+++ b/.changeset/strong-tigers-return.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Use relative imports when importing from utils

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
 			{
 				patterns: [
 					{
-						group: ['core/*'],
+						group: ['core/*', 'utils/*'],
 						message:
 							'Paths starting with “core”, are forbidden. Please use a relative path instead',
 					},

--- a/src/core/messenger/background.ts
+++ b/src/core/messenger/background.ts
@@ -1,9 +1,9 @@
 import { isObject } from '@guardian/libs';
-import fastdom from 'utils/fastdom-promise';
 import {
 	renderAdvertLabel,
 	renderStickyScrollForMoreLabel,
 } from '../../events/render-advert-label';
+import fastdom from '../../utils/fastdom-promise';
 import {
 	initVideoProgressReporting,
 	updateVideoProgress,

--- a/src/core/messenger/passback.ts
+++ b/src/core/messenger/passback.ts
@@ -2,8 +2,8 @@ import { log } from '@guardian/libs';
 import { breakpoints } from '@guardian/source/foundations';
 import { getCurrentBreakpoint } from 'lib/detect/detect-breakpoint';
 import { getAdvertById } from 'lib/dfp/get-advert-by-id';
-import fastdom from 'utils/fastdom-promise';
 import { adSlotIdPrefix } from '../../lib/dfp/dfp-env-globals';
+import fastdom from '../../utils/fastdom-promise';
 import { adSizes } from '../ad-sizes';
 import type { RegisterListener } from '../messenger';
 

--- a/src/core/messenger/resize.ts
+++ b/src/core/messenger/resize.ts
@@ -1,5 +1,5 @@
 import { isObject, isString } from '@guardian/libs';
-import fastdom from 'utils/fastdom-promise';
+import fastdom from '../../utils/fastdom-promise';
 import type { RegisterListener } from '../messenger';
 
 interface Styles {

--- a/src/core/messenger/scroll.spec.ts
+++ b/src/core/messenger/scroll.spec.ts
@@ -1,4 +1,4 @@
-import { noop } from 'utils/noop';
+import { noop } from '../../utils/noop';
 import { _ as testExports } from './scroll';
 
 const addScrollListener = testExports.addScrollListener;

--- a/src/core/messenger/scroll.ts
+++ b/src/core/messenger/scroll.ts
@@ -1,7 +1,7 @@
 import type { Viewport } from 'lib/detect/detect-viewport';
 import { getViewport } from 'lib/detect/detect-viewport';
 import { addEventListener } from 'lib/events';
-import fastdom from 'utils/fastdom-promise';
+import fastdom from '../../utils/fastdom-promise';
 import type { RegisterListener } from '../messenger';
 
 type Respond = (...args: unknown[]) => void;

--- a/src/core/messenger/type.ts
+++ b/src/core/messenger/type.ts
@@ -1,5 +1,5 @@
 import { isString } from '@guardian/libs';
-import fastdom from 'utils/fastdom-promise';
+import fastdom from '../../utils/fastdom-promise';
 import type { RegisterListener } from '../messenger';
 
 const setType = (adSlotType: string, adSlot: Element) =>

--- a/src/core/messenger/viewport.ts
+++ b/src/core/messenger/viewport.ts
@@ -1,6 +1,6 @@
 import { getViewport } from 'lib/detect/detect-viewport';
 import type { Viewport } from 'lib/detect/detect-viewport';
-import fastdom from 'utils/fastdom-promise';
+import fastdom from '../../utils/fastdom-promise';
 import type { RegisterPersistentListener, RespondProxy } from '../messenger';
 
 type IFrameMapValue = {

--- a/src/define/Advert.ts
+++ b/src/define/Advert.ts
@@ -1,5 +1,4 @@
 import { breakpoints as sourceBreakpoints } from '@guardian/source/foundations';
-import fastdom from 'utils/fastdom-promise';
 import {
 	createAdSize,
 	findAppliedSizesForBreakpoint,
@@ -10,6 +9,7 @@ import { concatSizeMappings } from '../core/create-ad-slot';
 import type { Breakpoint } from '../core/lib/breakpoint';
 import { breakpointNameToAttribute } from '../lib/breakpoint-name-to-attribute';
 import type { HeaderBiddingSize } from '../lib/header-bidding/prebid-types';
+import fastdom from '../utils/fastdom-promise';
 import { buildGoogletagSizeMapping, defineSlot } from './define-slot';
 
 const stringToTuple = (size: string): [number, number] => {

--- a/src/define/define-slot.spec.ts
+++ b/src/define/define-slot.spec.ts
@@ -1,6 +1,6 @@
-import { toGoogleTagSize } from 'utils/googletag-ad-size';
 import type { SizeMapping } from '../core/ad-sizes';
 import { adSizes, createAdSize } from '../core/ad-sizes';
+import { toGoogleTagSize } from '../utils/googletag-ad-size';
 import {
 	buildGoogletagSizeMapping,
 	collectSizes,

--- a/src/define/define-slot.ts
+++ b/src/define/define-slot.ts
@@ -1,9 +1,9 @@
 import { breakpoints as sourceBreakpoints } from '@guardian/source/foundations';
 import { once } from 'lodash-es';
 import { EventTimer } from 'core';
-import { toGoogleTagSize } from 'utils/googletag-ad-size';
-import { getUrlVars } from 'utils/url';
 import type { SizeMapping, SlotName } from '../core/ad-sizes';
+import { toGoogleTagSize } from '../utils/googletag-ad-size';
+import { getUrlVars } from '../utils/url';
 import { initSlotIas } from './init-slot-ias';
 
 const breakpointViewports: Record<keyof SizeMapping, [number, number]> = {

--- a/src/define/init-slot-ias.ts
+++ b/src/define/init-slot-ias.ts
@@ -1,6 +1,6 @@
 import { once } from 'lodash-es';
 import type { IasPETSlot, IasTargeting } from 'types/ias';
-import { getUrlVars } from 'utils/url';
+import { getUrlVars } from '../utils/url';
 
 const adUnit = once((): string => {
 	const urlVars = getUrlVars();

--- a/src/events/on-slot-viewable.ts
+++ b/src/events/on-slot-viewable.ts
@@ -1,7 +1,5 @@
 import { log } from '@guardian/libs';
 import { EventTimer } from 'core';
-import fastdom from 'utils/fastdom-promise';
-import { getUrlVars } from 'utils/url';
 import { outstreamSizes } from '../core/ad-sizes';
 import { AD_LABEL_HEIGHT } from '../core/constants/ad-label-height';
 import type { Advert } from '../define/Advert';
@@ -10,6 +8,8 @@ import { enableLazyLoad } from '../display/lazy-load';
 import { getAdvertById } from '../lib/dfp/get-advert-by-id';
 import { memoizedFetchNonRefreshableLineItemIds } from '../lib/dfp/non-refreshable-line-items';
 import { shouldRefresh } from '../lib/dfp/should-refresh';
+import fastdom from '../utils/fastdom-promise';
+import { getUrlVars } from '../utils/url';
 
 const ADVERT_REFRESH_RATE = 30_000; // 30 seconds. The minimum time allowed by Google.
 

--- a/src/events/render-advert-label.ts
+++ b/src/events/render-advert-label.ts
@@ -4,8 +4,8 @@
 -- "Promise returned in function argument where a void return was expected"
 */
 import { getCookie } from '@guardian/libs';
-import fastdom from 'utils/fastdom-promise';
 import crossIcon from '../../static/svg/icon/cross.svg';
+import fastdom from '../utils/fastdom-promise';
 
 const templatesWithoutLabels = [
 	10077207, // CAPI_MULTIPLE_HOSTED

--- a/src/events/render-advert.ts
+++ b/src/events/render-advert.ts
@@ -1,8 +1,8 @@
-import { $$ } from 'utils/$$';
-import fastdom from 'utils/fastdom-promise';
 import { adSizes } from '../core/ad-sizes';
 import type { Advert } from '../define/Advert';
 import { getAdIframe } from '../lib/dfp/get-ad-iframe';
+import { $$ } from '../utils/$$';
+import fastdom from '../utils/fastdom-promise';
 import { reportError } from '../utils/report-error';
 import { renderAdvertLabel } from './render-advert-label';
 

--- a/src/init/consented/prepare-a9.spec.ts
+++ b/src/init/consented/prepare-a9.spec.ts
@@ -1,6 +1,6 @@
 import { commercialFeatures } from 'lib/commercial-features';
-import { isInCanada } from 'utils/geo-utils';
 import { a9 } from '../../lib/header-bidding/a9/a9';
+import { isInCanada } from '../../utils/geo-utils';
 import { _ } from './prepare-a9';
 
 const { setupA9 } = _;

--- a/src/init/consented/prepare-a9.ts
+++ b/src/init/consented/prepare-a9.ts
@@ -2,10 +2,10 @@ import { getConsentFor, log, onConsent } from '@guardian/libs';
 import { once } from 'lodash-es';
 import { commercialFeatures } from 'lib/commercial-features';
 import { isGoogleProxy } from 'lib/detect/detect-google-proxy';
-import { isInCanada } from 'utils/geo-utils';
 import { a9Apstag } from '../../core/__vendor/a9-apstag';
 import { a9 } from '../../lib/header-bidding/a9/a9';
 import { shouldIncludeOnlyA9 } from '../../lib/header-bidding/utils';
+import { isInCanada } from '../../utils/geo-utils';
 
 const shouldLoadA9 = () =>
 	// There are two articles that InfoSec would like to avoid loading scripts on

--- a/src/init/consented/prepare-prebid.spec.ts
+++ b/src/init/consented/prepare-prebid.spec.ts
@@ -5,8 +5,8 @@ import type {
 } from '@guardian/libs';
 import { getConsentFor, log, onConsent } from '@guardian/libs';
 import { commercialFeatures } from 'lib/commercial-features';
-import { isInCanada } from 'utils/geo-utils';
 import { prebid } from '../../lib/header-bidding/prebid/prebid';
+import { isInCanada } from '../../utils/geo-utils';
 import { _ } from './prepare-prebid';
 
 const { setupPrebid } = _;

--- a/src/init/consented/prepare-prebid.ts
+++ b/src/init/consented/prepare-prebid.ts
@@ -3,9 +3,9 @@ import { getConsentFor, log, onConsent } from '@guardian/libs';
 import { once } from 'lodash-es';
 import { commercialFeatures } from 'lib/commercial-features';
 import { isGoogleProxy } from 'lib/detect/detect-google-proxy';
-import { isInCanada } from 'utils/geo-utils';
 import { prebid } from '../../lib/header-bidding/prebid/prebid';
 import { shouldIncludeOnlyA9 } from '../../lib/header-bidding/utils';
+import { isInCanada } from '../../utils/geo-utils';
 
 const shouldLoadPrebid = () =>
 	!isGoogleProxy() &&

--- a/src/init/consented/static-ad-slots.ts
+++ b/src/init/consented/static-ad-slots.ts
@@ -5,7 +5,6 @@ import { setupPrebidOnce } from 'init/consented/prepare-prebid';
 import { removeDisabledSlots } from 'init/consented/remove-slots';
 import { commercialFeatures } from 'lib/commercial-features';
 import { getCurrentBreakpoint } from 'lib/detect/detect-breakpoint';
-import { isInUk, isInUsa } from 'utils/geo-utils';
 import { adSizes, createAdSize } from '../../core/ad-sizes';
 import type { SizeMapping } from '../../core/ad-sizes';
 import { createAdvert } from '../../define/create-advert';
@@ -13,6 +12,7 @@ import { displayAds } from '../../display/display-ads';
 import { displayLazyAds } from '../../display/display-lazy-ads';
 import { dfpEnv } from '../../lib/dfp/dfp-env';
 import { queueAdvert } from '../../lib/dfp/queue-advert';
+import { isInUk, isInUsa } from '../../utils/geo-utils';
 
 const decideAdditionalSizes = (adSlot: HTMLElement): SizeMapping => {
 	const { contentType } = window.guardian.config.page;

--- a/src/init/consentless/dynamic/exclusion-slot.ts
+++ b/src/init/consentless/dynamic/exclusion-slot.ts
@@ -1,5 +1,5 @@
-import fastdom from 'utils/fastdom-promise';
 import { createAdSlot } from '../../../core/create-ad-slot';
+import fastdom from '../../../utils/fastdom-promise';
 import { defineSlot } from '../define-slot';
 
 /**

--- a/src/init/consentless/render-advert-label.ts
+++ b/src/init/consentless/render-advert-label.ts
@@ -3,7 +3,7 @@
 -- Nested fastdom measure-mutate promises throw the error:
 -- "Promise returned in function argument where a void return was expected"
 */
-import fastdom from 'utils/fastdom-promise';
+import fastdom from '../../utils/fastdom-promise';
 
 const shouldRenderConsentlessLabel = (adSlotNode: HTMLElement): boolean => {
 	if (

--- a/src/insert/article-aside-adverts.ts
+++ b/src/insert/article-aside-adverts.ts
@@ -1,5 +1,5 @@
-import { $$ } from 'utils/$$';
-import fastdom from 'utils/fastdom-promise';
+import { $$ } from '../utils/$$';
+import fastdom from '../utils/fastdom-promise';
 
 const minArticleHeight = 1300;
 

--- a/src/insert/spacefinder/liveblog-adverts.ts
+++ b/src/insert/spacefinder/liveblog-adverts.ts
@@ -9,9 +9,9 @@ import type {
 } from 'insert/spacefinder/spacefinder';
 import { commercialFeatures } from 'lib/commercial-features';
 import { getCurrentBreakpoint } from 'lib/detect/detect-breakpoint';
-import fastdom from 'utils/fastdom-promise';
 import { adSizes } from '../../core/ad-sizes';
 import { createAdSlot } from '../../core/create-ad-slot';
+import fastdom from '../../utils/fastdom-promise';
 
 /**
  * Maximum number of inline ads to display on the page

--- a/src/insert/spacefinder/spacefinder.ts
+++ b/src/insert/spacefinder/spacefinder.ts
@@ -2,8 +2,8 @@
 
 import { log } from '@guardian/libs';
 import { memoize } from 'lodash-es';
-import fastdom from 'utils/fastdom-promise';
-import { getUrlVars } from 'utils/url';
+import fastdom from '../../utils/fastdom-promise';
+import { getUrlVars } from '../../utils/url';
 
 type RuleSpacing = {
 	/**

--- a/src/insert/sticky-inlines.ts
+++ b/src/insert/sticky-inlines.ts
@@ -1,6 +1,6 @@
 import { isUndefined } from '@guardian/libs';
 import { breakpoints } from '@guardian/source/foundations';
-import fastdom from 'utils/fastdom-promise';
+import fastdom from '../utils/fastdom-promise';
 
 /**
  * Represents an element that has some presence in the right column that we need to account for

--- a/src/lib/dfp/dfp-env.spec.ts
+++ b/src/lib/dfp/dfp-env.spec.ts
@@ -1,5 +1,5 @@
 import { getCurrentBreakpoint as getCurrentBreakpoint_ } from 'lib/detect/detect-breakpoint';
-import { getUrlVars as getUrlVars_ } from 'utils/url';
+import { getUrlVars as getUrlVars_ } from '../../utils/url';
 import { dfpEnv } from './dfp-env';
 
 const getCurrentBreakpoint = getCurrentBreakpoint_ as jest.MockedFunction<

--- a/src/lib/dfp/dfp-env.ts
+++ b/src/lib/dfp/dfp-env.ts
@@ -1,6 +1,6 @@
 import { getCurrentBreakpoint } from 'lib/detect/detect-breakpoint';
-import { getUrlVars as _getUrlVars } from 'utils/url';
 import type { Advert } from '../../define/Advert';
+import { getUrlVars as _getUrlVars } from '../../utils/url';
 
 const getUrlVars = _getUrlVars as (arg?: string) => Record<string, string>;
 

--- a/src/lib/header-bidding/a9/a9.ts
+++ b/src/lib/header-bidding/a9/a9.ts
@@ -1,7 +1,7 @@
 import { flatten } from 'lodash-es';
 import type { Advert } from 'define/Advert';
 import type { A9AdUnitInterface } from 'types/global';
-import { noop } from 'utils/noop';
+import { noop } from '../../../utils/noop';
 import type { HeaderBiddingSlot, SlotFlatMap } from '../prebid-types';
 import { getHeaderBiddingAdSlots } from '../slot-config';
 

--- a/src/lib/header-bidding/prebid/appnexus.spec.ts
+++ b/src/lib/header-bidding/prebid/appnexus.spec.ts
@@ -1,10 +1,10 @@
+import { createAdSize } from '../../../core/ad-sizes';
 import {
 	isInAuOrNz as isInAuOrNz_,
 	isInRow as isInRow_,
 	isInUk as isInUk_,
 	isInUsa as isInUsa_,
-} from 'utils/geo-utils';
-import { createAdSize } from '../../../core/ad-sizes';
+} from '../../../utils/geo-utils';
 import {
 	containsBillboard as containsBillboard_,
 	containsBillboardNotLeaderboard as containsBillboardNotLeaderboard_,

--- a/src/lib/header-bidding/prebid/appnexus.ts
+++ b/src/lib/header-bidding/prebid/appnexus.ts
@@ -1,6 +1,6 @@
 import { buildAppNexusTargetingObject } from 'lib/build-page-targeting';
-import { isInAuOrNz, isInRow } from 'utils/geo-utils';
 import type { PageTargeting } from '../../../core/targeting/build-page-targeting';
+import { isInAuOrNz, isInRow } from '../../../utils/geo-utils';
 import type { HeaderBiddingSize } from '../prebid-types';
 import {
 	containsBillboardNotLeaderboard,

--- a/src/lib/header-bidding/prebid/bid-config.spec.ts
+++ b/src/lib/header-bidding/prebid/bid-config.spec.ts
@@ -1,14 +1,14 @@
 import { isUserInVariant as isUserInVariant_ } from 'experiments/ab';
 import config from 'lib/config';
+import { createAdSize } from '../../../core/ad-sizes';
+import type { PageTargeting } from '../../../core/targeting/build-page-targeting';
 import {
 	isInAuOrNz as isInAuOrNz_,
 	isInRow as isInRow_,
 	isInUk as isInUk_,
 	isInUsa as isInUsa_,
 	isInUsOrCa as isInUsOrCa_,
-} from 'utils/geo-utils';
-import { createAdSize } from '../../../core/ad-sizes';
-import type { PageTargeting } from '../../../core/targeting/build-page-targeting';
+} from '../../../utils/geo-utils';
 import type { HeaderBiddingSize, PrebidBidder } from '../prebid-types';
 import {
 	containsBillboard as containsBillboard_,

--- a/src/lib/header-bidding/prebid/bid-config.ts
+++ b/src/lib/header-bidding/prebid/bid-config.ts
@@ -5,15 +5,15 @@ import {
 } from 'lib/build-page-targeting';
 import { dfpEnv } from 'lib/dfp/dfp-env';
 import type { PrebidIndexSite } from 'types/global';
+import type { PageTargeting } from '../../../core/targeting/build-page-targeting';
 import {
 	isInAuOrNz,
 	isInRow,
 	isInUk,
 	isInUsa,
 	isInUsOrCa,
-} from 'utils/geo-utils';
-import { pbTestNameMap } from 'utils/url';
-import type { PageTargeting } from '../../../core/targeting/build-page-targeting';
+} from '../../../utils/geo-utils';
+import { pbTestNameMap } from '../../../utils/url';
 import type {
 	BidderCode,
 	HeaderBiddingSize,

--- a/src/lib/header-bidding/prebid/improve-digital.spec.ts
+++ b/src/lib/header-bidding/prebid/improve-digital.spec.ts
@@ -1,10 +1,10 @@
+import { createAdSize } from '../../../core/ad-sizes';
 import {
 	isInAuOrNz as isInAuOrNz_,
 	isInRow as isInRow_,
 	isInUk as isInUk_,
 	isInUsOrCa as isInUsOrCa_,
-} from 'utils/geo-utils';
-import { createAdSize } from '../../../core/ad-sizes';
+} from '../../../utils/geo-utils';
 import { getBreakpointKey as getBreakpointKey_ } from '../utils';
 import {
 	getImprovePlacementId,

--- a/src/lib/header-bidding/prebid/improve-digital.ts
+++ b/src/lib/header-bidding/prebid/improve-digital.ts
@@ -1,4 +1,4 @@
-import { isInRow, isInUk } from 'utils/geo-utils';
+import { isInRow, isInUk } from '../../../utils/geo-utils';
 import type { HeaderBiddingSize } from '../prebid-types';
 import {
 	containsBillboardNotLeaderboard,

--- a/src/lib/header-bidding/prebid/magnite.spec.ts
+++ b/src/lib/header-bidding/prebid/magnite.spec.ts
@@ -1,10 +1,10 @@
+import { createAdSize } from '../../../core/ad-sizes';
 import {
 	isInAuOrNz as isInAuOrNz_,
 	isInRow as isInRow_,
 	isInUk as isInUk_,
 	isInUsOrCa as isInUsOrCa_,
-} from 'utils/geo-utils';
-import { createAdSize } from '../../../core/ad-sizes';
+} from '../../../utils/geo-utils';
 import { getBreakpointKey as getBreakpointKey_ } from '../utils';
 import { getMagniteSiteId, getMagniteZoneId } from './magnite';
 

--- a/src/lib/header-bidding/prebid/magnite.ts
+++ b/src/lib/header-bidding/prebid/magnite.ts
@@ -1,4 +1,9 @@
-import { isInAuOrNz, isInRow, isInUk, isInUsOrCa } from 'utils/geo-utils';
+import {
+	isInAuOrNz,
+	isInRow,
+	isInUk,
+	isInUsOrCa,
+} from '../../../utils/geo-utils';
 import type { HeaderBiddingSize } from '../prebid-types';
 import {
 	containsBillboard,

--- a/src/lib/header-bidding/slot-config.ts
+++ b/src/lib/header-bidding/slot-config.ts
@@ -1,7 +1,7 @@
 import type { Advert } from 'define/Advert';
-import { isInUk } from 'utils/geo-utils';
 import type { AdSize } from '../../core/ad-sizes';
 import { adSizes, createAdSize } from '../../core/ad-sizes';
+import { isInUk } from '../../utils/geo-utils';
 import type {
 	HeaderBiddingSizeKey,
 	HeaderBiddingSizeMapping,

--- a/src/lib/header-bidding/utils.spec.ts
+++ b/src/lib/header-bidding/utils.spec.ts
@@ -5,9 +5,9 @@ import {
 	matchesBreakpoints as matchesBreakpoints_,
 } from 'lib/detect/detect-breakpoint';
 import type { SourceBreakpoint } from 'lib/detect/detect-breakpoint';
-import { _ } from 'utils/geo-utils';
-import { getCountryCode as getCountryCode_ } from 'utils/geolocation';
 import { createAdSize } from '../../core/ad-sizes';
+import { _ } from '../../utils/geo-utils';
+import { getCountryCode as getCountryCode_ } from '../../utils/geolocation';
 import {
 	getBreakpointKey,
 	getLargestSize,

--- a/src/lib/header-bidding/utils.ts
+++ b/src/lib/header-bidding/utils.ts
@@ -4,6 +4,7 @@ import {
 	getCurrentTweakpoint,
 	matchesBreakpoints,
 } from 'lib/detect/detect-breakpoint';
+import { createAdSize } from '../../core/ad-sizes';
 import {
 	isInAuOrNz,
 	isInCanada,
@@ -11,9 +12,8 @@ import {
 	isInUk,
 	isInUsa,
 	isInUsOrCa,
-} from 'utils/geo-utils';
-import { pbTestNameMap } from 'utils/url';
-import { createAdSize } from '../../core/ad-sizes';
+} from '../../utils/geo-utils';
+import { pbTestNameMap } from '../../utils/url';
 import type { HeaderBiddingSize } from './prebid-types';
 
 type StringManipulation = (a: string, b: string) => string;

--- a/src/lib/third-party-tags/imr-worldwide-legacy.ts
+++ b/src/lib/third-party-tags/imr-worldwide-legacy.ts
@@ -1,4 +1,4 @@
-import { isInAuOrNz } from 'utils/geo-utils';
+import { isInAuOrNz } from '../../utils/geo-utils';
 
 // nol_t is a global function defined by the IMR worldwide library
 

--- a/src/lib/third-party-tags/imr-worldwide.ts
+++ b/src/lib/third-party-tags/imr-worldwide.ts
@@ -1,4 +1,4 @@
-import { isInAuOrNz } from 'utils/geo-utils';
+import { isInAuOrNz } from '../../utils/geo-utils';
 
 // NOLCMB is a global function defined by the IMR worldwide library
 

--- a/src/utils/geo-utils.spec.ts
+++ b/src/utils/geo-utils.spec.ts
@@ -9,7 +9,7 @@ import {
 	isInUk,
 	isInUsa,
 	isInUsOrCa,
-} from 'utils/geo-utils';
+} from './geo-utils';
 
 let mockCountryCode: CountryCode;
 jest.mock('utils/geolocation', () => ({

--- a/src/utils/geo-utils.ts
+++ b/src/utils/geo-utils.ts
@@ -1,5 +1,5 @@
 import type { CountryCode } from '@guardian/libs';
-import { getCountryCode } from 'utils/geolocation';
+import { getCountryCode } from './geolocation';
 
 // cache the users location so we only have to look it up once
 let geo: CountryCode | undefined;

--- a/src/utils/support-utilities.spec.ts
+++ b/src/utils/support-utilities.spec.ts
@@ -1,5 +1,5 @@
 import { removeCookie, setCookie } from '@guardian/libs';
-import { _ } from 'utils/geolocation';
+import { _ } from './geolocation';
 import { addCountryGroupToSupportLink } from './support-utilities';
 
 const { countryCookieName } = _;

--- a/src/utils/support-utilities.ts
+++ b/src/utils/support-utilities.ts
@@ -1,7 +1,7 @@
 import {
 	countryCodeToSupportInternationalisationId,
 	getCountryCode,
-} from 'utils/geolocation';
+} from './geolocation';
 
 const supportUrlRegex = /(support.theguardian.com)\/(contribute|subscribe)/;
 

--- a/src/utils/time-utils.spec.ts
+++ b/src/utils/time-utils.spec.ts
@@ -1,5 +1,5 @@
 import MockDate from 'mockdate';
-import { dateDiffDays, isExpired } from 'utils/time-utils';
+import { dateDiffDays, isExpired } from './time-utils';
 
 describe('calculating the difference between 2 dates', () => {
 	it('should return the correct duration', () => {


### PR DESCRIPTION
## What does this change?
Adds an eslint rule to ban non-relative imports from utils, and updates all imports to comply.

## Why?
Non-relative imports can cause issues with builds when being used in frontend.