### PR TITLE
Add an error message if we can't pull DCR container image

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -53,6 +53,7 @@ jobs:
       # This makes the commercial dev server available from inside the container
       # Note that GHA provides a service container feature, but it does not support this argument
       - name: Start DCR in a container
+        id: start-dcr-container
         run: |
           /usr/bin/docker run -d \
             --network host \
@@ -60,6 +61,10 @@ jobs:
             -e "PORT=3030" \
             -e "COMMERCIAL_BUNDLE_URL=http://localhost:3031/graun.standalone.commercial.js" \
             ghcr.io/guardian/dotcom-rendering:main
+
+      - name: Start DCR in a container step failed
+        if: ${{ failure() && steps.start-dcr-container.conclusion == 'failure' }}
+        run: echo "Run the DCR main build in order to create a new container image."
 
       - name: Install Playwright Browsers
         run: pnpm playwright install --with-deps chromium


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR adds an error message to the Github Actions logs if we can't pull the DCR container image and the step is failed which means we need to rebuild DCR main to create a new image.

## Why?

We rarely fail this step because we can't pull the image from DCR due to no images https://github.com/guardian/commercial/actions/runs/11627393704/job/32380639973. It's hard to debug when the issue isn't ongoing so an error message will be sufficient until the issue happens again then we can debug.
