### PR TITLE
Update to `@guardian/libs@19.2.1`

### DIFF
--- a/.changeset/sharp-cherries-lay.md
+++ b/.changeset/sharp-cherries-lay.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Fix for usnat supported api lookup

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"@guardian/eslint-config-typescript": "^12.0.0",
 		"@guardian/identity-auth": "^3.0.0",
 		"@guardian/identity-auth-frontend": "^5.0.0",
-		"@guardian/libs": "19.1.0",
+		"@guardian/libs": "19.2.1",
 		"@guardian/prettier": "8.0.1",
 		"@guardian/source": "8.0.0",
 		"@playwright/test": "1.48.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,19 +72,19 @@ devDependencies:
     version: 6.1.1(browserslist@4.24.2)(tslib@2.7.0)
   '@guardian/core-web-vitals':
     specifier: 7.0.0
-    version: 7.0.0(@guardian/libs@19.1.0)(tslib@2.7.0)(typescript@5.6.3)(web-vitals@4.2.3)
+    version: 7.0.0(@guardian/libs@19.2.1)(tslib@2.7.0)(typescript@5.6.3)(web-vitals@4.2.3)
   '@guardian/eslint-config-typescript':
     specifier: ^12.0.0
     version: 12.0.0(eslint@8.57.0)(tslib@2.7.0)(typescript@5.6.3)
   '@guardian/identity-auth':
     specifier: ^3.0.0
-    version: 3.0.1(@guardian/libs@19.1.0)(tslib@2.7.0)(typescript@5.6.3)
+    version: 3.0.1(@guardian/libs@19.2.1)(tslib@2.7.0)(typescript@5.6.3)
   '@guardian/identity-auth-frontend':
     specifier: ^5.0.0
-    version: 5.0.0(@guardian/identity-auth@3.0.1)(@guardian/libs@19.1.0)(tslib@2.7.0)(typescript@5.6.3)
+    version: 5.0.0(@guardian/identity-auth@3.0.1)(@guardian/libs@19.2.1)(tslib@2.7.0)(typescript@5.6.3)
   '@guardian/libs':
-    specifier: 19.1.0
-    version: 19.1.0(tslib@2.7.0)(typescript@5.6.3)
+    specifier: 19.2.1
+    version: 19.2.1(tslib@2.7.0)(typescript@5.6.3)
   '@guardian/prettier':
     specifier: 8.0.1
     version: 8.0.1(prettier@3.3.3)(tslib@2.7.0)
@@ -1893,7 +1893,7 @@ packages:
       tslib: 2.7.0
     dev: true
 
-  /@guardian/core-web-vitals@7.0.0(@guardian/libs@19.1.0)(tslib@2.7.0)(typescript@5.6.3)(web-vitals@4.2.3):
+  /@guardian/core-web-vitals@7.0.0(@guardian/libs@19.2.1)(tslib@2.7.0)(typescript@5.6.3)(web-vitals@4.2.3):
     resolution: {integrity: sha512-1JLUQjkLY8SXYJqcy0TiE9/9hCcmyIlmMpRoW8Ygn/qGtyNxG+zzwkwsgtJIP+B0ZjtDqfukra2IV9l7wX5A0g==}
     peerDependencies:
       '@guardian/libs': ^18.0.0
@@ -1904,7 +1904,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@guardian/libs': 19.1.0(tslib@2.7.0)(typescript@5.6.3)
+      '@guardian/libs': 19.2.1(tslib@2.7.0)(typescript@5.6.3)
       tslib: 2.7.0
       typescript: 5.6.3
       web-vitals: 4.2.3
@@ -1950,7 +1950,7 @@ packages:
       - supports-color
     dev: true
 
-  /@guardian/identity-auth-frontend@5.0.0(@guardian/identity-auth@3.0.1)(@guardian/libs@19.1.0)(tslib@2.7.0)(typescript@5.6.3):
+  /@guardian/identity-auth-frontend@5.0.0(@guardian/identity-auth@3.0.1)(@guardian/libs@19.2.1)(tslib@2.7.0)(typescript@5.6.3):
     resolution: {integrity: sha512-Y5wIg8Zo92jl/ChZ4v/Ve3CGQWnoZSfkrhwSOIoZPm88YvijEASxHteVF04QOy/rhVs1O6AQJfl5Ilx244zS6w==}
     peerDependencies:
       '@guardian/identity-auth': ^3.0.0
@@ -1961,13 +1961,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@guardian/identity-auth': 3.0.1(@guardian/libs@19.1.0)(tslib@2.7.0)(typescript@5.6.3)
-      '@guardian/libs': 19.1.0(tslib@2.7.0)(typescript@5.6.3)
+      '@guardian/identity-auth': 3.0.1(@guardian/libs@19.2.1)(tslib@2.7.0)(typescript@5.6.3)
+      '@guardian/libs': 19.2.1(tslib@2.7.0)(typescript@5.6.3)
       tslib: 2.7.0
       typescript: 5.6.3
     dev: true
 
-  /@guardian/identity-auth@3.0.1(@guardian/libs@19.1.0)(tslib@2.7.0)(typescript@5.6.3):
+  /@guardian/identity-auth@3.0.1(@guardian/libs@19.2.1)(tslib@2.7.0)(typescript@5.6.3):
     resolution: {integrity: sha512-QwvQY6BmirP9Me2DkVkNCq0VQeNMzko9zG73G9l0XpQKk5+tTPUf31kyj06Uw11pWUfNacscjbfSU4rDqZOxCA==}
     peerDependencies:
       '@guardian/libs': ^18.0.0
@@ -1977,7 +1977,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@guardian/libs': 19.1.0(tslib@2.7.0)(typescript@5.6.3)
+      '@guardian/libs': 19.2.1(tslib@2.7.0)(typescript@5.6.3)
       tslib: 2.7.0
       typescript: 5.6.3
     dev: true
@@ -1995,8 +1995,8 @@ packages:
       typescript: 5.6.3
     dev: false
 
-  /@guardian/libs@19.1.0(tslib@2.7.0)(typescript@5.6.3):
-    resolution: {integrity: sha512-hH+yMhsBwUU7p8BdmbSqjk9hwp5obtglugviwSIeu89JqlDQnC1LrYKw0kVZbkn+P4sW+aQDYg7OVswgpNPOHg==}
+  /@guardian/libs@19.2.1(tslib@2.7.0)(typescript@5.6.3):
+    resolution: {integrity: sha512-U/JElVPXdy95XnpHQ5OWxMYH4mar4lBvGcKOyZrWPDrhmQr4Z5cFwa07LBh6kUZuXk4m/nasZTGS4Jy136ckMQ==}
     peerDependencies:
       tslib: ^2.6.2
       typescript: ~5.5.2


### PR DESCRIPTION
## What does this change?

Update to `@guardian/libs@19.2.1`

## Why?

To bring in this fix:

https://github.com/guardian/csnx/pull/1804
