### PR TITLE
Don't add label when NOLABEL tag is present

### DIFF
--- a/.changeset/nervous-planes-attend.md
+++ b/.changeset/nervous-planes-attend.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Don't add labels to opt out ads with the NOLABEL tag

--- a/src/init/consentless/define-slot.ts
+++ b/src/init/consentless/define-slot.ts
@@ -39,8 +39,8 @@ const defineSlot = (
 			slot.classList.add('ad-slot--native');
 		}
 
-		if (optOutExt.tags.includes('HOSTEDBY')) {
-			slot.classList.add('ad-slot--hostedby');
+		if (optOutExt.tags.includes('NOLABEL')) {
+			slot.classList.add('ad-slot--no-label');
 		}
 
 		void renderConsentlessAdvertLabel(slot);

--- a/src/init/consentless/render-advert-label.ts
+++ b/src/init/consentless/render-advert-label.ts
@@ -10,7 +10,7 @@ const shouldRenderConsentlessLabel = (adSlotNode: HTMLElement): boolean => {
 		adSlotNode.classList.contains('ad-slot--frame') ||
 		adSlotNode.classList.contains('ad-slot--gc') ||
 		adSlotNode.classList.contains('u-h') ||
-		adSlotNode.classList.contains('ad-slot--hostedby') ||
+		adSlotNode.classList.contains('ad-slot--no-label') ||
 		// set for out-of-page (1x1) and empty (2x2) ads
 		adSlotNode.classList.contains('ad-slot--collapse') ||
 		adSlotNode.getAttribute('data-label') === 'false'


### PR DESCRIPTION
## What does this change?
Move to using a generic 'NOLABEL' tag that can be added to opt out templates that we don't want an ad label added to.

## Why?
The previous approach of adding a template specific label was unsustainable and would have meant a code change for every new template we add to opt out.

### Before
<img width="1324" alt="Screenshot 2024-10-15 at 13 07 23" src="https://github.com/user-attachments/assets/487171b4-4b73-4518-bab2-9f60dc3f5abd">


### After

<img width="1341" alt="Screenshot 2024-10-15 at 13 07 04" src="https://github.com/user-attachments/assets/07fc1cde-4d21-4366-b7c4-17c48d71cb21">

