### PR TITLE
Swap out deprecated jest functions

### DIFF
--- a/src/define/Advert.spec.ts
+++ b/src/define/Advert.spec.ts
@@ -90,7 +90,7 @@ describe('Advert', () => {
 		slot.setAttribute('data-name', 'top-above-nav');
 		const ad = new Advert(slot);
 		expect(ad).toBeDefined();
-		expect(googleSlot.setSafeFrameConfig).toBeCalledWith({
+		expect(googleSlot.setSafeFrameConfig).toHaveBeenCalledWith({
 			allowOverlayExpansion: false,
 			allowPushExpansion: true,
 			sandbox: true,
@@ -102,7 +102,7 @@ describe('Advert', () => {
 		slot.setAttribute('data-name', 'inline1');
 		const ad = new Advert(slot);
 		expect(ad).toBeDefined();
-		expect(googleSlot.setSafeFrameConfig).toBeCalledWith({
+		expect(googleSlot.setSafeFrameConfig).toHaveBeenCalledWith({
 			allowOverlayExpansion: false,
 			allowPushExpansion: true,
 			sandbox: true,
@@ -114,7 +114,7 @@ describe('Advert', () => {
 		slot.setAttribute('data-name', 'inline2');
 		const ad = new Advert(slot);
 		expect(ad).toBeDefined();
-		expect(googleSlot.setSafeFrameConfig).not.toBeCalled();
+		expect(googleSlot.setSafeFrameConfig).not.toHaveBeenCalled();
 	});
 
 	it('should throw an error if no size mappings are found or passed in', () => {

--- a/src/init/consented/comscore.spec.ts
+++ b/src/init/consented/comscore.spec.ts
@@ -103,14 +103,14 @@ describe('setupComscore', () => {
 	it('should do nothing if the comscore is disabled in commercial features', async () => {
 		commercialFeatures.comscore = false;
 		await setupComscore();
-		expect(onConsent).not.toBeCalled();
+		expect(onConsent).not.toHaveBeenCalled();
 	});
 
 	it('should register a callback with onConsentChange if enabled in commercial features', async () => {
 		mockOnConsent(tcfv2WithConsent);
 		commercialFeatures.comscore = true;
 		await setupComscore();
-		expect(onConsent).toBeCalled();
+		expect(onConsent).toHaveBeenCalled();
 	});
 
 	describe('Framework consent: running on consent', () => {
@@ -122,37 +122,37 @@ describe('setupComscore', () => {
 			mockOnConsent(tcfv2WithConsent);
 			mockGetConsentFor(true);
 			await setupComscore();
-			expect(loadScript).toBeCalled();
+			expect(loadScript).toHaveBeenCalled();
 		});
 
 		it('TCFv2 without consent: does not run', async () => {
 			mockOnConsent(tcfv2WithoutConsent);
 			mockGetConsentFor(false);
 			await setupComscore();
-			expect(loadScript).not.toBeCalled();
+			expect(loadScript).not.toHaveBeenCalled();
 		});
 		it('USNAT with consent: runs', async () => {
 			mockOnConsent(usnatWithConsent);
 			await setupComscore();
-			expect(loadScript).toBeCalled();
+			expect(loadScript).toHaveBeenCalled();
 		});
 
 		it('USNAT without consent: does not run', async () => {
 			mockOnConsent(usnatWithoutConsent);
 			await setupComscore();
-			expect(loadScript).not.toBeCalled();
+			expect(loadScript).not.toHaveBeenCalled();
 		});
 
 		it('Aus without consent: runs', async () => {
 			mockOnConsent(AusWithoutConsent);
 			await setupComscore();
-			expect(loadScript).toBeCalled();
+			expect(loadScript).toHaveBeenCalled();
 		});
 
 		it('Aus with consent: runs', async () => {
 			mockOnConsent(AusWithConsent);
 			await setupComscore();
-			expect(loadScript).toBeCalled();
+			expect(loadScript).toHaveBeenCalled();
 		});
 	});
 });

--- a/src/init/consented/prepare-a9.spec.ts
+++ b/src/init/consented/prepare-a9.spec.ts
@@ -64,7 +64,7 @@ describe('init', () => {
 
 		await setupA9();
 
-		expect(a9.initialise).toBeCalled();
+		expect(a9.initialise).toHaveBeenCalled();
 	});
 
 	it('should NOT initialise A9 when in Canada', async () => {
@@ -77,7 +77,7 @@ describe('init', () => {
 
 		await setupA9();
 
-		expect(a9.initialise).not.toBeCalled();
+		expect(a9.initialise).not.toHaveBeenCalled();
 	});
 
 	it('should initialise A9 when both prebid and a9 switches are ON and advertising is on and ad-free is off', async () => {
@@ -87,13 +87,13 @@ describe('init', () => {
 		commercialFeatures.shouldLoadGoogletag = true;
 		commercialFeatures.adFree = false;
 		await setupA9();
-		expect(a9.initialise).toBeCalled();
+		expect(a9.initialise).toHaveBeenCalled();
 	});
 
 	it('should not initialise A9 when useragent is Google Web Preview', async () => {
 		fakeUserAgent('Google Web Preview');
 		await setupA9();
-		expect(a9.initialise).not.toBeCalled();
+		expect(a9.initialise).not.toHaveBeenCalled();
 	});
 
 	it('should not initialise A9 when no external demand', async () => {
@@ -101,7 +101,7 @@ describe('init', () => {
 			a9HeaderBidding: false,
 		};
 		await setupA9();
-		expect(a9.initialise).not.toBeCalled();
+		expect(a9.initialise).not.toHaveBeenCalled();
 	});
 
 	it('should not initialise a9 when advertising is switched off', async () => {
@@ -111,7 +111,7 @@ describe('init', () => {
 		commercialFeatures.shouldLoadGoogletag = false;
 		commercialFeatures.adFree = false;
 		await setupA9();
-		expect(a9.initialise).not.toBeCalled();
+		expect(a9.initialise).not.toHaveBeenCalled();
 	});
 
 	it('should not initialise a9 when ad-free is on', async () => {
@@ -121,7 +121,7 @@ describe('init', () => {
 		commercialFeatures.shouldLoadGoogletag = true;
 		commercialFeatures.adFree = true;
 		await setupA9();
-		expect(a9.initialise).not.toBeCalled();
+		expect(a9.initialise).not.toHaveBeenCalled();
 	});
 
 	it('should not initialise a9 when the page has a pageskin', async () => {
@@ -132,7 +132,7 @@ describe('init', () => {
 		commercialFeatures.adFree = false;
 		window.guardian.config.page.hasPageSkin = true;
 		await setupA9();
-		expect(a9.initialise).not.toBeCalled();
+		expect(a9.initialise).not.toHaveBeenCalled();
 	});
 
 	it('should initialise a9 when the page has no pageskin', async () => {
@@ -143,7 +143,7 @@ describe('init', () => {
 		commercialFeatures.adFree = false;
 		window.guardian.config.page.hasPageSkin = false;
 		await setupA9();
-		expect(a9.initialise).toBeCalled();
+		expect(a9.initialise).toHaveBeenCalled();
 	});
 
 	it('should not initialise a9 on the secure contact pages', async () => {
@@ -154,6 +154,6 @@ describe('init', () => {
 		commercialFeatures.adFree = false;
 		commercialFeatures.isSecureContact = true;
 		await setupA9();
-		expect(a9.initialise).not.toBeCalled();
+		expect(a9.initialise).not.toHaveBeenCalled();
 	});
 });

--- a/src/init/consented/prepare-prebid.spec.ts
+++ b/src/init/consented/prepare-prebid.spec.ts
@@ -161,7 +161,7 @@ describe('init', () => {
 		mockGetConsentFor(true);
 
 		await setupPrebid();
-		expect(prebid.initialise).toBeCalled();
+		expect(prebid.initialise).toHaveBeenCalled();
 	});
 
 	it('should not initialise Prebid when useragent is Google Web Preview', async () => {
@@ -176,7 +176,7 @@ describe('init', () => {
 		mockGetConsentFor(true);
 
 		await setupPrebid();
-		expect(prebid.initialise).not.toBeCalled();
+		expect(prebid.initialise).not.toHaveBeenCalled();
 	});
 
 	it('should not initialise Prebid when no header bidding switches are on', async () => {
@@ -191,7 +191,7 @@ describe('init', () => {
 		mockGetConsentFor(true);
 
 		await setupPrebid();
-		expect(prebid.initialise).not.toBeCalled();
+		expect(prebid.initialise).not.toHaveBeenCalled();
 	});
 
 	it('should initialise Prebid when NOT in Canada', async () => {
@@ -206,7 +206,7 @@ describe('init', () => {
 		mockGetConsentFor(true);
 
 		await setupPrebid();
-		expect(prebid.initialise).toBeCalled();
+		expect(prebid.initialise).toHaveBeenCalled();
 	});
 
 	it('should NOT initialise Prebid when in Canada', async () => {
@@ -222,7 +222,7 @@ describe('init', () => {
 		(isInCanada as jest.Mock).mockReturnValueOnce(true);
 
 		await setupPrebid();
-		expect(prebid.initialise).not.toBeCalled();
+		expect(prebid.initialise).not.toHaveBeenCalled();
 	});
 
 	it('should not initialise Prebid when advertising is switched off', async () => {
@@ -237,7 +237,7 @@ describe('init', () => {
 		mockGetConsentFor(true);
 
 		await setupPrebid();
-		expect(prebid.initialise).not.toBeCalled();
+		expect(prebid.initialise).not.toHaveBeenCalled();
 	});
 
 	it('should not initialise Prebid when ad-free is on', async () => {
@@ -252,7 +252,7 @@ describe('init', () => {
 		mockGetConsentFor(true);
 
 		await setupPrebid();
-		expect(prebid.initialise).not.toBeCalled();
+		expect(prebid.initialise).not.toHaveBeenCalled();
 	});
 
 	it('should not initialise Prebid when the page has a pageskin', async () => {
@@ -268,7 +268,7 @@ describe('init', () => {
 		mockGetConsentFor(true);
 
 		await setupPrebid();
-		expect(prebid.initialise).not.toBeCalled();
+		expect(prebid.initialise).not.toHaveBeenCalled();
 	});
 
 	it('should initialise Prebid when the page has no pageskin', async () => {
@@ -282,7 +282,7 @@ describe('init', () => {
 		mockGetConsentFor(true);
 
 		await setupPrebid();
-		expect(prebid.initialise).toBeCalled();
+		expect(prebid.initialise).toHaveBeenCalled();
 	});
 
 	it('should initialise Prebid if TCFv2 consent with correct Sourcepoint Id is true ', async () => {
@@ -297,7 +297,7 @@ describe('init', () => {
 		mockGetConsentFor(true);
 
 		await setupPrebid();
-		expect(prebid.initialise).toBeCalled();
+		expect(prebid.initialise).toHaveBeenCalled();
 	});
 
 	it('should not initialise Prebid if TCFv2 consent with correct Sourcepoint Id is false', async () => {
@@ -318,7 +318,7 @@ describe('init', () => {
 			expect.stringContaining('No consent for prebid'),
 		);
 
-		expect(prebid.initialise).not.toBeCalled();
+		expect(prebid.initialise).not.toHaveBeenCalled();
 	});
 
 	it('should initialise Prebid in USNAT if doNotSell is false', async () => {
@@ -333,7 +333,7 @@ describe('init', () => {
 		mockGetConsentFor(true);
 
 		await setupPrebid();
-		expect(prebid.initialise).toBeCalled();
+		expect(prebid.initialise).toHaveBeenCalled();
 	});
 
 	it('should not initialise Prebid in USNAT if doNotSell is true', async () => {
@@ -354,7 +354,7 @@ describe('init', () => {
 			expect.stringContaining('No consent for prebid'),
 		);
 
-		expect(prebid.initialise).not.toBeCalled();
+		expect(prebid.initialise).not.toHaveBeenCalled();
 	});
 
 	it('should initialise Prebid in AUS if Advertising is not rejected', async () => {
@@ -369,7 +369,7 @@ describe('init', () => {
 		mockGetConsentFor(true);
 
 		await setupPrebid();
-		expect(prebid.initialise).toBeCalled();
+		expect(prebid.initialise).toHaveBeenCalled();
 	});
 
 	it('should not initialise Prebid in AUS if Advertising is rejected', async () => {
@@ -390,7 +390,7 @@ describe('init', () => {
 			expect.stringContaining('No consent for prebid'),
 		);
 
-		expect(prebid.initialise).not.toBeCalled();
+		expect(prebid.initialise).not.toHaveBeenCalled();
 	});
 
 	it('should not initialise Prebid if the framework is invalid', async () => {
@@ -411,7 +411,7 @@ describe('init', () => {
 			expect.stringContaining('Unknown framework'),
 		);
 
-		expect(prebid.initialise).not.toBeCalled();
+		expect(prebid.initialise).not.toHaveBeenCalled();
 	});
 
 	it('should initialise Prebid in TCF when global vendor has consent and custom vendor does not', async () => {
@@ -426,7 +426,7 @@ describe('init', () => {
 		mockGetConsentForWithCustom(true, false);
 
 		await setupPrebid();
-		expect(prebid.initialise).toBeCalled();
+		expect(prebid.initialise).toHaveBeenCalled();
 	});
 
 	it('should initialise Prebid in TCF when global vendor does not have consent but the custom vendor does', async () => {
@@ -441,7 +441,7 @@ describe('init', () => {
 		mockGetConsentForWithCustom(false, true);
 
 		await setupPrebid();
-		expect(prebid.initialise).toBeCalled();
+		expect(prebid.initialise).toHaveBeenCalled();
 	});
 
 	it('should NOT initialise Prebid in TCF when BOTH the global vendor AND custom vendor do NOT have consent', async () => {
@@ -462,6 +462,6 @@ describe('init', () => {
 			expect.stringContaining('No consent for prebid'),
 		);
 
-		expect(prebid.initialise).not.toBeCalled();
+		expect(prebid.initialise).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## What does this change?

Swaps `toBeCalled` for `toHaveBeenCalled` in Jest tests

## Why?

`toBeCalled` is deprecated in favour of `toHaveBeenCalled`

