### PR TITLE
Use specific versions of github actions in workflows

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -10,7 +10,7 @@ runs:
     - run: corepack prepare pnpm@9.15.2 --activate
       shell: bash
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v4.2.0
       with:
         node-version-file: '.nvmrc'
         cache: 'pnpm'

--- a/.github/workflows/beta-release-on-label.yml
+++ b/.github/workflows/beta-release-on-label.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.event.label.name == '[beta] @guardian/commercial'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
         run: pnpm changeset version --snapshot beta
 
       - name: Create Release
-        uses: changesets/action@v1
+        uses: changesets/action@v1.4.9
         id: changeset
         with:
           publish: pnpm changeset publish --tag beta
@@ -57,7 +57,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7.0.1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -85,7 +85,7 @@ jobs:
             })
 
       - name: Remove label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7.0.1
         if: always()
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       # Temporarily force newer version of corepack
       # See https://github.com/guardian/support-service-lambdas/pull/2666
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       # Temporarily force newer version of corepack
       # See https://github.com/guardian/support-service-lambdas/pull/2666
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       # Temporarily force newer version of corepack
       # See https://github.com/guardian/support-service-lambdas/pull/2666
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       # Temporarily force newer version of corepack
       # See https://github.com/guardian/support-service-lambdas/pull/2666
@@ -82,7 +82,7 @@ jobs:
         run: pnpm build
 
       - name: Save build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: dist
           path: dist
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -107,7 +107,7 @@ jobs:
         uses: ./.github/actions/setup-node-env
 
       - name: Fetch build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.8
         with:
           name: dist
           path: dist
@@ -126,7 +126,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@v1.4.9
         with:
           publish: pnpm changeset publish
           title: '🦋 Release package updates'
@@ -147,7 +147,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -160,13 +160,13 @@ jobs:
         uses: ./.github/actions/setup-node-env
 
       - name: Fetch build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.8
         with:
           name: dist
           path: dist
 
       - name: Riff-Raff Upload
-        uses: guardian/actions-riff-raff@v4
+        uses: guardian/actions-riff-raff@v4.1.7
         with:
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       # Commercial
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.2
         with:
           path: ./commercial
 
@@ -37,7 +37,7 @@ jobs:
         working-directory: ./commercial
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.2.0
         with:
           node-version-file: './commercial/.nvmrc'
           cache: 'pnpm'
@@ -86,7 +86,7 @@ jobs:
         run: pnpm playwright test --shard=${{ matrix.group }}/5
         working-directory: ./commercial
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.6.0
         if: always()
         with:
           name: playwright-report-${{ matrix.group }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v9.1.0
         id: stale
         # Read about options here: https://github.com/actions/stale#all-options
         with:

--- a/.github/workflows/test-ad-load-time.yml
+++ b/.github/workflows/test-ad-load-time.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # Commercial
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       # Temporarily force newer version of corepack
       # See https://github.com/guardian/support-service-lambdas/pull/2666
@@ -36,7 +36,7 @@ jobs:
       - name: Run Playwright
         run: pnpm benchmark
 
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v7.0.1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |


### PR DESCRIPTION
## What does this change?

Uses specific versions of Github actions in our workflows rather than approximate major versions

## Why?

We can be sure which version of the action we are running at any time without having to use debug logging

Dependabot should be configured to prompt us to update these versions when new ones become available