### PR TITLE
Refactor out some unnecessary awaits in module loading code

### DIFF
--- a/src/init/consented/dynamic-ad-slots.ts
+++ b/src/init/consented/dynamic-ad-slots.ts
@@ -19,8 +19,8 @@ const dynamicAdSlotModules: Modules = [
 	['cm-footballRight', initFootballRightAds],
 ];
 
-export const initDynamicAdSlots = async (): Promise<void> => {
-	await Promise.all(
+export const initDynamicAdSlots = async (): Promise<void[]> => {
+	return Promise.all(
 		dynamicAdSlotModules.map(async ([name, init]) => {
 			try {
 				await init();

--- a/src/init/consented/third-party-tags.ts
+++ b/src/init/consented/third-party-tags.ts
@@ -62,7 +62,7 @@ const insertScripts = async (
 	advertisingServices: ThirdPartyTag[],
 	performanceServices: ThirdPartyTag[], // performanceServices always run
 ): Promise<void> => {
-	await addScripts(performanceServices);
+	void addScripts(performanceServices);
 	const consentState = await onConsent();
 	const consentedAdvertisingServices = advertisingServices.filter(
 		(script) => {
@@ -72,7 +72,7 @@ const insertScripts = async (
 	);
 
 	if (consentedAdvertisingServices.length > 0) {
-		await addScripts(consentedAdvertisingServices);
+		void addScripts(consentedAdvertisingServices);
 	}
 };
 
@@ -102,7 +102,7 @@ const init = async (): Promise<boolean> => {
 	if (!commercialFeatures.thirdPartyTags) {
 		return Promise.resolve(false);
 	}
-	await loadOther();
+	void loadOther();
 	return Promise.resolve(true);
 };
 

--- a/src/init/consented/third-party-tags.ts
+++ b/src/init/consented/third-party-tags.ts
@@ -99,11 +99,11 @@ const loadOther = (): Promise<void> => {
 };
 
 const init = async (): Promise<boolean> => {
-	if (!commercialFeatures.thirdPartyTags) {
-		return Promise.resolve(false);
+	if (commercialFeatures.thirdPartyTags) {
+		void loadOther();
+		return Promise.resolve(true);
 	}
-	void loadOther();
-	return Promise.resolve(true);
+	return Promise.resolve(false);
 };
 
 export { init };


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This is a small refactor of unnecesary use of `await` in module loading/initialisation code.

## Why?

This is unlikely to have any significant performance impact, but improves code quality- `await` should only be used when we actually *need* to wait for the result of an asynchronous function call in order to proceed with the following code.
