### PR TITLE
Don't define static top-above-nav on consentless mobile DCR

### DIFF
--- a/.changeset/eight-tools-press.md
+++ b/.changeset/eight-tools-press.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Filter out static top-above-nav on consentless mobile

--- a/src/init/consentless/init-fixed-slots.ts
+++ b/src/init/consentless/init-fixed-slots.ts
@@ -1,14 +1,24 @@
+import { getCurrentBreakpoint } from '../../lib/detect/detect-breakpoint';
 import { removeDisabledSlots } from '../consented/remove-slots';
 import { defineSlot } from './define-slot';
 
 const initFixedSlots = async (): Promise<void> => {
 	await removeDisabledSlots();
 
+	const isDCRMobile =
+		window.guardian.config.isDotcomRendering &&
+		getCurrentBreakpoint() === 'mobile';
+
 	const adverts = [
 		...document.querySelectorAll<HTMLElement>(
 			'.js-ad-slot:not(.ad-slot--survey)',
 		),
-	];
+	]
+		// we need to not init top-above-nav on mobile view in DCR
+		// as the DOM element needs to be removed and replaced to be inline
+		.filter(
+			(adSlot) => !(isDCRMobile && adSlot.id === 'dfp-ad--top-above-nav'),
+		);
 
 	// define slots
 	adverts.forEach((slotElement) => {


### PR DESCRIPTION
## What does this change?
Filter out the static top-above-nav slot on mobile DCR when defining consentless fixed slots.

## Why?
At the moment, two top-above-nav slots get defined - the static one, and the dynamically inserted mobile top-above-nav. The styling and ad label logic is currently being applied to the static slot, not the dynamic one, causing display issues. Filtering out the static slot so that we don't have duplicate definitions mirrors the logic for consented ads, and makes sure the label and extra classes are applied as expected.

## Before
### MPU
<img width="319" alt="Screenshot 2024-10-31 at 15 45 08" src="https://github.com/user-attachments/assets/c7d63df0-91c9-41e6-a339-5181f5451790">


### Fabric
<img width="317" alt="Screenshot 2024-10-31 at 15 40 25" src="https://github.com/user-attachments/assets/3cb0a266-9475-4854-823f-e4c49b54e565">

## After
### MPU
<img width="321" alt="Screenshot 2024-10-31 at 15 45 44" src="https://github.com/user-attachments/assets/65b2b72e-3716-4cbb-9bdf-209bd680b0d3">


### Fabric
<img width="326" alt="Screenshot 2024-10-31 at 15 39 29" src="https://github.com/user-attachments/assets/856bf955-d3df-4e03-b969-c3e834314bc4">
