### PR TITLE
Fix persisting of forced ab test to localstorage

### DIFF
--- a/.changeset/curvy-ads-scream.md
+++ b/.changeset/curvy-ads-scream.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Fix persisting of forced ab tests to localstorage

--- a/docs/ab-testing/readme.md
+++ b/docs/ab-testing/readme.md
@@ -4,17 +4,17 @@
 
 ### Setup
 
-1. Follow steps 1-6 in [the DCR documentation](https://github.com/guardian/frontend/blob/main/common/app/conf/switches/ABTestSwitches.scala)
-1. Create a test in [src/experiments/tests](https://github.com/guardian/commercial-core/blob/main/src/experiments/tests)
-1. Add the test to [concurrent tests](https://github.com/guardian/commercial-core/blob/main/src/experiments/ab-tests.ts)
+1. Follow steps 1-6 in [the DCR documentation](https://github.com/guardian/dotcom-rendering/blob/main/dotcom-rendering/docs/development/ab-testing-in-dcr.md)
+1. Create a test in [src/experiments/tests](https://github.com/guardian/commercial/blob/main/src/experiments/tests)
+1. Add the test to [concurrent tests](https://github.com/guardian/commercial/blob/main/src/experiments/ab-tests.ts)
 
 ### Example usage
 
 ```ts
-import { isInVariantSynchronous } from 'experiments/ab';
+import { isUserInVariant } from 'experiments/ab';
 import { sectionAdDensity } from 'experiments/tests/section-ad-density';
 
-const isInVariant = isInVariantSynchronous(sectionAdDensity, 'variant');
+const isInVariant = isUserInVariant(sectionAdDensity, 'variant');
 ```
 
 ### How to test
@@ -22,6 +22,8 @@ const isInVariant = isInVariantSynchronous(sectionAdDensity, 'variant');
 Use the URL opt-in link to force yourself into a particular variant, e.g. `http://localhost:3030/Front/https://www.theguardian.com/uk#ab-yourTest=yourVariant`
 
 If you test has multiple variants, you can test each one by updating the `yourVariant` part of the above URL.
+
+To remove yourself from the test unset the varaint e.g. `http://localhost:3030/Front/https://www.theguardian.com/uk#ab-yourTest=`
 
 ## Server-side tests
 

--- a/src/core/lib/ab-localstorage.ts
+++ b/src/core/lib/ab-localstorage.ts
@@ -19,3 +19,9 @@ export const getParticipationsFromLocalStorage = (): Participations => {
 	const participations = storage.local.get(participationsKey);
 	return isParticipations(participations) ? participations : {};
 };
+
+export const setParticipationsInLocalStorage = (
+	participations: Participations,
+): void => {
+	storage.local.set(participationsKey, participations);
+};

--- a/src/experiments/ab-url.ts
+++ b/src/experiments/ab-url.ts
@@ -6,12 +6,18 @@ export const getForcedParticipationsFromUrl = (): Participations => {
 
 		return tokens.reduce((obj, token) => {
 			const [testId, variantId] = token.split('=');
-			if (testId && variantId) {
+			if (testId) {
+				if (variantId) {
+					return {
+						...obj,
+						[testId]: {
+							variant: variantId,
+						},
+					};
+				}
 				return {
 					...obj,
-					[testId]: {
-						variant: variantId,
-					},
+					[testId]: undefined,
 				};
 			}
 			return obj;

--- a/src/experiments/ab.ts
+++ b/src/experiments/ab.ts
@@ -1,6 +1,10 @@
 import type { ABTest } from '@guardian/ab-core';
 import { AB } from '@guardian/ab-core';
 import { getCookie, log } from '@guardian/libs';
+import {
+	getParticipationsFromLocalStorage,
+	setParticipationsInLocalStorage,
+} from '../core/lib/ab-localstorage';
 import { concurrentTests } from './ab-tests';
 import { getForcedParticipationsFromUrl } from './ab-url';
 
@@ -71,13 +75,20 @@ const abTestSwitches = Object.entries(window.guardian.config.switches).reduce(
 );
 
 const init = () => {
+	const forcedTestVariants = {
+		...getParticipationsFromLocalStorage(),
+		...getForcedParticipationsFromUrl(),
+	};
+
+	setParticipationsInLocalStorage(forcedTestVariants);
+
 	const ab = new AB({
 		mvtId: mvtId ?? -1,
 		mvtMaxValue,
 		pageIsSensitive: window.guardian.config.page.isSensitive,
 		abTestSwitches,
 		arrayOfTestObjects: concurrentTests,
-		forcedTestVariants: getForcedParticipationsFromUrl(),
+		forcedTestVariants,
 		ophanRecord: getOphan().record,
 		serverSideTests: window.guardian.config.tests ?? {},
 		errorReporter: (error) => {


### PR DESCRIPTION
## What does this change?
This used to work, evidenced by the fact that `ab-localstorage.ts` already existed, and broke at some point.

I'm not sure how leaving the test used to work but have modified slightly to allow leaving by clearing the variant e.g. `http://localhost:3030/Front/https://www.theguardian.com/uk#ab-yourTest=`

## Why?
It's quite useful for the test to persist between pageviews.