### PR TITLE
Disable old prebid analytics endpoint

### DIFF
--- a/.changeset/five-owls-obey.md
+++ b/.changeset/five-owls-obey.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Disable old prebid analytics endpoint

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
 		"webpack-merge": "^6.0.1"
 	},
 	"dependencies": {
-		"@guardian/prebid.js": "8.52.0-9",
+		"@guardian/prebid.js": "8.52.0-10",
 		"@octokit/core": "^6.1.2",
 		"fastdom": "^1.0.11",
 		"lodash-es": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@guardian/prebid.js':
-    specifier: 8.52.0-9
-    version: 8.52.0-9(babel-core@7.0.0-bridge.0)(tslib@2.7.0)(typescript@5.6.3)
+    specifier: 8.52.0-10
+    version: 8.52.0-10(babel-core@7.0.0-bridge.0)(tslib@2.7.0)(typescript@5.6.3)
   '@octokit/core':
     specifier: ^6.1.2
     version: 6.1.2
@@ -2008,8 +2008,8 @@ packages:
       typescript: 5.6.3
     dev: true
 
-  /@guardian/prebid.js@8.52.0-9(babel-core@7.0.0-bridge.0)(tslib@2.7.0)(typescript@5.6.3):
-    resolution: {integrity: sha512-Jjb7QaMm9NevbHsBuD0hcJDnslCITFGsj4w9sJIsRPWbz75ssHJdg9+UXA7fPuLpie9aczECWudffw4z4FYzPw==}
+  /@guardian/prebid.js@8.52.0-10(babel-core@7.0.0-bridge.0)(tslib@2.7.0)(typescript@5.6.3):
+    resolution: {integrity: sha512-/oGFQ3GlwzJOfc7Fe1AiTI2XCjPcco7fDDli4FDJx0GAuiJDuzL6hEogqATXJzbmaXx3zp21nRgyxYh+ykR1AA==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@babel/core': 7.26.0

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -126,8 +126,6 @@ type EnableAnalyticsConfig = {
 	options: {
 		ajaxUrl: string;
 		pv: string;
-		enableV2Endpoint: boolean;
-		ajaxUrlV2: string;
 	};
 };
 
@@ -454,12 +452,10 @@ const initialise = (
 			{
 				provider: 'gu',
 				options: {
-					ajaxUrl: window.guardian.config.page.ajaxUrl ?? '',
-					pv: window.guardian.ophan.pageViewId,
-					enableV2Endpoint: true,
-					ajaxUrlV2: window.guardian.config.page.isDev
+					ajaxUrl: window.guardian.config.page.isDev
 						? `//performance-events.code.dev-guardianapis.com/header-bidding`
 						: `//performance-events.guardianapis.com/header-bidding`,
+					pv: window.guardian.ophan.pageViewId,
 				},
 			},
 		]);


### PR DESCRIPTION
## What does this change?
Stop logging to both endpoints and just log to the new endpoint that's been receiving 100% of data as of #1676

## Why?
The new endpoint has been working great over the last few weeks.

See https://github.com/guardian/gcp-iac-terraform/pull/984 for details.