### PR TITLE
Improve E2E testing of prebid

### DIFF
--- a/playwright/tests/prebid.spec.ts
+++ b/playwright/tests/prebid.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '@playwright/test';
+import type { PrebidAuctionInitEvent } from '../../src/lib/header-bidding/prebid-types';
+import { articles } from '../fixtures/pages';
+import { cmpAcceptAll } from '../lib/cmp';
+import { loadPage } from '../lib/load-page';
+
+const testPage = articles[0];
+
+test.describe('Prebid', () => {
+	test('should load the prebid script', async ({ page }) => {
+		const scriptRequestPromise = page.waitForRequest(
+			/.*\\graun\.Prebid\.js\.commercial\.js$/,
+		);
+		await loadPage(page, testPage.path);
+		await cmpAcceptAll(page);
+		const prebid = await scriptRequestPromise;
+
+		expect(prebid).toBeTruthy();
+	});
+
+	test('should request bids for top-above-nav', async ({ page }) => {
+		await loadPage(page, testPage.path);
+
+		await cmpAcceptAll(page);
+
+		await page.waitForFunction(
+			() => {
+				const events = window.pbjs?.getEvents() ?? [];
+				return events.find(
+					(event) =>
+						event.eventType === 'auctionInit' &&
+						event.args.adUnitCodes.includes(
+							'dfp-ad--top-above-nav',
+						),
+				);
+			},
+			{ timeout: 10000 },
+		);
+
+		const topAboveNavBidderRequests = await page.evaluate(() => {
+			const auctionInitEvent = window.pbjs
+				?.getEvents()
+				.find(
+					(event): event is PrebidAuctionInitEvent =>
+						event.eventType === 'auctionInit' &&
+						event.args.adUnitCodes.includes(
+							'dfp-ad--top-above-nav',
+						),
+				);
+
+			return auctionInitEvent?.args.bidderRequests;
+		});
+
+		const bidders = topAboveNavBidderRequests?.map(
+			(request) => request.bidderCode,
+		);
+
+		expect(bidders).toBeTruthy();
+		expect(bidders).toHaveLength(10);
+		[
+			'oxd',
+			'and',
+			'pubmatic',
+			'ix',
+			'adyoulike',
+			'ozone',
+			'xhb',
+			'criteo',
+			'ttd',
+			'rubicon',
+		].forEach((bidder) => {
+			expect(bidders).toContain(bidder);
+		});
+	});
+});

--- a/playwright/tests/prebid.spec.ts
+++ b/playwright/tests/prebid.spec.ts
@@ -9,7 +9,7 @@ const testPage = articles[0];
 test.describe('Prebid', () => {
 	test('should load the prebid script', async ({ page }) => {
 		const scriptRequestPromise = page.waitForRequest(
-			/.*\\graun\.Prebid\.js\.commercial\.js$/,
+			/graun\.Prebid\.js\.commercial\.js$/,
 		);
 		await loadPage(page, testPage.path);
 		await cmpAcceptAll(page);

--- a/src/lib/header-bidding/prebid-types.ts
+++ b/src/lib/header-bidding/prebid-types.ts
@@ -152,6 +152,24 @@ export type PrebidBid = {
 	params: PrebidParams;
 };
 
+export type PrebidBidderRequest = {
+	bidderCode: string;
+};
+
+export type PrebidBidReqestedEvent = {
+	eventType: 'bidRequested';
+	args: {
+		bids: PrebidBid[];
+	};
+};
+
+export type PrebidAuctionInitEvent = {
+	eventType: 'auctionInit';
+	args: {
+		adUnitCodes: string[];
+		bidderRequests: PrebidBidderRequest[];
+	};
+};
 export type PrebidMediaTypes = {
 	banner: {
 		sizes: HeaderBiddingSize[];

--- a/src/lib/header-bidding/prebid-types.ts
+++ b/src/lib/header-bidding/prebid-types.ts
@@ -163,6 +163,16 @@ export type PrebidBidReqestedEvent = {
 	};
 };
 
+export type PrebidBidderErrorEvent = {
+	eventType: 'bidderError';
+	args: {
+		bidderRequest: PrebidBidderRequest;
+		error: {
+			timedOut?: boolean;
+		};
+	};
+};
+
 export type PrebidAuctionInitEvent = {
 	eventType: 'auctionInit';
 	args: {
@@ -170,6 +180,21 @@ export type PrebidAuctionInitEvent = {
 		bidderRequests: PrebidBidderRequest[];
 	};
 };
+
+export type PrebidAuctionEndEvent = {
+	eventType: 'auctionEnd';
+	args: {
+		adUnitCodes: string[];
+		bidsReceived: PrebidBid[];
+	};
+};
+
+export type PrebidEvent =
+	| PrebidBidReqestedEvent
+	| PrebidBidderErrorEvent
+	| PrebidAuctionInitEvent
+	| PrebidAuctionEndEvent;
+
 export type PrebidMediaTypes = {
 	banner: {
 		sizes: HeaderBiddingSize[];

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -16,9 +16,8 @@ import { getPageTargeting } from '../../page-targeting';
 import type {
 	BidderCode,
 	HeaderBiddingSlot,
-	PrebidAuctionInitEvent,
 	PrebidBid,
-	PrebidBidReqestedEvent,
+	PrebidEvent,
 	PrebidMediaTypes,
 	SlotFlatMap,
 } from '../prebid-types';
@@ -265,9 +264,7 @@ declare global {
 				codeArr?: string[],
 				customSlotMatching?: (slot: unknown) => unknown,
 			) => void;
-			getEvents: () => Array<
-				PrebidAuctionInitEvent | PrebidBidReqestedEvent
-			>;
+			getEvents: () => PrebidEvent[];
 		};
 	}
 }

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -16,7 +16,9 @@ import { getPageTargeting } from '../../page-targeting';
 import type {
 	BidderCode,
 	HeaderBiddingSlot,
+	PrebidAuctionInitEvent,
 	PrebidBid,
+	PrebidBidReqestedEvent,
 	PrebidMediaTypes,
 	SlotFlatMap,
 } from '../prebid-types';
@@ -263,6 +265,9 @@ declare global {
 				codeArr?: string[],
 				customSlotMatching?: (slot: unknown) => unknown,
 			) => void;
+			getEvents: () => Array<
+				PrebidAuctionInitEvent | PrebidBidReqestedEvent
+			>;
 		};
 	}
 }


### PR DESCRIPTION
## What does this change?
Expand our e2e tests to better verify prebid is running correctly.

checks include:
* That the prebid.js script is loaded
* That bids are requested for our bidders
* That no bidderErrors occur, excluding timeouts as these are fairly common and unlikely to be because of our own code.

## Why?
Confidence when making changes to prebid
