### PR TITLE
Also add keywords to site.ext.data

### DIFF
--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -92,6 +92,11 @@ type PbjsConfig = {
 	ortb2?: {
 		site: {
 			keywords: string;
+			ext: {
+				data: {
+					keywords: string[];
+				};
+			};
 		};
 	};
 	consentManagement?: ConsentManagement;
@@ -371,12 +376,20 @@ const initialise = (
 	);
 
 	const shouldIncludeKeywords = isUserInVariant(prebidKeywords, 'variant');
-	const keywords = window.guardian.config.page.keywords;
+	const keywordsString = window.guardian.config.page.keywords;
+	const keywordsArray = window.guardian.config.page.keywords
+		? window.guardian.config.page.keywords.split(',')
+		: [];
 
 	if (shouldIncludeKeywords) {
 		pbjsConfig.ortb2 = {
 			site: {
-				keywords,
+				keywords: keywordsString,
+				ext: {
+					data: {
+						keywords: keywordsArray,
+					},
+				},
 			},
 		};
 	}

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -377,9 +377,7 @@ const initialise = (
 
 	const shouldIncludeKeywords = isUserInVariant(prebidKeywords, 'variant');
 	const keywordsString = window.guardian.config.page.keywords;
-	const keywordsArray = keywordsString
-		? keywordsString.split(',')
-		: [];
+	const keywordsArray = keywordsString ? keywordsString.split(',') : [];
 
 	if (shouldIncludeKeywords) {
 		pbjsConfig.ortb2 = {

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -377,8 +377,8 @@ const initialise = (
 
 	const shouldIncludeKeywords = isUserInVariant(prebidKeywords, 'variant');
 	const keywordsString = window.guardian.config.page.keywords;
-	const keywordsArray = window.guardian.config.page.keywords
-		? window.guardian.config.page.keywords.split(',')
+	const keywordsArray = keywordsString
+		? keywordsString.split(',')
 		: [];
 
 	if (shouldIncludeKeywords) {


### PR DESCRIPTION
## What does this change?
Adds keywords as an array to `site.ext.data`. I'm adding it under the existing test so that we can measure the combined revenue impact.

<img width="670" alt="Screenshot 2025-01-15 at 16 48 08" src="https://github.com/user-attachments/assets/73b6e6ce-5997-435e-8aea-0debe1702987" />


## Why?
Magnite require the keywords to be sent via `site.ext.data` in order to use them for targeting.