### PR TITLE
Increase new header bidding endpoint rollout to 1% of users

### DIFF
--- a/.changeset/short-beers-pay.md
+++ b/.changeset/short-beers-pay.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+increase new header bidding endpoint rollout to 1% of users

--- a/src/experiments/tests/new-header-bidding-endpoint.ts
+++ b/src/experiments/tests/new-header-bidding-endpoint.ts
@@ -5,7 +5,7 @@ export const newHeaderBiddingEndpoint: ABTest = {
 	author: '@commercial-dev',
 	start: '2024-11-11',
 	expiry: '2024-11-30',
-	audience: 0 / 100,
+	audience: 2 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',
 	successMeasure: '',


### PR DESCRIPTION
## What does this change?
Start gathering data from real users on the new endpoint, 

note: This is in addition to the current method not instead of, the old method will be turned off once this ramps up to 100%.

## Why?

See https://github.com/guardian/gcp-iac-terraform/pull/984
