### PR TITLE
Move the initPermutive call

### DIFF
--- a/.changeset/unlucky-lizards-hide.md
+++ b/.changeset/unlucky-lizards-hide.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': minor
+---
+
+Move the initPermutive call so that the googletag script can be loaded a little earlier

--- a/src/init/consented-advertising.ts
+++ b/src/init/consented-advertising.ts
@@ -9,7 +9,6 @@ import { init as initIpsosMori } from './consented/ipsos-mori';
 import { init as initMessenger } from './consented/messenger';
 import { init as prepareA9 } from './consented/prepare-a9';
 import { init as prepareGoogletag } from './consented/prepare-googletag';
-import { initPermutive } from './consented/prepare-permutive';
 import { init as preparePrebid } from './consented/prepare-prebid';
 import { removeDisabledSlots as closeDisabledSlots } from './consented/remove-slots';
 import { initTeadsCookieless } from './consented/teads-cookieless';
@@ -35,9 +34,7 @@ const commercialModules = [
 	reloadPageOnConsentChange,
 	preparePrebid,
 	initDfpListeners,
-	// Permutive init code must run before google tag enableServices()
-	// The permutive lib however is loaded async with the third party tags
-	() => initPermutive().then(prepareGoogletag),
+	prepareGoogletag,
 	initDynamicAdSlots,
 	prepareA9,
 	initFillSlotListener,

--- a/src/init/consented/static-ad-slots.ts
+++ b/src/init/consented/static-ad-slots.ts
@@ -11,6 +11,7 @@ import { getCurrentBreakpoint } from '../../lib/detect/detect-breakpoint';
 import { dfpEnv } from '../../lib/dfp/dfp-env';
 import { queueAdvert } from '../../lib/dfp/queue-advert';
 import { isInUk, isInUsa } from '../../lib/geo/geo-utils';
+import { initPermutive } from './prepare-permutive';
 import { setupPrebidOnce } from './prepare-prebid';
 import { removeDisabledSlots } from './remove-slots';
 
@@ -61,7 +62,11 @@ const fillStaticAdvertSlots = async (): Promise<void> => {
 	// This module has the following strict dependencies. These dependencies must be
 	// fulfilled before this function can execute reliably. The bootstrap
 	// initiates these dependencies, to speed up the init process. Bootstrap also captures the module performance.
-	const dependencies: Array<Promise<void>> = [removeDisabledSlots()];
+	const dependencies: Array<Promise<void>> = [
+		removeDisabledSlots(),
+		// Permutive segmentation init code must run before google tag enableServices()
+		initPermutive(),
+	];
 
 	await Promise.all(dependencies);
 

--- a/src/init/consented/static-ad-slots.ts
+++ b/src/init/consented/static-ad-slots.ts
@@ -64,7 +64,8 @@ const fillStaticAdvertSlots = async (): Promise<void> => {
 	// initiates these dependencies, to speed up the init process. Bootstrap also captures the module performance.
 	const dependencies: Array<Promise<void>> = [
 		removeDisabledSlots(),
-		// Permutive segmentation init code must run before google tag enableServices()
+		// Permutive segmentation init code must run before googletag.enableServices() is called
+		/** @see https://support.permutive.com/hc/en-us/articles/360011779239-Deploying-the-Permutive-JavaScript-Tag */
 		initPermutive(),
 	];
 


### PR DESCRIPTION
## What does this change?
Moves the `initPermutive()` call from `consented-advertising` to be a dependency of `fillStaticAdvertSlots`.

## Why?
At the moment, `initPermutive()` has to happen before `prepareGoogletag`, so it blocks the loading of the googletag script. By moving it to be a dependency of `fillStaticAdvertSlots`, we can load the googletag script a little earlier.

The [documentation states](https://support.permutive.com/hc/en-us/articles/360011779239-Deploying-the-Permutive-JavaScript-Tag#:~:text=The%20JavaScript%20required%20for%20this%20is%20shown%20below.%20This%20script%20should%20be%20placed%20after%C2%A0googletag%C2%A0%C2%A0is%20defined%20but%20before%20a%20call%20is%20made%20to%C2%A0googletag.enableServices()) that the `initPermutive()` code must run before `googletag.enableServices()` is called. `googletag.enableServices()` is called by `displayAds` and `displayLazyAds`, both of which are only called by `fillStaticAdvertSlots`, so as long as initPermutive runs before that, we should be all good.