### PR TITLE
Replace commas with semicolons in Permutive setup with googletag

### DIFF
--- a/src/init/consented/prepare-permutive.ts
+++ b/src/init/consented/prepare-permutive.ts
@@ -222,20 +222,21 @@ const initPermutiveSegmentation = () => {
 		'359ba275-5edd-4756-84f8-21a24369ce0b',
 		{},
 	);
+
 	/* eslint-enable */
-	(window.googletag = window.googletag || {}), // eslint-disable-line @typescript-eslint/no-unnecessary-condition -- this is a stub
-		// @ts-expect-error -- this is a stub
-		(window.googletag.cmd = window.googletag.cmd || []), // eslint-disable-line @typescript-eslint/no-unnecessary-condition -- this is a stub
-		window.googletag.cmd.push(() => {
-			if (
-				window.googletag.pubads().getTargeting('permutive').length === 0
-			) {
-				const g = window.localStorage.getItem('_pdfps');
-				window.googletag
-					.pubads()
-					.setTargeting('permutive', g ? JSON.parse(g) : []);
-			}
-		});
+	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- this is a stub
+	window.googletag = window.googletag || {};
+	// @ts-expect-error -- this is a stub
+	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- this is a stub
+	window.googletag.cmd = window.googletag.cmd || [];
+	window.googletag.cmd.push(() => {
+		if (window.googletag.pubads().getTargeting('permutive').length === 0) {
+			const g = window.localStorage.getItem('_pdfps');
+			window.googletag
+				.pubads()
+				.setTargeting('permutive', g ? JSON.parse(g) : []);
+		}
+	});
 	const permutiveConfig: PermutivePageConfig = {
 		user: window.guardian.config.user,
 		page: window.guardian.config.page,


### PR DESCRIPTION
## What does this change?

- Replaces commas with semicolons
- Moves eslint disable comments above the line they refer to

## Why?

Was it a mistake that the permutive setup commands ended with commas instead of semicolons?

From when permutive was added (https://github.com/guardian/frontend/commit/09675cc7df4b50cb64f56ed74a9864fd3183980c#diff-3553e1025635aeb071b2bfe8d9b01ee48d9d27adf6597350bf315f5dae03648b) it's always had commas instead of semicolons 🤔 


This is unlikely to affect anything, since these commands probably still run fine with commas instead of semicolons, but this brings us closer to the way the docs recommend: https://developer.permutive.com/docs/ad-manager-dfp#javascript-changes