### PR TITLE
Show ads in right column of football live page

### DIFF
--- a/.changeset/nine-yaks-type.md
+++ b/.changeset/nine-yaks-type.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+show ads in right column of football live pages

--- a/src/lib/commercial-features.ts
+++ b/src/lib/commercial-features.ts
@@ -88,6 +88,7 @@ class CommercialFeatures {
 		const isFootballPage = pageId.startsWith('football/');
 		const isPageWithRightAdSpace =
 			pageId.endsWith('/fixtures') ||
+			pageId.endsWith('/live') ||
 			pageId.endsWith('/results') ||
 			pageId.endsWith('/tables') ||
 			pageId.endsWith('/table');


### PR DESCRIPTION
## What does this change?

Allow ads to show in the right column on the [football live page](https://www.theguardian.com/football/live). 

## Why?

![8ca948df7b68e24dbd666765e9457f6b](https://github.com/user-attachments/assets/6331ba8d-1dbd-4591-b7a8-278a26d3b993)


Follow on from #1379

