### PR TITLE
Hide the third party cookie detection iframe

### DIFF
--- a/.changeset/moody-kangaroos-kick.md
+++ b/.changeset/moody-kangaroos-kick.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Hide the third party cookie iframe

--- a/src/lib/third-party-cookies.ts
+++ b/src/lib/third-party-cookies.ts
@@ -15,6 +15,8 @@ const isTPCTestPayload = (payload: unknown): payload is TPCTestPayload =>
  **/
 const checkThirdPartyCookiesEnabled = (): void => {
 	const crossSiteIrame = document.createElement('iframe');
+
+	crossSiteIrame.style.display = 'none';
 	crossSiteIrame.src = `${window.guardian.config.frontendAssetsFullURL}commercial/tpc-test/v1/index.html`;
 
 	window.addEventListener('message', ({ data }) => {


### PR DESCRIPTION
## Why?
It's causing whitespace at the bottom of the page and it should not be visible!