### PR TITLE
Add comment to explain what prebidPermutiveAudience switch is for

### DIFF
--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -331,7 +331,7 @@ const initialise = (
 
 	if (
 		window.guardian.config.switches.permutive &&
-		window.guardian.config.switches.prebidPermutiveAudience
+		window.guardian.config.switches.prebidPermutiveAudience // this switch specifically controls whether or not the Permutive Audience Connector can run with Prebid
 	) {
 		pbjsConfig.realTimeData = {
 			dataProviders: [


### PR DESCRIPTION
## What does this change?
Adds a comment to describe what the prebidPermutiveAudience switch is used for.

## Why?
It wasn't immediately clear looking at the code what the difference between the permutive switches was - hopefully this makes things clearer in the future.