### PR TITLE
add pubmatic placement id for US

### DIFF
--- a/.changeset/giant-toes-tease.md
+++ b/.changeset/giant-toes-tease.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+add US specific placement ID for pubmatic ad partner

--- a/src/lib/header-bidding/prebid/bid-config.ts
+++ b/src/lib/header-bidding/prebid/bid-config.ts
@@ -497,7 +497,6 @@ const getPubmaticPlacementId = (
 	slotId: string,
 	slotSizes: HeaderBiddingSize[],
 ): string | undefined => {
-	console.log('slotId=====', slotId);
 	if (
 		slotId === 'dfp-ad--inline2' &&
 		slotSizes.find((size) => size.width === 371 && size.height === 660)

--- a/src/lib/header-bidding/prebid/bid-config.ts
+++ b/src/lib/header-bidding/prebid/bid-config.ts
@@ -493,6 +493,22 @@ const getAdYouLikePlacementId = (sizes: HeaderBiddingSize[]) => {
 	return '';
 };
 
+const getPubmaticPlacementId = (
+	slotId: string,
+	slotSizes: HeaderBiddingSize[],
+): string | undefined => {
+	console.log('slotId=====', slotId);
+	if (
+		slotId === 'dfp-ad--inline2' &&
+		slotSizes.find((size) => size.width === 371 && size.height === 660)
+	) {
+		return isInUsa()
+			? 'seenthis_guardian_mweb_us'
+			: 'seenthis_guardian_371x660_mweb';
+	}
+	return undefined;
+};
+
 const pubmaticBidder = (slotSizes: HeaderBiddingSize[]): PrebidBidder => {
 	const defaultParams = {
 		name: 'pubmatic' as BidderCode,
@@ -500,13 +516,7 @@ const pubmaticBidder = (slotSizes: HeaderBiddingSize[]): PrebidBidder => {
 		bidParams: (slotId: string): PrebidPubmaticParams => ({
 			publisherId: getPubmaticPublisherId(),
 			adSlot: stripDfpAdPrefixFrom(slotId),
-			placementId:
-				slotId === 'dfp-ad--inline2' &&
-				slotSizes.find(
-					(size) => size.width === 371 && size.height === 660,
-				)
-					? 'seenthis_guardian_371x660_mweb'
-					: undefined,
+			placementId: getPubmaticPlacementId(slotId, slotSizes),
 		}),
 	};
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.


-->

## What does this change?
We are adding a new placementID to the Pubmatic custom ad-size[371x660]

Currently we have a a prebid  ad  partner - `Pubmatic` which runs globally.
We would like a US specific integration keeping the existing placement ID for all other countries.
Logic has been added to deliver a specific placement ID customised for US `seenthis_guardian_mweb_us`
We are continuing to deliver the existing placement id `seenthis_guardian_371x660_mweb` for the rest of the world.

## Why?
This will allow fine-tuned targeting, better performance in the market market, and compliance with regional needs.


## Screenshot

| Professor prebid:`Pubmatic` - dfp-ad-inline2 US (VPN)   |
|----------|
| <img width="1100" alt="Screenshot 2024-11-20 at 12 57 46" src="https://github.com/user-attachments/assets/5945ab62-6b9c-4f44-8e1b-705e2bc4bfd2"> |

| Professor prebid: `Pubmatic` - dfp-ad-inline2 UK  |
|----------|
| <img width="1090" alt="Screenshot 2024-11-20 at 13 04 47" src="https://github.com/user-attachments/assets/dd920bd5-5c3c-42e1-9a93-bc21fa46265c"> |




