### PR TITLE
remove a9 block bidder add for fronts

### DIFF
--- a/.changeset/hip-lemons-sit.md
+++ b/.changeset/hip-lemons-sit.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+serve gumgum interscroller for Fronts

--- a/src/lib/header-bidding/a9/a9.ts
+++ b/src/lib/header-bidding/a9/a9.ts
@@ -64,11 +64,23 @@ const requestBids = async (
 		return requestQueue;
 	}
 
+	const section = window.guardian.config.page.section;
+
+	const isNetworkFront =
+		section === 'uk' || section === 'us' || section === 'au';
+
+	const filteredAdUnits = adUnits.filter((adUnit) => {
+		if (isNetworkFront) {
+			return adUnit.slotID === 'dfp-ad--inline1--mobile';
+		}
+		return adUnit.slotID === 'dfp-ad--top-above-nav';
+	});
+
 	requestQueue = requestQueue
 		.then(
 			() =>
 				new Promise<void>((resolve) => {
-					window.apstag?.fetchBids({ slots: adUnits }, () => {
+					window.apstag?.fetchBids({ slots: filteredAdUnits }, () => {
 						window.googletag.cmd.push(() => {
 							window.apstag?.setDisplayBids();
 							resolve();

--- a/src/lib/header-bidding/a9/a9.ts
+++ b/src/lib/header-bidding/a9/a9.ts
@@ -92,23 +92,26 @@ const requestBids = async (
 	 * @param adUnits - The array of ad units to be filtered.
 	 * @returns The filtered array of ad units based on the page context.
 	 */
-	const filteredAdUnits = adUnits.filter((adUnit) => {
-		if (isNetworkFront) {
-			return adUnit.slotID === 'dfp-ad--inline1--mobile';
+	const updatedAdUnits = adUnits.map((adUnit) => {
+		let blockedBidders: string[] = [];
+
+		if (isNetworkFront && adUnit.slotID === 'dfp-ad--inline1--mobile') {
+			blockedBidders = ['1lsxjb4']; // Block GumGum for network front condition
+		} else if (
+			isSectionFront &&
+			adUnit.slotID === 'dfp-ad--top-above-nav'
+		) {
+			blockedBidders = ['1lsxjb4']; // Block GumGum for section front condition
 		}
-		if (isSectionFront) {
-			return adUnit.slotID === 'dfp-ad--top-above-nav';
-		}
-		if (!window.guardian.config.page.isFront) {
-			return true;
-		}
+
+		return { ...adUnit, params: { blockedBidders } };
 	});
 
 	requestQueue = requestQueue
 		.then(
 			() =>
 				new Promise<void>((resolve) => {
-					window.apstag?.fetchBids({ slots: filteredAdUnits }, () => {
+					window.apstag?.fetchBids({ slots: updatedAdUnits }, () => {
 						window.googletag.cmd.push(() => {
 							window.apstag?.setDisplayBids();
 							resolve();

--- a/src/lib/header-bidding/a9/a9.ts
+++ b/src/lib/header-bidding/a9/a9.ts
@@ -66,14 +66,42 @@ const requestBids = async (
 
 	const section = window.guardian.config.page.section;
 
-	const isNetworkFront =
-		section === 'uk' || section === 'us' || section === 'au';
+	const isNetworkFront = [
+		'uk',
+		'us',
+		'au',
+		'europe',
+		'international',
+	].includes(section);
+	const isSectionFront = [
+		'commentisfree',
+		'sport',
+		'culture',
+		'lifeandstyle',
+	].includes(section);
 
+	/**
+	 * Filters the provided ad units based on the current page context.
+	 *
+	 * - If the page is a network front, only the ad unit with the slot ID 'dfp-ad--inline1--mobile' is included.
+	 * - If the page is a section front, only the ad unit with the slot ID 'dfp-ad--top-above-nav' is included.
+	 * - If the page is not a front, all ad units are included.
+	 * - There is a cross over in logic where the page is both an article as well as a network front/section front,
+	 * - in this case we want to identify the page as a non-front page (arrticle) and include all ad units.
+	 *
+	 * @param adUnits - The array of ad units to be filtered.
+	 * @returns The filtered array of ad units based on the page context.
+	 */
 	const filteredAdUnits = adUnits.filter((adUnit) => {
 		if (isNetworkFront) {
 			return adUnit.slotID === 'dfp-ad--inline1--mobile';
 		}
-		return adUnit.slotID === 'dfp-ad--top-above-nav';
+		if (isSectionFront) {
+			return adUnit.slotID === 'dfp-ad--top-above-nav';
+		}
+		if (!window.guardian.config.page.isFront) {
+			return true;
+		}
 	});
 
 	requestQueue = requestQueue

--- a/src/lib/header-bidding/a9/a9.ts
+++ b/src/lib/header-bidding/a9/a9.ts
@@ -30,16 +30,10 @@ const bidderTimeout = 1500;
 const initialise = (): void => {
 	if (!initialised && window.apstag) {
 		initialised = true;
-		const blockedBidders = window.guardian.config.page.isFront
-			? [
-					'1lsxjb4', // GumGum, as they have been showing wonky formats on fronts
-				]
-			: [];
 		window.apstag.init({
 			pubID: window.guardian.config.page.a9PublisherId,
 			adServer: 'googletag',
 			bidTimeout: bidderTimeout,
-			blockedBidders,
 		});
 	}
 };

--- a/src/lib/header-bidding/a9/a9.ts
+++ b/src/lib/header-bidding/a9/a9.ts
@@ -17,7 +17,7 @@ class A9AdUnit implements A9AdUnitInterface {
 
 	constructor(advert: Advert, slot: HeaderBiddingSlot) {
 		this.slotID = advert.id;
-		this.slotName = window.guardian.config.page.adUnit;
+		this.slotName = `${window.guardian.config.page.adUnit}/${this.slotID}`;
 		this.sizes = slot.sizes.map((size) => Array.from(size));
 	}
 }

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -251,7 +251,6 @@ type ApstagInitConfig = {
 	pubID: string;
 	adServer?: string;
 	bidTimeout?: number;
-	// blockedBidders?: string[];
 };
 
 type FetchBidsBidConfig = {

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -251,7 +251,7 @@ type ApstagInitConfig = {
 	pubID: string;
 	adServer?: string;
 	bidTimeout?: number;
-	blockedBidders?: string[];
+	// blockedBidders?: string[];
 };
 
 type FetchBidsBidConfig = {


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
This PR reintroduces the ability for GumGum (interscroller ads) to serve on Fronts after being previously blocked. 

Changes to A9 module:
1. **Context-Based Filtering:**
 - Filters ad units based on the page context:
   - Network front: Includes only the ad unit with slot ID `dfp-ad--inline1--mobile`.
   - Section front: Includes only the ad unit with slot ID `dfp-ad--top-above-nav`.
   - Non-front pages: Includes all ad units.
   - For pages that are both articles and fronts, treats them as non-front pages and includes all ad units.

#### 2. Bidder Blocking:
- Adds a params object to each ad unit with a blockedBidders property:
Network front: Blocks GumGum for dfp-ad--inline1--mobile.
Section front: Blocks GumGum for dfp-ad--top-above-nav.

#### 3. Ad Unit Updates:
- Maps over ad units to include the new params object with blockedBidders, ensuring proper configuration based on context and bidder blocking.

## Why?
GumGum interscrollers were blocked in a previous ticket (linked below) but generated significant revenue before the block. Commercial has approved reintroducing them under these controlled conditions to balance user experience and revenue.

## Notes
- "Fronts" refer to prominent pages, including the Network Front (e.g., homepage) and Section Fronts (e.g., category or topic-specific pages).
- The `inline1` and `top-above-nav` ad slots were chosen based on their positions to optimize both user engagement and ad performance.

Related PR: [Add blocked bidder within Amazon A9 for SSP GumGum when on Fronts](https://github.com/guardian/commercial/pull/1647)

## Screenshots

| Network Front   | 
|------------|
| ![Screenshot 2024-12-04 at 14 04 29](https://github.com/user-attachments/assets/0117367c-82c4-4bfd-990b-773b04c99448)) | 



| Section Front   | 
|------------|
| ![Screenshot 2024-12-04 at 14 02 30](https://github.com/user-attachments/assets/fd0408e3-c9b8-481a-9b00-252f5d7ddab7) | 

| Article: Non Front  page  | 
|------------|
| <img width="1275" alt="Screenshot 2024-12-06 at 18 02 08" src="https://github.com/user-attachments/assets/133ccefc-4d06-4558-88ec-e976847e586d"> | 