### PR TITLE
Increase margin for most viewed on Showcase articles

### DIFF
--- a/.changeset/thick-camels-grin.md
+++ b/.changeset/thick-camels-grin.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Increase the margin for inline2 to avoid most viewed by for showcase articles or articles with a video at the top

--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -102,7 +102,7 @@ const desktopRightRailMinAbove = (isConsentless: boolean) => {
 	}
 
 	if (hasShowcaseMainElement || (!hasImages && hasVideo)) {
-		return base + 100;
+		return base + 250;
 	}
 	return base;
 };


### PR DESCRIPTION
## What does this change?
Increases the margin added to the base value for the inline2 min above on showcase articles or articles that have video as the main media.

## Why?
A few long headlines in the Most Viewed component caused inline2 to overlap with Most Viewed on one article. Increasing the value of this margin eliminates the overlap.

I have added a ticket to Trello to investigate if we can handle this better, we do a few too many of these types of PRs!

## Screenshots
| Before      | After      |
| ------------- | ------------- |
| <img width="416" alt="Screenshot 2025-01-22 at 15 47 13" src="https://github.com/user-attachments/assets/79593746-66d7-4f6d-b5a6-d56b38bbb00a" /> | <img width="345" alt="Screenshot 2025-01-22 at 16 47 32" src="https://github.com/user-attachments/assets/d2d363be-9add-4900-98c4-554958f61eb3" /> |
