### PR TITLE
Reduce prout cache control max age

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,7 +8,11 @@ deployments:
     type: aws-s3
     parameters:
       bucketSsmKey: /account/services/dotcom-static.bucket
-      cacheControl: '[{ "pattern": "^/commercial/prout", "value": "max-age=0" },{ "pattern": ".*", "value": "public, max-age=315360000, immutable"}]'
+      cacheControl:
+        - pattern: "^/commercial/prout"
+          value: "max-age=0"
+        - pattern": ".*"
+          value": "public, max-age=315360000, immutable"
       prefixStack: false
       publicReadAcl: false
   commercial-bundle-path:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,7 +8,7 @@ deployments:
     type: aws-s3
     parameters:
       bucketSsmKey: /account/services/dotcom-static.bucket
-      cacheControl: public, max-age=315360000, immutable
+      cacheControl: '[{ "pattern": "^/commercial/prout", "value": "max-age=0" },{ "pattern": ".*", "value": "public, max-age=315360000, immutable"}]'
       prefixStack: false
       publicReadAcl: false
   commercial-bundle-path:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,11 +8,7 @@ deployments:
     type: aws-s3
     parameters:
       bucketSsmKey: /account/services/dotcom-static.bucket
-      cacheControl:
-        - pattern: "^/commercial/prout"
-          value: "max-age=0"
-        - pattern": ".*"
-          value": "public, max-age=315360000, immutable"
+      cacheControl: [{ "pattern": "^/commercial/prout", "value": "max-age=0" },{ "pattern": ".*", "value": "public, max-age=315360000, immutable"}]
       prefixStack: false
       publicReadAcl: false
   commercial-bundle-path:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,7 +8,7 @@ deployments:
     type: aws-s3
     parameters:
       bucketSsmKey: /account/services/dotcom-static.bucket
-      cacheControl: [{ "pattern": "^/commercial/prout", "value": "max-age=0" },{ "pattern": ".*", "value": "public, max-age=315360000, immutable"}]
+      cacheControl: [{ "pattern": "/commercial/prout$", "value": "max-age=0" },{ "pattern": ".*", "value": "public, max-age=315360000, immutable"}]
       prefixStack: false
       publicReadAcl: false
   commercial-bundle-path:


### PR DESCRIPTION
## What does this change?
Configure riff-raff to set the max-age of the prout file to 0

Checked on CODE:
prout file
![Screenshot 2025-01-17 at 10 37 40](https://github.com/user-attachments/assets/8f35ea2f-6980-48d4-afcd-4bdb9b15b657)

All other files still have very large max-age

And curl:
```
> curl -I https://assets-code.guim.co.uk/commercial/prout
HTTP/2 200
x-amz-id-2: TG5pKLzK0faqoebnXK8armIsUvY71SwKZP/ux4z/xCw1TsnTAyHH4jn88+mGqZx+D4k2a5t7Z9KGRcxN1uyY9A==
x-amz-request-id: BMMZ56W5E3M1SATF
last-modified: Fri, 17 Jan 2025 10:34:07 GMT
etag: "5bfbe965af71978abdbd50d7dae58c61"
x-amz-server-side-encryption: AES256
cache-control: max-age=0
x-amz-version-id: JrmuvoRqyHwdYH4.zE23dk9719WvJwhK
content-type: application/octet-stream
server: AmazonS3
fastly-restarts: 1
accept-ranges: bytes
date: Fri, 17 Jan 2025 10:58:27 GMT
via: 1.1 varnish
age: 0
x-served-by: cache-lhr-egll1980087-LHR
x-cache: MISS
x-cache-hits: 0
x-timer: S1737111507.463207,VS0,VE49
access-control-allow-credentials: true
access-control-allow-origin: *
strict-transport-security: max-age=31536000
x-gu-debug-url: /CODE/frontend-static/commercial/prout
content-length: 71
```

## Why?
 So that prout-bot can be sure to see the up to date commit hash.