### PR TITLE
Fix ad speed benchmarking

### DIFF
--- a/playwright/benchmark/test-ad-load-time.spec.ts
+++ b/playwright/benchmark/test-ad-load-time.spec.ts
@@ -26,7 +26,7 @@ const interceptCommercial = (page: Page) =>
 			});
 		}
 		const body = await readFile(
-			resolve(`dist/bundle/prod/${path}`),
+			resolve(`dist/prod/artifacts/commercial/${path}`),
 			'utf-8',
 		);
 		await route.fulfill({


### PR DESCRIPTION
## What does this change?
This broke when changing to riff-raff deployment as the prod bundle build location has moved.

