### PR TITLE
Specify `pnpm` version to use in Github workflows

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -7,6 +7,9 @@ runs:
     - run: corepack enable
       shell: bash
 
+    - run: corepack prepare pnpm@9.15.2 --activate
+      shell: bash
+
     - uses: actions/setup-node@v4
       with:
         node-version-file: '.nvmrc'

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -32,7 +32,9 @@ jobs:
 
       - run: corepack enable
         working-directory: ./commercial
-        shell: bash
+
+      - run: corepack prepare pnpm@9.15.2 --activate
+        working-directory: ./commercial
 
       - name: Setup node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## What does this change?

Add additional `corepack` step to jobs in Github workflows to specify which pnpm version to use when installing dependencies

## Why?

Without specifying the pnpm version, corepack seems to just use the latest pnpm version at all times.
Jumping from v9 to v10 seems to cause issues with caching
