### PR TITLE
Setup test for new prebid analytics endpoint

### DIFF
--- a/.changeset/rare-pants-jump.md
+++ b/.changeset/rare-pants-jump.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Setup test for new prebid analytics endpoint

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
 	},
 	"dependencies": {
 		"@changesets/cli": "^2.26.2",
-		"@guardian/prebid.js": "8.52.0-7",
+		"@guardian/prebid.js": "8.52.0-8",
 		"@octokit/core": "^6.1.2",
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^2.26.2
     version: 2.27.7
   '@guardian/prebid.js':
-    specifier: 8.52.0-7
-    version: 8.52.0-7(babel-core@7.0.0-bridge.0)(tslib@2.7.0)(typescript@5.5.3)
+    specifier: 8.52.0-8
+    version: 8.52.0-8(babel-core@7.0.0-bridge.0)(tslib@2.7.0)(typescript@5.5.3)
   '@octokit/core':
     specifier: ^6.1.2
     version: 6.1.2
@@ -1995,8 +1995,8 @@ packages:
       typescript: 5.5.3
     dev: true
 
-  /@guardian/prebid.js@8.52.0-7(babel-core@7.0.0-bridge.0)(tslib@2.7.0)(typescript@5.5.3):
-    resolution: {integrity: sha512-RWg8vyyfZccrqRXu5w+nnghsskYCHkLWQqXdFh1iSadYRU+exuNcynxStKdzUZdPNnh8aUyEuMIoaZXHmEZEYg==}
+  /@guardian/prebid.js@8.52.0-8(babel-core@7.0.0-bridge.0)(tslib@2.7.0)(typescript@5.5.3):
+    resolution: {integrity: sha512-JQ9unudgn5DAwLoqEiBdjuEaEFOhR9JZhjHD46pm4306C1XfYF0ts3YWIT9poq6vN1tbMQJw0NQeyXcL5QGIcA==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@babel/core': 7.25.2

--- a/src/experiments/ab-tests.ts
+++ b/src/experiments/ab-tests.ts
@@ -1,5 +1,6 @@
 import type { ABTest } from '@guardian/ab-core';
 import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
+import { newHeaderBiddingEndpoint } from './tests/new-header-bidding-endpoint';
 import { optOutFrequencyCap } from './tests/opt-out-frequency-cap';
 
 /**
@@ -11,4 +12,5 @@ export const concurrentTests: ABTest[] = [
 	// one test per line
 	mpuWhenNoEpic,
 	optOutFrequencyCap,
+	newHeaderBiddingEndpoint,
 ];

--- a/src/experiments/tests/new-header-bidding-endpoint.ts
+++ b/src/experiments/tests/new-header-bidding-endpoint.ts
@@ -9,7 +9,7 @@ export const newHeaderBiddingEndpoint: ABTest = {
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',
 	successMeasure: '',
-	description: 'Test new header bidding (prebid) anlytics endpoint.',
+	description: 'Test new header bidding (prebid) analytics endpoint.',
 	variants: [
 		{
 			id: 'control',

--- a/src/experiments/tests/new-header-bidding-endpoint.ts
+++ b/src/experiments/tests/new-header-bidding-endpoint.ts
@@ -1,0 +1,28 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const newHeaderBiddingEndpoint: ABTest = {
+	id: 'newHeaderBiddingEndpoint',
+	author: '@commercial-dev',
+	start: '2024-11-11',
+	expiry: '2024-11-30',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: '',
+	successMeasure: '',
+	description: 'Test new header bidding (prebid) anlytics endpoint.',
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+	canRun: () => true,
+};

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -8,6 +8,8 @@ import { PREBID_TIMEOUT } from '../../../core/constants/prebid-timeout';
 import { EventTimer } from '../../../core/event-timer';
 import type { PageTargeting } from '../../../core/targeting/build-page-targeting';
 import type { Advert } from '../../../define/Advert';
+import { isUserInVariant } from '../../../experiments/ab';
+import { newHeaderBiddingEndpoint } from '../../../experiments/tests/new-header-bidding-endpoint';
 import { getPageTargeting } from '../../build-page-targeting';
 import { getAdvertById } from '../../dfp/get-advert-by-id';
 import { isUserLoggedInOktaRefactor } from '../../identity/api';
@@ -124,6 +126,8 @@ type EnableAnalyticsConfig = {
 	options: {
 		ajaxUrl: string;
 		pv: string;
+		enableV2Endpoint: boolean;
+		ajaxUrlV2: string;
 	};
 };
 
@@ -423,6 +427,11 @@ const initialise = (
 				options: {
 					ajaxUrl: window.guardian.config.page.ajaxUrl ?? '',
 					pv: window.guardian.ophan.pageViewId,
+					enableV2Endpoint: isUserInVariant(
+						newHeaderBiddingEndpoint,
+						'variant',
+					),
+					ajaxUrlV2: `//performance-events.code.dev-guardianapis.com/header-bidding`,
 				},
 			},
 		]);


### PR DESCRIPTION
## What does this change?
Adds a second endpoint for prebid analytics that is behind a 0% test.

## Why?
To get a small amount of data in the new table to compare with the current data.