### PR TITLE
Add `.top-fronts-banner-ad-container` to elements removed by removeSlots

### DIFF
--- a/src/init/consented/remove-slots.ts
+++ b/src/init/consented/remove-slots.ts
@@ -7,6 +7,7 @@ import fastdom from '../../lib/fastdom-promise';
 const selectors: string[] = [
 	dfpEnv.adSlotSelector,
 	'.top-banner-ad-container',
+	'.top-fronts-banner-ad-container',
 	'.ad-slot-container',
 ];
 


### PR DESCRIPTION
## Why?
On the first page view where for ad free users but where the ad free cookie hasn't been set yet or has expired and not been renewed yet. Slots aren't hidden server-side, and need to be removed client side.

There's reports of the fronts-banners not being hidden in some circumstances, this could be the cause.