### PR TITLE
Unskip liveblog-ad-limit test

### DIFF
--- a/playwright/tests/liveblog-ad-limit.spec.ts
+++ b/playwright/tests/liveblog-ad-limit.spec.ts
@@ -18,6 +18,8 @@ const MAX_AD_SLOTS = 8;
 const addAndAwaitNewBlocks = async (page: Page, blockContent: string) => {
 	// scroll to the top so we get a toast to click on
 	await page.evaluate(() => window.scrollTo(0, 0));
+	// @ts-expect-error -- browser land
+	await page.waitForFunction(() => window.mockLiveUpdate !== undefined);
 	await page.evaluate((blockContent) => {
 		// @ts-expect-error -- browser land
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-call -- browser land

--- a/playwright/tests/liveblog-ad-limit.spec.ts
+++ b/playwright/tests/liveblog-ad-limit.spec.ts
@@ -7,10 +7,6 @@ import { cmpAcceptAll } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
 import { countLiveblogInlineSlots } from '../lib/util';
 
-/**
- * TODO serial e2e tests
- * - It would be good to see if these tests could be run in parallel in the future
- */
 const pages = blogs.filter(({ name }) => name === 'under-ad-limit');
 
 const desktopBreakpoint = breakpoints.filter(
@@ -51,7 +47,7 @@ const addAndAwaitNewBlocks = async (page: Page, blockContent: string) => {
 	await expect(newBlock).toBeVisible();
 };
 
-test.skip('A minimum amount of ad slots load', () => {
+test.describe('A minimum amount of ad slots load', () => {
 	pages.forEach(({ path, expectedMinInlineSlots }) => {
 		/**
 		 * First ensure that the we receive the expected initial amount of ad slots.

--- a/playwright/tests/liveblog-live-update.spec.ts
+++ b/playwright/tests/liveblog-live-update.spec.ts
@@ -42,6 +42,10 @@ test.describe.serial('Liveblog live updates', () => {
 					isMobile,
 				);
 
+				await page.waitForFunction(
+					// @ts-expect-error -- browser land
+					() => window.mockLiveUpdate !== undefined,
+				);
 				await page.evaluate(() => {
 					// @ts-expect-error -- browser land
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-call -- browser land


### PR DESCRIPTION
## What does this change?

Update `liveblog-ad-limit` e2e test to reduce flakiness.

On inspection it looks like its possible for `window.mockLiveUpdate` to be undefined until the `Liveness` island is hydrated and the function is set on the window.

Adding a wait on `window.mockLiveUpdate` to be defined should remove this corner case.

