### PR TITLE
Remove Sonobi SSP from Prebid Configuration

### DIFF
--- a/.changeset/warm-donuts-yawn.md
+++ b/.changeset/warm-donuts-yawn.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+removes sonobi ssr from prebid configuaration

--- a/src/lib/header-bidding/prebid-types.ts
+++ b/src/lib/header-bidding/prebid-types.ts
@@ -42,15 +42,6 @@ export type PrebidOzoneParams = {
 	ozoneData?: Record<string, unknown>;
 };
 
-export type PrebidSonobiParams = {
-	ad_unit: string;
-	dom_id: string;
-	appNexusTargeting: string;
-	pageViewId: string;
-	keywords: string[];
-	render?: string;
-};
-
 export type PrebidPubmaticParams = {
 	publisherId: string;
 	adSlot: string;
@@ -134,7 +125,6 @@ export type BidderCode =
 	| 'oxd'
 	| 'ozone'
 	| 'pubmatic'
-	| 'sonobi'
 	| 'triplelift'
 	| 'trustx'
 	| 'xhb';
@@ -150,7 +140,6 @@ export type PrebidParams =
 	| PrebidOpenXParams
 	| PrebidOzoneParams
 	| PrebidPubmaticParams
-	| PrebidSonobiParams
 	| PrebidTripleLiftParams
 	| PrebidTrustXParams
 	| PrebidXaxisParams;

--- a/src/lib/header-bidding/prebid/appnexus.spec.ts
+++ b/src/lib/header-bidding/prebid/appnexus.spec.ts
@@ -56,7 +56,6 @@ const resetConfig = () => {
 		prebidOpenx: true,
 		prebidImproveDigital: true,
 		prebidIndexExchange: true,
-		prebidSonobi: true,
 		prebidTrustx: true,
 		prebidXaxis: true,
 		prebidAdYouLike: true,

--- a/src/lib/header-bidding/prebid/bid-config.spec.ts
+++ b/src/lib/header-bidding/prebid/bid-config.spec.ts
@@ -1,5 +1,6 @@
 import { createAdSize } from '../../../core/ad-sizes';
 import type { PageTargeting } from '../../../core/targeting/build-page-targeting';
+import { isUserInVariant as isUserInVariant_ } from '../../../experiments/ab';
 import {
 	isInAuOrNz as isInAuOrNz_,
 	isInRow as isInRow_,
@@ -67,6 +68,7 @@ const shouldIncludeXaxis = shouldIncludeXaxis_ as jest.Mock;
 const shouldIncludeTripleLift = shouldIncludeTripleLift_ as jest.Mock;
 const stripMobileSuffix = stripMobileSuffix_ as jest.Mock;
 const getBreakpointKey = getBreakpointKey_ as jest.Mock;
+const isUserInVariant = isUserInVariant_ as jest.Mock;
 
 jest.mock('lib/geo/geo-utils');
 const isInAuOrNz = isInAuOrNz_ as jest.Mock;
@@ -306,6 +308,16 @@ describe('bids', () => {
 		setQueryString('pbtest=xhb');
 		shouldIncludeXaxis.mockReturnValue(false);
 		expect(getBidders()).toEqual(['xhb']);
+	});
+
+	test('should only include multiple bidders being tested, even when their switches are off', () => {
+		setQueryString('pbtest=xhb&pbtest=adyoulike');
+		isUserInVariant.mockImplementation(
+			(testId, variantId) => variantId === 'variant',
+		);
+		window.guardian.config.switches.prebidXaxis = false;
+		window.guardian.config.switches.prebidAdYouLike = false;
+		expect(getBidders()).toEqual(['xhb', 'adyoulike']); // Ensure 'xhb' and 'and' are the correct codes for prebidXaxis and prebidAppnexus
 	});
 
 	test('should ignore bidder that does not exist', () => {

--- a/src/lib/header-bidding/prebid/bid-config.spec.ts
+++ b/src/lib/header-bidding/prebid/bid-config.spec.ts
@@ -1,6 +1,5 @@
 import { createAdSize } from '../../../core/ad-sizes';
 import type { PageTargeting } from '../../../core/targeting/build-page-targeting';
-import { isUserInVariant as isUserInVariant_ } from '../../../experiments/ab';
 import {
 	isInAuOrNz as isInAuOrNz_,
 	isInRow as isInRow_,
@@ -21,7 +20,6 @@ import {
 	shouldIncludeAppNexus as shouldIncludeAppNexus_,
 	shouldIncludeImproveDigital as shouldIncludeImproveDigital_,
 	shouldIncludeOpenx as shouldIncludeOpenx_,
-	shouldIncludeSonobi as shouldIncludeSonobi_,
 	shouldIncludeTripleLift as shouldIncludeTripleLift_,
 	shouldIncludeTrustX as shouldIncludeTrustX_,
 	shouldIncludeXaxis as shouldIncludeXaxis_,
@@ -66,11 +64,9 @@ const shouldIncludeImproveDigital = shouldIncludeImproveDigital_ as jest.Mock;
 const shouldIncludeOpenx = shouldIncludeOpenx_ as jest.Mock;
 const shouldIncludeTrustX = shouldIncludeTrustX_ as jest.Mock;
 const shouldIncludeXaxis = shouldIncludeXaxis_ as jest.Mock;
-const shouldIncludeSonobi = shouldIncludeSonobi_ as jest.Mock;
 const shouldIncludeTripleLift = shouldIncludeTripleLift_ as jest.Mock;
 const stripMobileSuffix = stripMobileSuffix_ as jest.Mock;
 const getBreakpointKey = getBreakpointKey_ as jest.Mock;
-const isUserInVariant = isUserInVariant_ as jest.Mock;
 
 jest.mock('lib/geo/geo-utils');
 const isInAuOrNz = isInAuOrNz_ as jest.Mock;
@@ -98,7 +94,6 @@ const resetConfig = () => {
 		prebidOpenx: true,
 		prebidImproveDigital: true,
 		prebidIndexExchange: true,
-		prebidSonobi: true,
 		prebidTrustx: true,
 		prebidXaxis: true,
 		prebidAdYouLike: true,
@@ -271,11 +266,6 @@ describe('bids', () => {
 		expect(getBidders()).toEqual(['criteo', 'adyoulike']);
 	});
 
-	test('should include Sonobi if in target geolocation', () => {
-		shouldIncludeSonobi.mockReturnValue(true);
-		expect(getBidders()).toEqual(['ix', 'criteo', 'sonobi', 'adyoulike']);
-	});
-
 	test('should include AppNexus directly if in target geolocation', () => {
 		shouldIncludeAppNexus.mockReturnValue(true);
 		expect(getBidders()).toEqual(['ix', 'criteo', 'and', 'adyoulike']);
@@ -316,16 +306,6 @@ describe('bids', () => {
 		setQueryString('pbtest=xhb');
 		shouldIncludeXaxis.mockReturnValue(false);
 		expect(getBidders()).toEqual(['xhb']);
-	});
-
-	test('should only include multiple bidders being tested, even when their switches are off', () => {
-		setQueryString('pbtest=xhb&pbtest=sonobi');
-		isUserInVariant.mockImplementation(
-			(testId, variantId) => variantId === 'variant',
-		);
-		window.guardian.config.switches.prebidXaxis = false;
-		window.guardian.config.switches.prebidSonobi = false;
-		expect(getBidders()).toEqual(['sonobi', 'xhb']);
 	});
 
 	test('should ignore bidder that does not exist', () => {

--- a/src/lib/header-bidding/prebid/bid-config.ts
+++ b/src/lib/header-bidding/prebid/bid-config.ts
@@ -10,10 +10,7 @@ import {
 import { pbTestNameMap } from '../../../lib/url';
 import type { PrebidIndexSite } from '../../../types/global';
 import { dfpEnv } from '../../dfp/dfp-env';
-import {
-	buildAppNexusTargeting,
-	buildAppNexusTargetingObject,
-} from '../../page-targeting';
+import { buildAppNexusTargetingObject } from '../../page-targeting';
 import type {
 	BidderCode,
 	HeaderBiddingSize,
@@ -28,7 +25,6 @@ import type {
 	PrebidOpenXParams,
 	PrebidOzoneParams,
 	PrebidPubmaticParams,
-	PrebidSonobiParams,
 	PrebidTripleLiftParams,
 	PrebidTrustXParams,
 	PrebidXaxisParams,
@@ -51,7 +47,6 @@ import {
 	shouldIncludeKargo,
 	shouldIncludeMagnite,
 	shouldIncludeOpenx,
-	shouldIncludeSonobi,
 	shouldIncludeTripleLift,
 	shouldIncludeTrustX,
 	shouldIncludeXaxis,
@@ -337,22 +332,6 @@ const ozoneClientSideBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
 			ozoneData: {}, // TODO: confirm if we need to send any
 		};
 	},
-});
-
-const sonobiBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
-	pageTargeting: PageTargeting,
-) => ({
-	name: 'sonobi',
-	switchName: 'prebidSonobi',
-	bidParams: (slotId: string): PrebidSonobiParams => ({
-		ad_unit: window.guardian.config.page.adUnit,
-		dom_id: slotId,
-		appNexusTargeting: buildAppNexusTargeting(pageTargeting),
-		pageViewId: window.guardian.ophan.pageViewId,
-		keywords: window.guardian.config.page.keywords
-			? window.guardian.config.page.keywords.split(',')
-			: [],
-	}),
 });
 
 const getPubmaticPublisherId = (): string => {
@@ -681,7 +660,6 @@ const currentBidders = (
 ): PrebidBidder[] => {
 	const biddersToCheck: Array<[boolean, PrebidBidder]> = [
 		[true, criteoBidder(slotSizes)],
-		[shouldIncludeSonobi(), sonobiBidder(pageTargeting)],
 		[shouldIncludeTrustX(), trustXBidder],
 		[shouldIncludeTripleLift(), tripleLiftBidder],
 		[shouldIncludeAppNexus(), appNexusBidder(pageTargeting)],

--- a/src/lib/header-bidding/prebid/prebid.spec.ts
+++ b/src/lib/header-bidding/prebid/prebid.spec.ts
@@ -33,7 +33,6 @@ describe('initialise', () => {
 		window.guardian.config.switches.consentManagement = true;
 		window.guardian.config.switches.prebidUserSync = true;
 		window.guardian.config.switches.prebidAppNexus = true;
-		window.guardian.config.switches.prebidSonobi = true;
 		window.guardian.config.switches.prebidXaxis = true;
 		getAdvertById.mockReset();
 	});

--- a/src/lib/header-bidding/utils.spec.ts
+++ b/src/lib/header-bidding/utils.spec.ts
@@ -16,7 +16,6 @@ import {
 	shouldIncludeImproveDigital,
 	shouldIncludeMobileSticky,
 	shouldIncludeOpenx,
-	shouldIncludeSonobi,
 	shouldIncludeTrustX,
 	shouldIncludeXaxis,
 	stripDfpAdPrefixFrom,
@@ -60,7 +59,6 @@ const resetConfig = () => {
 	window.guardian.config.switches.prebidOpenx = true;
 	window.guardian.config.switches.prebidImproveDigital = true;
 	window.guardian.config.switches.prebidIndexExchange = true;
-	window.guardian.config.switches.prebidSonobi = true;
 	window.guardian.config.switches.prebidTrustx = true;
 	window.guardian.config.switches.prebidXaxis = true;
 	window.guardian.config.switches.prebidAdYouLike = true;
@@ -259,30 +257,6 @@ describe('Utils', () => {
 		for (const testGeo of testGeos) {
 			getCountryCode.mockReturnValue(testGeo);
 			expect(shouldIncludeXaxis()).toBe(false);
-		}
-	});
-
-	test('shouldIncludeSonobi should return true if geolocation is US', () => {
-		const testGeos: CountryCode[] = ['US', 'CA'];
-		for (const testGeo of testGeos) {
-			getCountryCode.mockReturnValueOnce(testGeo);
-			expect(shouldIncludeSonobi()).toBe(true);
-		}
-	});
-
-	test('shouldIncludeSonobi should otherwise return false', () => {
-		const testGeos: CountryCode[] = [
-			'FK',
-			'GI',
-			'GG',
-			'IM',
-			'JE',
-			'SH',
-			'AU',
-		];
-		for (const testGeo of testGeos) {
-			getCountryCode.mockReturnValueOnce(testGeo);
-			expect(shouldIncludeSonobi()).toBe(false);
 		}
 	});
 

--- a/src/lib/header-bidding/utils.ts
+++ b/src/lib/header-bidding/utils.ts
@@ -157,8 +157,6 @@ export const getRandomIntInclusive = (
 	return Math.floor(Math.random() * (max - min + 1)) + min;
 };
 
-export const shouldIncludeSonobi = (): boolean => isInUsOrCa();
-
 export const shouldIncludeOpenx = (): boolean => !isInUsOrCa();
 
 export const shouldIncludeTrustX = (): boolean => isInUsOrCa();


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
This PR removes the Sonobi SSR (Server-Side Rendering) integration from the Prebid configuration. The following changes have been made to achieve this:

1. **Removed Sonobi Bidder Configuration:**
Deleted all references to the Sonobi bidder from the Prebid configuration files.
Removed Sonobi-specific parameters and targeting logic.

2. **Updated Bidder Imports:**
Removed Sonobi-related imports from the relevant modules.

3. **Cleaned Up Bidder Code:**
Ensured that any Sonobi-specific code, including bid requests and response handling, has been removed.

4. **Updated Documentation:**
Updated any relevant documentation to reflect the removal of the Sonobi bidder.## Why?
Sonobi has been determined to be not be worthwhile supporting. Let’s remove the SSP and all associated code.

## Why?
Sonobi has been determined to be not be worthwhile supporting. 
The Sonobi bidder was previously configured to participate in the header bidding process via Prebid.
This PR ensures that Sonobi is no longer included in the bid requests or responses.
The removal of Sonobi simplifies the Prebid configuration and reduces the overall complexity of the header bidding setup.


### Testing:
- Verified that the Prebid configuration works correctly without the Sonobi bidder.
- Ensured that other bidders continue to function as expected.
- Conducted end-to-end tests to confirm that ads are served correctly without Sonobi.