### PR TITLE
extend expiry of gpid test to end of January

### DIFF
--- a/src/experiments/tests/gpid-prebid.ts
+++ b/src/experiments/tests/gpid-prebid.ts
@@ -4,7 +4,7 @@ export const gpidPrebidAdUnits: ABTest = {
 	id: 'GpidPrebidAdUnits',
 	author: '@commercial-dev',
 	start: '2024-11-15',
-	expiry: '2024-12-22',
+	expiry: '2024-1-31',
 	audience: 2 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
This PR extends the expiry of the GPID test to the end of January. Associated with PR: https://github.com/guardian/commercial/pull/1651


## Why?
To collate more meaningful data from the experiment.