### PR TITLE
Escape fullstops with backslashes in regex for URL

### DIFF
--- a/playwright/tests/consent.spec.ts
+++ b/playwright/tests/consent.spec.ts
@@ -54,7 +54,7 @@ const visitArticleNoOkta = async (page: Page) => {
 };
 
 const waitForOptOut = (page: Page) =>
-	page.waitForRequest(/cdn.optoutadvertising.com/);
+	page.waitForRequest(/cdn\.optoutadvertising\.com/);
 
 test.describe('tcfv2 consent', () => {
 	test(`Accept all, ad slots are fulfilled`, async ({ page }) => {


### PR DESCRIPTION
## What does this change?

Updates URL used in Playwright test to match on exact URL by escaping the fullstops used in the regex


## Why?

Resolves a code scanning alert https://github.com/guardian/commercial/security/code-scanning/2