### PR TITLE
Add amIUsed calls to see if modules are still needed

### DIFF
--- a/.changeset/pretty-feet-worry.md
+++ b/.changeset/pretty-feet-worry.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Add amIUsed logs for old frontend modules

--- a/src/insert/article-aside-adverts.ts
+++ b/src/insert/article-aside-adverts.ts
@@ -1,3 +1,4 @@
+import { amIUsed } from '../utils/am-i-used';
 import fastdom from '../utils/fastdom-promise';
 
 const minArticleHeight = 1300;
@@ -59,6 +60,9 @@ export const init = (): Promise<void | boolean> => {
 		return Promise.resolve(false);
 	}
 
+	// logging to see if this code gets used at all
+	amIUsed('article-aside-adverts.ts', 'init');
+
 	return fastdom
 		.measure(() => {
 			const immersiveElementOffset = getTopOffset(immersiveEls[0]);
@@ -80,6 +84,8 @@ export const init = (): Promise<void | boolean> => {
 				window.guardian.config.page.isImmersive &&
 				immersiveEls.length > 0
 			) {
+				// logging to see if this conditional block is being fired
+				amIUsed('article-aside-adverts.ts', 'immersive adjustments');
 				return fastdom.mutate(() => {
 					removeStickyClasses(adSlotsWithinRightCol);
 					adSlotsWithinRightCol[0]?.setAttribute(
@@ -92,6 +98,11 @@ export const init = (): Promise<void | boolean> => {
 			// most articles are long enough to fit a DMPU. However, the occasional shorter article
 			// will need the slot sizes to be adjusted, and the sticky behaviour removed.
 			if (mainColHeight < minArticleHeight) {
+				// logging to see if this conditional block is being fired
+				amIUsed(
+					'article-aside-adverts.ts',
+					'short article adjustments',
+				);
 				return fastdom.mutate(() => {
 					removeStickyClasses(adSlotsWithinRightCol);
 					adSlotsWithinRightCol[0]?.setAttribute(

--- a/src/insert/high-merch.ts
+++ b/src/insert/high-merch.ts
@@ -1,5 +1,6 @@
 import { createAdSlot, wrapSlotInContainer } from '../core/create-ad-slot';
 import { commercialFeatures } from '../lib/commercial-features';
+import { amIUsed } from '../utils/am-i-used';
 import fastdom from '../utils/fastdom-promise';
 
 /**
@@ -23,6 +24,7 @@ export const init = (): Promise<void> => {
 		// \Remove this
 		return fastdom.mutate(() => {
 			if (anchor?.parentNode) {
+				amIUsed('high-merch.ts', 'valid anchor');
 				anchor.parentNode.insertBefore(container, anchor);
 			}
 		});


### PR DESCRIPTION
## What does this change?
Adds `amIUsed` calls to see if some modules we have to handle ads on frontend are still needed. Also does some more granular logging in `article-aside-adverts` to see if both conditional blocks are still needed, in case we might be able to reduce the code down.

## Why?
We last checked these modules a couple of years ago and we've had more migrations since, so we're checking if these bits of code are still needed.