### PR TITLE
Respect permutive switch for `prepare-permutive`

### DIFF
--- a/.changeset/angry-boats-relax.md
+++ b/.changeset/angry-boats-relax.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Respect permutive switch for prepare-permutive

--- a/src/init/consented/prepare-permutive.ts
+++ b/src/init/consented/prepare-permutive.ts
@@ -165,7 +165,7 @@ const runPermutive = (
  * https://permutive.com/audience-platform/publishers/
  * @returns Promise
  */
-export const initPermutive = (): Promise<void> => {
+const initPermutiveSegmentation = () => {
 	/* eslint-disable -- permutive code */
 	// From here until we re-enable eslint is the Permutive code
 	// that we received from them.
@@ -237,7 +237,12 @@ export const initPermutive = (): Promise<void> => {
 		ophan: window.guardian.config.ophan,
 	};
 	runPermutive(permutiveConfig, window.permutive);
+};
 
+export const initPermutive = () => {
+	if (window.guardian.config.switches.permutive) {
+		void initPermutiveSegmentation();
+	}
 	return Promise.resolve();
 };
 


### PR DESCRIPTION
## What does this change?

Respect permutive switch for `prepare-permutive`

## Why?

We respect the switch for loading the [permutive script](https://github.com/guardian/commercial/blob/cc2714570fa248ac298aa3875dd8e5116188585a/src/init/consented/third-party-tags.ts#L85-L87) but but not for initialising permutive segments.

This change adds a check of the permutive switch for initialisation of permutive segments.
