### PR TITLE
Sample prebid analytics at 10%

### DIFF
--- a/.changeset/polite-ghosts-guess.md
+++ b/.changeset/polite-ghosts-guess.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Sample prebid analytics at 10%

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -8,7 +8,7 @@ import { PREBID_TIMEOUT } from '../../../core/constants/prebid-timeout';
 import { EventTimer } from '../../../core/event-timer';
 import type { PageTargeting } from '../../../core/targeting/build-page-targeting';
 import type { Advert } from '../../../define/Advert';
-import { isUserInVariant } from '../../../experiments/ab';
+import { getParticipations, isUserInVariant } from '../../../experiments/ab';
 import { gpidPrebidAdUnits } from '../../../experiments/tests/gpid-prebid';
 import { getPageTargeting } from '../../build-page-targeting';
 import { getAdvertById } from '../../dfp/get-advert-by-id';
@@ -266,6 +266,16 @@ declare global {
 	}
 }
 
+const shouldEnableAnalytics = (): boolean => {
+	const analyticsSampleRate = 10 / 100;
+	const isInSample = Math.random() < analyticsSampleRate;
+
+	const isInServerSideTest =
+		Object.keys(window.guardian.config.tests ?? {}).length > 0;
+	const isInClientSideTest = Object.keys(getParticipations()).length > 0;
+	return isInServerSideTest || isInClientSideTest || isInSample;
+};
+
 /**
  * Prebid supports an additional timeout buffer to account for noisiness in
  * timing JavaScript on the page. This value is passed to the Prebid config
@@ -447,7 +457,10 @@ const initialise = (
 		});
 	}
 
-	if (window.guardian.config.switches.prebidAnalytics) {
+	if (
+		window.guardian.config.switches.prebidAnalytics &&
+		shouldEnableAnalytics()
+	) {
 		window.pbjs.enableAnalytics([
 			{
 				provider: 'gu',


### PR DESCRIPTION
## What does this change?
Sample prebid analytics unless in a test

## Why?
There's no sampling at the moment, 100% of analytics are sent and recorded, this is a huge amount as there is a prebid auction every time an ad is displayed on the page.

We asked D&I if we could sample these which will reduce the amount of requests in users browsers and amount of data generated that needs processing, and they have said that 10% would be enough to be able to perform analysis effectively.