### PR TITLE
adds gpt pre auction module to prebid

### DIFF
--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -354,6 +354,48 @@ const initialise = (
 		};
 	}
 
+	// Custom PreAuction logiccustomPreAuction
+	window.pbjs.setConfig({
+		gptPreAuction: {
+			enabled: true,
+			useDefaultPreAuction: false,
+			customPreAuction: function (adUnit, adServerAdSlot, adUnits) {
+				const sectionName = adUnit.section || 'default-section';
+				const contentType = adUnit.contentType || 'default-content';
+				const slotName = adUnit.slotName || 'default-slot';
+				adUnits.forEach(
+					(adUnit) =>
+						(adUnit.gpid = `/59666047/gu/${sectionName}/${contentType}/${slotName}`),
+				);
+				const gpid = `/59666047/gu/${sectionName}/${contentType}/${slotName}`;
+				adUnit.gpid = gpid;
+				return gpid;
+			},
+			customPbAdSlot: function (adUnitCode, adServerAdSlot) {
+				const matchingAdUnits = window.pbjs.adUnits.filter(
+					(au) => au.code === adUnitCode,
+				);
+				if (matchingAdUnits.length === 0) return;
+
+				if (matchingAdUnits[0].ortb2Imp?.ext?.data?.pbadslot) {
+					return matchingAdUnits[0].ortb2Imp.ext.data.pbadslot;
+				}
+
+				if (!(googletag && googletag.apiReady)) return;
+
+				const gptSlots = googletag
+					.pubads()
+					.getSlots()
+					.filter((slot) => slot.getAdUnitPath() === adServerAdSlot);
+				if (gptSlots.length === 1) {
+					return adServerAdSlot;
+				}
+
+				return `${adServerAdSlot}#${adUnitCode}`;
+			},
+		},
+	});
+
 	if (window.guardian.config.switches.prebidCriteo) {
 		window.pbjs.bidderSettings.criteo = {
 			storageAllowed: true,

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -63,6 +63,9 @@ const config = {
 			failOnError: true,
 		}),
 	],
+	externals: {
+		'prebid.js/modules/gptPreAuction': 'gptPreAuction',
+	},
 };
 
 // eslint-disable-next-line import/no-default-export -- webpack config


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
The GPID is being added to enable the successful sending of GPID to prebid vendors. This implementation uses the `[GPT Pre-Auction module](https://docs.prebid.org/dev-docs/modules/gpt-pre-auction.html)`, as recommended by the [Prebid Docs](https://docs.prebid.org/features/pbAdSlot.html) if your project is using GAM/GPT.

## Why?
We are adding the GPID to prebid as part of the OpenRTB framework, there isa field in the `impressionExtension` object called `imp.ext.gpid`. This will allow uis to conform to the protocol by sending a standardised GPID across all SPP's.
The Guardian’s ad server (GAM) to Prebid needs to follow certain standards to ensure that Prebid can interpret the information correctly and that all exchanges involved in the auction can handle and propagate it.