### PR TITLE
Add `keywords` param to Sonobi prebid

### DIFF
--- a/.changeset/large-emus-sin.md
+++ b/.changeset/large-emus-sin.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Add Keywords parameter to Sonobi prebid

--- a/src/lib/header-bidding/prebid-types.ts
+++ b/src/lib/header-bidding/prebid-types.ts
@@ -47,6 +47,7 @@ export type PrebidSonobiParams = {
 	dom_id: string;
 	appNexusTargeting: string;
 	pageViewId: string;
+	keywords: string[];
 	render?: string;
 };
 

--- a/src/lib/header-bidding/prebid/bid-config.ts
+++ b/src/lib/header-bidding/prebid/bid-config.ts
@@ -349,6 +349,7 @@ const sonobiBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
 		dom_id: slotId,
 		appNexusTargeting: buildAppNexusTargeting(pageTargeting),
 		pageViewId: window.guardian.ophan.pageViewId,
+		keywords: window.guardian.config.page.keywords.split(','),
 	}),
 });
 

--- a/src/lib/header-bidding/prebid/bid-config.ts
+++ b/src/lib/header-bidding/prebid/bid-config.ts
@@ -349,7 +349,9 @@ const sonobiBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
 		dom_id: slotId,
 		appNexusTargeting: buildAppNexusTargeting(pageTargeting),
 		pageViewId: window.guardian.ophan.pageViewId,
-		keywords: window.guardian.config.page.keywords.split(','),
+		keywords: window.guardian.config.page.keywords
+			? window.guardian.config.page.keywords.split(',')
+			: [],
 	}),
 });
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR adds `keywords` param to Sonobi prebid, a US prebid adaptor. `keywords` in the page config is a string but Sonobi wants an array of strings.

It's tested locally and it works as you can see from the screenshot 

![image](https://github.com/user-attachments/assets/0bc729bd-3c1a-46ac-a6ef-68bfc901fdd2)


## Why?

This was a request made by Sonobi prebid so that buyers can make better informed bidding decisions.
