### PR TITLE
add sticky banner to interactive articles

### DIFF
--- a/.changeset/empty-ghosts-film.md
+++ b/.changeset/empty-ghosts-film.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+add mobile banner to interactives

--- a/src/lib/header-bidding/utils.ts
+++ b/src/lib/header-bidding/utils.ts
@@ -42,7 +42,11 @@ const contains = (
 
 const isValidPageForMobileSticky = (): boolean => {
 	const { contentType, pageId } = window.guardian.config.page;
-	return contentType === 'Article' || pageId.startsWith('football/');
+	return (
+		contentType === 'Article' ||
+		contentType === 'Interactive' ||
+		pageId.startsWith('football/')
+	);
 };
 
 /**


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
This adds logic to the mobile-sticky banner to appear on Interactives outside of the UK
## Why?
As part of the process to allow for mobile sticky ad banners to be available in Interactives as well as Articles


## Testing
https://www.theguardian.com/us-news/ng-interactive/2024/oct/30/election-harris-trump-myths-lies-fact-checkfalse-claims-include-that-noncitizens-are-voting-in-broad-numbers-and-attacks-on-the-voting-and-counting-process

Having set VPN to AUS/US vs Uk to see the difference.

To ensure loading of mobile sticky in testing you can use `?adtest=mobile_sticky_test`


https://github.com/user-attachments/assets/0a6c6491-60aa-4ffc-9a4c-2838e5bd4cf6

