### PR TITLE
Stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+name: 'Stale PR Handler'
+
+on:
+  schedule:
+    # Every morning at 1AM, Mondays to Fridays
+    - cron: '0 1 * * MON-FRI'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        id: stale
+        # Read about options here: https://github.com/actions/stale#all-options
+        with:
+          # never automatically mark issues as stale
+          days-before-issue-stale: -1
+          days-before-stale: 30
+          stale-pr-message: >
+            "This PR is stale because it has been open 30 days with no activity.
+            Unless a comment is added or the “stale” label removed, this will be closed in 3 days"
+          days-before-close: 3
+          close-pr-message: 'This PR was closed because it has been stalled for 3 days with no activity.'
+          delete-branch: true
+          exempt-pr-labels: 'dependencies'


### PR DESCRIPTION
## What does this change?

Adds a workflow to mark PRs as stale after 30 days of inactivity

## Why?

Less noise
