### PR TITLE
Add keywords to pbjsConfig if user is in the prebidKeywords test

### DIFF
--- a/src/experiments/ab-tests.ts
+++ b/src/experiments/ab-tests.ts
@@ -2,6 +2,7 @@ import type { ABTest } from '@guardian/ab-core';
 import { gpidPrebidAdUnits } from './tests/gpid-prebid';
 import { mpuWhenNoEpic } from './tests/mpu-when-no-epic';
 import { optOutFrequencyCap } from './tests/opt-out-frequency-cap';
+import { prebidKeywords } from './tests/prebid-keywords';
 import { regionSpecificPrebid } from './tests/region-specific-prebid';
 
 /**
@@ -15,4 +16,5 @@ export const concurrentTests: ABTest[] = [
 	optOutFrequencyCap,
 	gpidPrebidAdUnits,
 	regionSpecificPrebid,
+	prebidKeywords,
 ];

--- a/src/experiments/tests/prebid-keywords.ts
+++ b/src/experiments/tests/prebid-keywords.ts
@@ -1,0 +1,29 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const prebidKeywords: ABTest = {
+	id: 'PrebidKeywords',
+	author: '@commercial-dev',
+	start: '2025-01-14',
+	expiry: '2025-01-31',
+	audience: 50 / 100,
+	audienceOffset: 20 / 100,
+	audienceCriteria: '',
+	successMeasure: '',
+	description:
+		'Test if adding keywords to our Prebid config affects revenue.',
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+	canRun: () => true,
+};

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -10,6 +10,7 @@ import type { PageTargeting } from '../../../core/targeting/build-page-targeting
 import type { Advert } from '../../../define/Advert';
 import { getParticipations, isUserInVariant } from '../../../experiments/ab';
 import { gpidPrebidAdUnits } from '../../../experiments/tests/gpid-prebid';
+import { prebidKeywords } from '../../../experiments/tests/prebid-keywords';
 import { getAdvertById } from '../../dfp/get-advert-by-id';
 import { isUserLoggedInOktaRefactor } from '../../identity/api';
 import { getPageTargeting } from '../../page-targeting';
@@ -88,6 +89,11 @@ type PbjsConfig = {
 	timeoutBuffer?: number;
 	priceGranularity: PrebidPriceGranularity;
 	userSync: UserSync;
+	ortb2?: {
+		site: {
+			keywords: string;
+		};
+	};
 	consentManagement?: ConsentManagement;
 	realTimeData?: unknown;
 	criteo?: {
@@ -363,6 +369,17 @@ const initialise = (
 			userSync,
 		},
 	);
+
+	const shouldIncludeKeywords = isUserInVariant(prebidKeywords, 'variant');
+	const keywords = window.guardian.config.page.keywords;
+
+	if (shouldIncludeKeywords) {
+		pbjsConfig.ortb2 = {
+			site: {
+				keywords,
+			},
+		};
+	}
 
 	window.pbjs.bidderSettings = {};
 


### PR DESCRIPTION
## What does this change?
Adds page keywords to the Prebid config following the docs [here](https://docs.prebid.org/features/firstPartyData.html#:~:text=hints%20are%20used.-,Supplying%20Global%20Data,-Here%E2%80%99s%20how%20a).

The change has been added behind a 50% test so that we can measure any impact this may have on revenue. I've offset the test to make sure that it doesn't overlap with the RegionSpecificPrebid test.

## Why?
We want to try adding keywords to our Prebid config to help make sure programmatic ads can target our pages properly. Our current implementation for adding keywords for Magnite is out of date for our current Prebid version, so we need to update how we do this.

Once the test is complete, if we want to go ahead with adding keywords this way, we can remove the current keyword implementation for Magnite.

## Screenshots
### Not in the test
<img width="534" alt="Screenshot 2025-01-15 at 10 48 15" src="https://github.com/user-attachments/assets/a703bc2d-cf4a-452a-81ca-44243bc7edef" />


### In the test
<img width="690" alt="Screenshot 2025-01-15 at 10 51 16" src="https://github.com/user-attachments/assets/65f7fb78-357d-4750-a07a-cfe32fac0021" />
