### PR TITLE
load intiPremutive for users alreadyVisited

### DIFF
--- a/src/init/consented/prepare-permutive.ts
+++ b/src/init/consented/prepare-permutive.ts
@@ -244,8 +244,17 @@ const initPermutiveSegmentation = () => {
 	runPermutive(permutiveConfig, window.permutive);
 };
 
+const getAlreadyVisitedCount = (): number => {
+	const alreadyVisited = parseInt(
+		localStorage.getItem('gu.alreadyVisited') ?? '',
+		10,
+	);
+	return !Number.isNaN(alreadyVisited) ? alreadyVisited : 0;
+};
+
 export const initPermutive = () => {
-	if (window.guardian.config.switches.permutive) {
+	const visitedCount = getAlreadyVisitedCount();
+	if (window.guardian.config.switches.permutive && visitedCount > 1) {
 		void initPermutiveSegmentation();
 	}
 	return Promise.resolve();


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
This PR aims to mitigate the bottleneck/blocking process for first-time users by optimising the initialisation of Permutive segmentation.

For new visitors we will bypass initialising the Permutive segmentation (initPermutiveSegmentation)

### Key Changes:
- Utilises the `gu.alreadyVisited` value in local storage (set in **frontend**) to check the number of times the user has visited our website.
- Bypasses initialising Permutive segmentation (`initPermutiveSegmentation`) for new visitors.


## Why?
As a result of investigating Permutive's impact on ad-speed & Core Web Vitals, we observed blocking requests from Permutive's CDN. This is likely due to the fact that the `prepareGoogleTag` (prepare GAM to serve ads) is only invoked after `initPermutive()` is resolved:

```js
() => initPermutive().then(prepareGoogletag),
```

Since first-time visitors to the site will not be placed in any Permutive "segment", waiting for initPermutive to load and complete before serving ads may be redundant in this situation.


|Guest Profile - no permutive (1st visit)|
|--------------------------------------|
|permutive init in window|
|<img width="382" alt="Screenshot 2025-02-05 at 14 20 06" src="https://github.com/user-attachments/assets/905d65cf-e05a-407b-acf9-bfaed3bf1cf4" /> |
|Local Storage|
|<img width="683" alt="Screenshot 2025-02-05 at 13 07 03" src="https://github.com/user-attachments/assets/e1202399-ef18-41aa-b68c-04a066737704" />
<img width="350" alt="Screenshot 2025-02-05 at 13 06 10" src="https://github.com/user-attachments/assets/c2e7181d-7daa-478d-ae88-1feca50cff23" />|


|Guest Profile - permutive in window (2nd + visit)|
|--------------------------------------|
|permutive init in window|
| <img width="528" alt="Screenshot 2025-02-05 at 14 15 17" src="https://github.com/user-attachments/assets/9ee6d82e-830b-4b8b-a7be-d1eb34e2a565" /> |
|Local Storage|
|<img width="668" alt="Screenshot 2025-02-05 at 14 17 54" src="https://github.com/user-attachments/assets/f84998ff-4740-47f4-ae27-5f58a6e44ca8" />
<img width="415" alt="Screenshot 2025-02-05 at 14 18 37" src="https://github.com/user-attachments/assets/5225192d-33c6-43d8-ad02-9f991442a587" />|



