### PR TITLE
adds a9 gumgum back to fronts

### DIFF
--- a/.changeset/violet-dragons-press.md
+++ b/.changeset/violet-dragons-press.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+adds A9 GumGum back to Fronts

--- a/src/lib/header-bidding/a9/a9.ts
+++ b/src/lib/header-bidding/a9/a9.ts
@@ -27,14 +27,32 @@ let requestQueue = Promise.resolve();
 
 const bidderTimeout = 1500;
 
+const displayAd = (adPosition: string): void => {
+	const adSlot = document.getElementById(`dfp-ad--${adPosition}`);
+	if (adSlot) {
+		window.googletag.display(adSlot.id);
+	}
+};
+
 const initialise = (): void => {
 	if (!initialised && window.apstag) {
 		initialised = true;
+		const pageConfig = window.guardian.config.page;
+		let adPosition = '';
+
+		if (pageConfig.isFront) {
+			if (pageConfig.section === 'network') {
+				adPosition = 'inline1';
+			} else {
+				adPosition = 'top-above-nav';
+			}
+		}
 		window.apstag.init({
 			pubID: window.guardian.config.page.a9PublisherId,
 			adServer: 'googletag',
 			bidTimeout: bidderTimeout,
 		});
+		displayAd(adPosition);
 	}
 };
 

--- a/src/lib/header-bidding/a9/a9.ts
+++ b/src/lib/header-bidding/a9/a9.ts
@@ -30,16 +30,10 @@ const bidderTimeout = 1500;
 const initialise = (): void => {
 	if (!initialised && window.apstag) {
 		initialised = true;
-		const blockedBidders = window.guardian.config.page.isFront
-			? [
-					'1lsxjb4', // GumGum, as they have been showing wonky formats on fronts
-				]
-			: [];
 		window.apstag.init({
 			pubID: window.guardian.config.page.a9PublisherId,
 			adServer: 'googletag',
 			bidTimeout: bidderTimeout,
-			blockedBidders,
 		});
 	}
 };

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -251,7 +251,6 @@ type ApstagInitConfig = {
 	pubID: string;
 	adServer?: string;
 	bidTimeout?: number;
-	blockedBidders?: string[];
 };
 
 type FetchBidsBidConfig = {


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
This PR add GumGum A9 back to Fronts.
## Why?
As a result of the change making extended revenue we have decided to re introduce it.