### PR TITLE
Add `plcmt` to IMA targeting

### DIFF
--- a/.changeset/tidy-grapes-judge.md
+++ b/.changeset/tidy-grapes-judge.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Add `plcmt` targeting to Youtube IMA targeting

--- a/src/core/targeting/youtube-ima.spec.ts
+++ b/src/core/targeting/youtube-ima.spec.ts
@@ -35,7 +35,7 @@ describe('Builds an IMA ad tag URL', () => {
 			isSignedIn: true,
 		});
 		expect(adTagURL).toEqual(
-			'https://securepubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&description_url=https%3A%2F%2Fwww.theguardian.com%2Fsport%2Fvideo%2F2024%2Foct%2F10%2Ftennis-rafael-nadal-announces-retirement&cust_params=at%3DadTestValue',
+			'https://securepubads.g.doubleclick.net/gampad/ads?iu=someAdUnit&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&plcmt=1&description_url=https%3A%2F%2Fwww.theguardian.com%2Fsport%2Fvideo%2F2024%2Foct%2F10%2Ftennis-rafael-nadal-announces-retirement&cust_params=at%3DadTestValue',
 		);
 	});
 	it('encodes custom parameters', () => {
@@ -60,7 +60,7 @@ describe('Builds an IMA ad tag URL', () => {
 		expect(adTagURL).toEqual(
 			// this is a real ad tag url that you can paste into Google's VAST tag checker:
 			// https://googleads.github.io/googleads-ima-html5/vsi/
-			'https://securepubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&description_url=https%3A%2F%2Fwww.theguardian.com%2Fsport%2Fvideo%2F2024%2Foct%2F10%2Ftennis-rafael-nadal-announces-retirement&cust_params=param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%252Chello4%26param6%3D%253D%2526%252C%26at%3Dfixed-puppies%26encodeMe%3D%253D%2526%252C',
+			'https://securepubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&plcmt=1&description_url=https%3A%2F%2Fwww.theguardian.com%2Fsport%2Fvideo%2F2024%2Foct%2F10%2Ftennis-rafael-nadal-announces-retirement&cust_params=param1%3Dhello1%26param2%3Dhello2%26param3%3Dhello3%252Chello4%26param6%3D%253D%2526%252C%26at%3Dfixed-puppies%26encodeMe%3D%253D%2526%252C',
 		);
 	});
 	it('uses provided custom parameters if page targeting throws an exception', () => {
@@ -77,7 +77,7 @@ describe('Builds an IMA ad tag URL', () => {
 			isSignedIn: true,
 		});
 		expect(adTagURL).toEqual(
-			'https://securepubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&description_url=https%3A%2F%2Fwww.theguardian.com%2Fsport%2Fvideo%2F2024%2Foct%2F10%2Ftennis-rafael-nadal-announces-retirement&cust_params=param1%3Dhello1',
+			'https://securepubads.g.doubleclick.net/gampad/ads?iu=/59666047/theguardian.com&tfcd=0&npa=0&sz=480x360|480x361|400x300&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&vad_type=linear&vpos=preroll&plcmt=1&description_url=https%3A%2F%2Fwww.theguardian.com%2Fsport%2Fvideo%2F2024%2Foct%2F10%2Ftennis-rafael-nadal-announces-retirement&cust_params=param1%3Dhello1',
 		);
 	});
 });

--- a/src/core/targeting/youtube-ima.ts
+++ b/src/core/targeting/youtube-ima.ts
@@ -85,6 +85,7 @@ const buildImaAdTagUrl = ({
 		impl: 's',
 		vad_type: 'linear',
 		vpos: 'preroll',
+		plcmt: '1',
 		description_url: encodeURIComponent(
 			`${window.guardian.config.page.host}/${window.guardian.config.page.pageId}`,
 		),


### PR DESCRIPTION
## What does this change?
Add `plcmt` to IMA targeting

## Why?
This is a new-ish parameter required for video ads - https://support.google.com/admanager/answer/10655276?ref_topic=10684636&sjid=18321668743419539961-EU#plcmt

This also needs to be done for outstream ads but we're unsure about implementation details, we're asking google for clarification.