### PR TITLE
Force corepack version to fix CI actions errors

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -4,6 +4,10 @@ description: 'Sets up Node.js environment and installs dependencies'
 runs:
   using: 'composite'
   steps:
+    # Temporarily force newer version of corepack
+    # See https://github.com/guardian/support-service-lambdas/pull/2666
+    - run: npm install --global corepack@0.31.0
+
     - run: corepack enable
       shell: bash
 

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           path: ./commercial
 
+      # Temporarily force newer version of corepack
+      # See https://github.com/guardian/support-service-lambdas/pull/2666
+      - run: npm install --global corepack@0.31.0
+
       - run: corepack enable
         working-directory: ./commercial
         shell: bash


### PR DESCRIPTION
## What does this change?
Forces specific version of corepack to fix CI actions errors. Copying what was done here: https://github.com/guardian/ad-manager-line-items-jobs/pull/19
