### PR TITLE
Avoid putting ads next to halfWidth elements on the page

### DIFF
--- a/.changeset/cool-turtles-grab.md
+++ b/.changeset/cool-turtles-grab.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Avoid inserting ads next to halfwidth elements

--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -35,7 +35,7 @@ const leftColumnOpponentSelector = ['richLink', 'thumbnail']
 	.join(',');
 const rightColumnOpponentSelector =
 	':scope > [data-spacefinder-role="immersive"]';
-const inlineOpponentSelector = ['inline', 'supporting', 'showcase']
+const inlineOpponentSelector = ['inline', 'supporting', 'showcase', 'halfWidth']
 	.map((role) => `:scope > [data-spacefinder-role="${role}"]`)
 	.join(',');
 


### PR DESCRIPTION
## What does this change?
Adds elements with the role 'halfWidth' to the list on inline elements that Spacefinder avoids inserting ads next to.

## Why?
At the moment Spacefinder doesn't know we should avoid these elements, and ads look terrible next to them.

## Screenshots
### Before
<img width="1490" alt="Screenshot 2024-11-21 at 14 23 03" src="https://github.com/user-attachments/assets/ec67041c-3603-41f5-9d60-8c73d91da317">


### After
<img width="1491" alt="Screenshot 2024-11-21 at 14 22 47" src="https://github.com/user-attachments/assets/a6496e8b-1457-4dbb-bf93-ee3535ed7478">
