### PR TITLE
Fix code scanning alert no. 1: Incomplete regular expression for hostnames

### DIFF
--- a/playwright/lib/gam.ts
+++ b/playwright/lib/gam.ts
@@ -1,6 +1,6 @@
 import type { Page, Request, Response } from '@playwright/test';
 
-const gamUrl = /https:\/\/securepubads.g.doubleclick.net\/gampad\/ads/;
+const gamUrl = /https:\/\/securepubads\.g\.doubleclick\.net\/gampad\/ads/;
 
 const getEncodedParamsFromRequest = (
 	request: Request,


### PR DESCRIPTION
Fixes [https://github.com/guardian/commercial/security/code-scanning/1](https://github.com/guardian/commercial/security/code-scanning/1)

To fix the problem, we need to escape the `.` character in the regular expression to ensure that it matches only the intended host (`securepubads.g.doubleclick.net`). This can be done by replacing the `.` with `\.` in the regular expression. This change will prevent the regular expression from matching unintended hosts and ensure that it only matches the exact host specified.

The specific change required is in the file `playwright/lib/gam.ts` on line 3. We need to update the regular expression to escape the `.` character before `doubleclick.net`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
