### PR TITLE
Revert "Add amIUsed calls to see if modules are still needed"

### DIFF
--- a/src/insert/article-aside-adverts.ts
+++ b/src/insert/article-aside-adverts.ts
@@ -1,4 +1,3 @@
-import { amIUsed } from '../utils/am-i-used';
 import fastdom from '../utils/fastdom-promise';
 
 const minArticleHeight = 1300;
@@ -60,9 +59,6 @@ export const init = (): Promise<void | boolean> => {
 		return Promise.resolve(false);
 	}
 
-	// logging to see if this code gets used at all
-	amIUsed('article-aside-adverts.ts', 'init');
-
 	return fastdom
 		.measure(() => {
 			const immersiveElementOffset = getTopOffset(immersiveEls[0]);
@@ -84,8 +80,6 @@ export const init = (): Promise<void | boolean> => {
 				window.guardian.config.page.isImmersive &&
 				immersiveEls.length > 0
 			) {
-				// logging to see if this conditional block is being fired
-				amIUsed('article-aside-adverts.ts', 'immersive adjustments');
 				return fastdom.mutate(() => {
 					removeStickyClasses(adSlotsWithinRightCol);
 					adSlotsWithinRightCol[0]?.setAttribute(
@@ -98,11 +92,6 @@ export const init = (): Promise<void | boolean> => {
 			// most articles are long enough to fit a DMPU. However, the occasional shorter article
 			// will need the slot sizes to be adjusted, and the sticky behaviour removed.
 			if (mainColHeight < minArticleHeight) {
-				// logging to see if this conditional block is being fired
-				amIUsed(
-					'article-aside-adverts.ts',
-					'short article adjustments',
-				);
 				return fastdom.mutate(() => {
 					removeStickyClasses(adSlotsWithinRightCol);
 					adSlotsWithinRightCol[0]?.setAttribute(

--- a/src/insert/high-merch.ts
+++ b/src/insert/high-merch.ts
@@ -1,6 +1,5 @@
 import { createAdSlot, wrapSlotInContainer } from '../core/create-ad-slot';
 import { commercialFeatures } from '../lib/commercial-features';
-import { amIUsed } from '../utils/am-i-used';
 import fastdom from '../utils/fastdom-promise';
 
 /**
@@ -24,7 +23,6 @@ export const init = (): Promise<void> => {
 		// \Remove this
 		return fastdom.mutate(() => {
 			if (anchor?.parentNode) {
-				amIUsed('high-merch.ts', 'valid anchor');
 				anchor.parentNode.insertBefore(container, anchor);
 			}
 		});


### PR DESCRIPTION
Reverts guardian/commercial#1726

We've got a few hours of data now, and having queried BigQuery, `high-merch.ts` is still being used by galleries, but there are no entries for `article-aside-adverts.ts`, so we can delete that in a follow up PR.