### PR TITLE
Add description_url to IMA ad requests

### DIFF
--- a/.changeset/modern-brooms-yawn.md
+++ b/.changeset/modern-brooms-yawn.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Add description_url to youtube ima requests

--- a/src/core/targeting/youtube-ima.spec.ts
+++ b/src/core/targeting/youtube-ima.spec.ts
@@ -16,6 +16,14 @@ const emptyConsent: ConsentState = {
 };
 
 describe('Builds an IMA ad tag URL', () => {
+	window.guardian = {
+		config: {
+			page: {
+				pageId: 'sport/video/2024/oct/10/tennis-rafael-nadal-announces-retirement',
+			},
+		},
+	} as typeof window.guardian;
+
 	it('default values and empty custom parameters', () => {
 		(buildPageTargeting as jest.Mock).mockReturnValue({
 			at: 'adTestValue',
@@ -28,7 +36,7 @@ describe('Builds an IMA ad tag URL', () => {
 			isSignedIn: true,
 		});
 		expect(adTagURL).toEqual(
-			'https://securepubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=at%3DadTestValue',
+			'https://securepubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&description_url=https%3A%2F%2Fwww.theguardian.com%2Fsport%2Fvideo%2F2024%2Foct%2F10%2Ftennis-rafael-nadal-announces-retirement&cust_params=at%3DadTestValue',
 		);
 	});
 	it('encodes custom parameters', () => {
@@ -53,7 +61,7 @@ describe('Builds an IMA ad tag URL', () => {
 		expect(adTagURL).toEqual(
 			// this is a real ad tag url that you can paste into Google's VAST tag checker:
 			// https://googleads.github.io/googleads-ima-html5/vsi/
-			'https://securepubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%252Chello4%26param6%3D%253D%2526%252C%26at%3Dfixed-puppies%26encodeMe%3D%253D%2526%252C',
+			'https://securepubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&description_url=https%3A%2F%2Fwww.theguardian.com%2Fsport%2Fvideo%2F2024%2Foct%2F10%2Ftennis-rafael-nadal-announces-retirement&cust_params=param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%252Chello4%26param6%3D%253D%2526%252C%26at%3Dfixed-puppies%26encodeMe%3D%253D%2526%252C',
 		);
 	});
 	it('uses provided custom parameters if page targeting throws an exception', () => {
@@ -70,7 +78,7 @@ describe('Builds an IMA ad tag URL', () => {
 			isSignedIn: true,
 		});
 		expect(adTagURL).toEqual(
-			'https://securepubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&cust_params=param1%3Dhello1',
+			'https://securepubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&description_url=https%3A%2F%2Fwww.theguardian.com%2Fsport%2Fvideo%2F2024%2Foct%2F10%2Ftennis-rafael-nadal-announces-retirement&cust_params=param1%3Dhello1',
 		);
 	});
 });

--- a/src/core/targeting/youtube-ima.spec.ts
+++ b/src/core/targeting/youtube-ima.spec.ts
@@ -19,6 +19,7 @@ describe('Builds an IMA ad tag URL', () => {
 	window.guardian = {
 		config: {
 			page: {
+				host: 'https://www.theguardian.com',
 				pageId: 'sport/video/2024/oct/10/tennis-rafael-nadal-announces-retirement',
 			},
 		},

--- a/src/core/targeting/youtube-ima.ts
+++ b/src/core/targeting/youtube-ima.ts
@@ -85,6 +85,9 @@ const buildImaAdTagUrl = ({
 		impl: 's',
 		vad_type: 'linear',
 		vpos: 'preroll',
+		description_url: encodeURIComponent(
+			`https://www.theguardian.com/${window.guardian.config.page.pageId}`,
+		),
 		/**
 		 * cust_params string is encoded
 		 * cust_params values are also encoded so they will get double encoded

--- a/src/core/targeting/youtube-ima.ts
+++ b/src/core/targeting/youtube-ima.ts
@@ -86,7 +86,7 @@ const buildImaAdTagUrl = ({
 		vad_type: 'linear',
 		vpos: 'preroll',
 		description_url: encodeURIComponent(
-			`https://www.theguardian.com/${window.guardian.config.page.pageId}`,
+			`${window.guardian.config.page.host}/${window.guardian.config.page.pageId}`,
 		),
 		/**
 		 * cust_params string is encoded


### PR DESCRIPTION
## What does this change?
Adds the article URL to the youtube IMA ad request, by adding the description_url parameter. It seems pretty common practice from what I've read online to use the URL of the page that the video is loading on as the description url. Also updates tests to make sure the request URL is constructed as expected.

## Why?
This is used to determine if the domain is eligible for ads to serve. See [here](https://support.google.com/admanager/answer/1734048?hl=en#:~:text=video%20ad%20inventory.-,The%20description%20URL,-For%20Ad%20Exchange) for more info.

## Testing

I've tested on CODE, and we get ads loading before the video as expected:

<img width="802" alt="Screenshot 2024-10-24 at 16 25 05" src="https://github.com/user-attachments/assets/ca4efb90-ab9a-4951-aa7b-ee7d80774bf7">

And we can see description_url getting added to the payload:

<img width="483" alt="Screenshot 2024-10-24 at 16 18 26" src="https://github.com/user-attachments/assets/31cdcbf0-3571-4df2-8eb6-74b0da2339ae">

