### PR TITLE
Update husky command in prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"lint": "eslint .",
 		"lint-staged": "lint-staged",
 		"precommit:lint": "npm-run-all lint-staged",
-		"prepare": "husky install",
+		"prepare": "husky",
 		"prepush:test": "jest --verbose --runInBand --onlyChanged",
 		"prettier:check": "prettier . --check --cache",
 		"prettier:fix": "prettier . --write --cache",


### PR DESCRIPTION
## What does this change?

Updates `prepare` script from `husky install` to `husky`

## Why?

`husky install` is deprecated

<img width="531" alt="Screenshot 2025-01-21 at 11 12 34" src="https://github.com/user-attachments/assets/8d7bfbe3-92c1-4653-b550-d729e832e2ea" />

See https://github.com/typicode/husky/releases/tag/v9.0.1