### PR TITLE
Improve playwright fixture types and fix liveblog test

### DIFF
--- a/playwright/benchmark/cmp-accept-all.setup.spec.ts
+++ b/playwright/benchmark/cmp-accept-all.setup.spec.ts
@@ -1,6 +1,5 @@
 import { test } from '@playwright/test';
 import { articles } from '../fixtures/pages';
-import { type GuPage } from '../fixtures/pages/Page';
 import { cmpAcceptAll } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
 
@@ -9,7 +8,7 @@ const viewport = { width: 1400, height: 800 };
 const authFile = 'playwright/.auth/accept-all.json';
 
 test('setup', async ({ page }) => {
-	const loadPath = articles[0]?.path as GuPage['path'];
+	const loadPath = articles[0].path;
 
 	await page.setViewportSize(viewport);
 

--- a/playwright/benchmark/cmp-reject-all.setup.spec.ts
+++ b/playwright/benchmark/cmp-reject-all.setup.spec.ts
@@ -1,6 +1,5 @@
 import { test } from '@playwright/test';
 import { articles } from '../fixtures/pages';
-import { type GuPage } from '../fixtures/pages/Page';
 import { cmpRejectAll } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
 
@@ -9,7 +8,7 @@ const viewport = { width: 1400, height: 800 };
 const authFile = 'playwright/.auth/reject-all.json';
 
 test('setup', async ({ page }) => {
-	const loadPath = articles[0]?.path as GuPage['path'];
+	const loadPath = articles[0].path;
 
 	await page.setViewportSize(viewport);
 

--- a/playwright/fixtures/breakpoints.ts
+++ b/playwright/fixtures/breakpoints.ts
@@ -25,9 +25,11 @@ const heights = {
 	wide: 1100,
 } as const;
 
-const testAtBreakpoints = (breakpointsToTest: Array<keyof BreakpointKeys>) =>
+const testAtBreakpoints = <T extends Array<keyof BreakpointKeys>>(
+	breakpointsToTest: T,
+) =>
 	breakpointsToTest.map((b) => ({
-		breakpoint: b,
+		breakpoint: b as T[number],
 		width: breakpoints[b],
 		height: heights[b],
 	}));

--- a/playwright/fixtures/pages/articles.ts
+++ b/playwright/fixtures/pages/articles.ts
@@ -9,7 +9,7 @@ const stage = getStage();
  *
  * Make sure that you are on the same viewport size as the test you are trying to update.
  **/
-const articles: GuPage[] = [
+const articles = [
 	{
 		path: getTestUrl({
 			stage,
@@ -65,6 +65,6 @@ const articles: GuPage[] = [
 			desktop: [6, 13, 20, 30, 37, 44, 51, 58, 65],
 		},
 	},
-];
+] as const satisfies GuPage[];
 
 export { articles };

--- a/playwright/fixtures/pages/blogs.ts
+++ b/playwright/fixtures/pages/blogs.ts
@@ -3,7 +3,7 @@ import type { GuPage } from './Page';
 
 const stage = getStage();
 
-const blogs: GuPage[] = [
+const blogs = [
 	{
 		path: getTestUrl({
 			stage,
@@ -37,6 +37,6 @@ const blogs: GuPage[] = [
 			mobile: 7,
 		},
 	},
-];
+] as const satisfies GuPage[];
 
 export { blogs };

--- a/playwright/fixtures/pages/blogs.ts
+++ b/playwright/fixtures/pages/blogs.ts
@@ -21,7 +21,7 @@ const blogs = [
 		name: 'under-ad-limit',
 		expectedMinInlineSlots: {
 			desktop: 4,
-			tablet: 6,
+			tablet: 4,
 			mobile: 6,
 		},
 	},
@@ -33,7 +33,7 @@ const blogs = [
 		}),
 		expectedMinInlineSlots: {
 			desktop: 5,
-			tablet: 7,
+			tablet: 5,
 			mobile: 7,
 		},
 	},

--- a/playwright/fixtures/pages/fronts.ts
+++ b/playwright/fixtures/pages/fronts.ts
@@ -9,7 +9,7 @@ type TagPage = GuPage;
 
 const stage = getStage();
 
-const fronts: Front[] = [
+const fronts = [
 	{
 		path: getTestUrl({
 			stage,
@@ -37,9 +37,9 @@ const fronts: Front[] = [
 		}),
 		section: 'sport',
 	},
-];
+] as const satisfies Front[];
 
-const tagPages: TagPage[] = [
+const tagPages = [
 	{
 		path: getTestUrl({
 			stage,
@@ -48,9 +48,9 @@ const tagPages: TagPage[] = [
 			adtest: 'fixed-puppies',
 		}),
 	},
-];
+] as const satisfies TagPage[];
 
-const frontWithPageSkin: Front = {
+const frontWithPageSkin = {
 	path: getTestUrl({
 		stage,
 		path: '/uk',
@@ -58,9 +58,9 @@ const frontWithPageSkin: Front = {
 		adtest: 'puppies-pageskin',
 	}),
 	section: 'uk',
-};
+} as const satisfies Front;
 
-const frontWithExclusion: Front = {
+const frontWithExclusion = {
 	path: getTestUrl({
 		stage,
 		path: '/us-news/baltimore-bridge-collapse',
@@ -68,6 +68,6 @@ const frontWithExclusion: Front = {
 		adtest: 'clear',
 	}),
 	section: 'us-news',
-};
+} as const satisfies Front;
 
 export { frontWithPageSkin, fronts, tagPages, frontWithExclusion };

--- a/playwright/fixtures/pages/index.ts
+++ b/playwright/fixtures/pages/index.ts
@@ -3,6 +3,6 @@ import { blogs } from './blogs';
 import { fronts, frontWithPageSkin, tagPages } from './fronts';
 import type { GuPage } from './Page';
 
-const allPages: GuPage[] = [...articles, ...blogs];
+const allPages = [...articles, ...blogs] satisfies GuPage[];
 
 export { allPages, articles, blogs, fronts, frontWithPageSkin, tagPages };

--- a/playwright/fixtures/pages/index.ts
+++ b/playwright/fixtures/pages/index.ts
@@ -1,7 +1,8 @@
 import { articles } from './articles';
 import { blogs } from './blogs';
 import { fronts, frontWithPageSkin, tagPages } from './fronts';
+import type { GuPage } from './Page';
 
-const allPages = [...articles, ...blogs];
+const allPages: GuPage[] = [...articles, ...blogs];
 
 export { allPages, articles, blogs, fronts, frontWithPageSkin, tagPages };

--- a/playwright/tests/article-inline-slots.spec.ts
+++ b/playwright/tests/article-inline-slots.spec.ts
@@ -4,88 +4,94 @@ import { articles } from '../fixtures/pages';
 import { cmpAcceptAll } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
 
-const pages = articles.filter((article) => 'name' in article && article.name === 'inlineSlots');
+const pages = articles.filter(
+	(article) => 'name' in article && article.name === 'inlineSlots',
+);
 
 test.describe('Slots and iframes load on article pages', () => {
-	pages.forEach(
-		(article, index) => {
-			breakpoints.forEach(({ breakpoint, width, height }) => {
-				const expectedMinSlotsOnPage =
-					'expectedMinInlineSlots' in article && breakpoint in article.expectedMinInlineSlots ? article.expectedMinInlineSlots[
-						breakpoint as keyof typeof article.expectedMinInlineSlots
-					] : undefined;
+	pages.forEach((article, index) => {
+		breakpoints.forEach(({ breakpoint, width, height }) => {
+			const expectedMinSlotsOnPage =
+				'expectedMinInlineSlots' in article &&
+				breakpoint in article.expectedMinInlineSlots
+					? article.expectedMinInlineSlots[
+							breakpoint as keyof typeof article.expectedMinInlineSlots
+						]
+					: undefined;
 
-				const expectedSlotPositionsForBreakpoint =
-					'expectedSlotPositions' in article && breakpoint in article.expectedSlotPositions ? article.expectedSlotPositions[
-						breakpoint as keyof typeof article.expectedSlotPositions
-					] : undefined;
+			const expectedSlotPositionsForBreakpoint =
+				'expectedSlotPositions' in article &&
+				breakpoint in article.expectedSlotPositions
+					? article.expectedSlotPositions[
+							breakpoint as keyof typeof article.expectedSlotPositions
+						]
+					: undefined;
 
-				if (expectedMinSlotsOnPage) {
-					test(`Test article ${index} has at least ${expectedMinSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, async ({
-						page,
-					}) => {
-						await page.setViewportSize({
-							width,
-							height,
-						});
-
-						await loadPage(page, article.path);
-						await cmpAcceptAll(page);
-
-						// wait for Spacefinder to place the first inline slot into the DOM
-						await page
-							.locator('.ad-slot--inline1')
-							.waitFor({ state: 'attached' });
-
-						// wait for Spacefinder to run a second time, to place the inline2+ slots
-						await page
-							.locator('.ad-slot--inline2')
-							.waitFor({ state: 'attached' });
-
-						const foundSlots = await page
-							.locator('.ad-slot--inline')
-							.count();
-
-						expect(foundSlots).toBeGreaterThanOrEqual(
-							expectedMinSlotsOnPage,
-						);
+			if (expectedMinSlotsOnPage) {
+				test(`Test article ${index} has at least ${expectedMinSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, async ({
+					page,
+				}) => {
+					await page.setViewportSize({
+						width,
+						height,
 					});
-				} else if (expectedSlotPositionsForBreakpoint) {
-					test(`Test article ${index} has slots at positions ${expectedSlotPositionsForBreakpoint.join(
-						',',
-					)} at breakpoint ${breakpoint}`, async ({ page }) => {
-						await page.setViewportSize({
-							width,
-							height,
-						});
 
-						await loadPage(page, article.path);
-						await cmpAcceptAll(page);
+					await loadPage(page, article.path);
+					await cmpAcceptAll(page);
 
-						await page
-							.locator('.ad-slot--inline2')
-							.waitFor({ state: 'attached' });
+					// wait for Spacefinder to place the first inline slot into the DOM
+					await page
+						.locator('.ad-slot--inline1')
+						.waitFor({ state: 'attached' });
 
-						const slotPositions = await page
-							.locator('.article-body-commercial-selector')
-							.evaluate((el) =>
-								Array.from(el.children)
-									.map((child, index) =>
-										child.classList.contains(
-											'ad-slot-container',
-										)
-											? index
-											: undefined,
+					// wait for Spacefinder to run a second time, to place the inline2+ slots
+					await page
+						.locator('.ad-slot--inline2')
+						.waitFor({ state: 'attached' });
+
+					const foundSlots = await page
+						.locator('.ad-slot--inline')
+						.count();
+
+					expect(foundSlots).toBeGreaterThanOrEqual(
+						expectedMinSlotsOnPage,
+					);
+				});
+			} else if (expectedSlotPositionsForBreakpoint) {
+				test(`Test article ${index} has slots at positions ${expectedSlotPositionsForBreakpoint.join(
+					',',
+				)} at breakpoint ${breakpoint}`, async ({ page }) => {
+					await page.setViewportSize({
+						width,
+						height,
+					});
+
+					await loadPage(page, article.path);
+					await cmpAcceptAll(page);
+
+					await page
+						.locator('.ad-slot--inline2')
+						.waitFor({ state: 'attached' });
+
+					const slotPositions = await page
+						.locator('.article-body-commercial-selector')
+						.evaluate((el) =>
+							Array.from(el.children)
+								.map((child, index) =>
+									child.classList.contains(
+										'ad-slot-container',
 									)
-									.filter((index) => index !== undefined),
-							);
-
-						expect(slotPositions).toEqual(
-							expectedSlotPositionsForBreakpoint,
+										? index
+										: undefined,
+								)
+								.filter((index) => index !== undefined),
 						);
-					});
-				}
-			});
-		},
-	);
+
+					expect(slotPositions).toEqual(
+						expectedSlotPositionsForBreakpoint,
+					);
+				});
+			}
+		});
+	});
 });

--- a/playwright/tests/article-inline-slots.spec.ts
+++ b/playwright/tests/article-inline-slots.spec.ts
@@ -53,7 +53,9 @@ test.describe('Slots and iframes load on article pages', () => {
 				} else if (expectedSlotPositionsForBreakpoint) {
 					test(`Test article ${index} has slots at positions ${expectedSlotPositionsForBreakpoint.join(
 						',',
-					)} at breakpoint ${breakpoint} on ${article.path}`, async ({ page }) => {
+					)} at breakpoint ${breakpoint} on ${article.path}`, async ({
+						page,
+					}) => {
 						await page.setViewportSize({
 							width,
 							height,

--- a/playwright/tests/article-inline-slots.spec.ts
+++ b/playwright/tests/article-inline-slots.spec.ts
@@ -4,21 +4,21 @@ import { articles } from '../fixtures/pages';
 import { cmpAcceptAll } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
 
-const pages = articles.filter(({ name }) => name === 'inlineSlots');
+const pages = articles.filter((article) => 'name' in article && article.name === 'inlineSlots');
 
 test.describe('Slots and iframes load on article pages', () => {
 	pages.forEach(
-		({ path, expectedMinInlineSlots, expectedSlotPositions }, index) => {
+		(article, index) => {
 			breakpoints.forEach(({ breakpoint, width, height }) => {
 				const expectedMinSlotsOnPage =
-					expectedMinInlineSlots?.[
-						breakpoint as keyof typeof expectedMinInlineSlots
-					];
+					'expectedMinInlineSlots' in article && breakpoint in article.expectedMinInlineSlots ? article.expectedMinInlineSlots[
+						breakpoint as keyof typeof article.expectedMinInlineSlots
+					] : undefined;
 
 				const expectedSlotPositionsForBreakpoint =
-					expectedSlotPositions?.[
-						breakpoint as keyof typeof expectedSlotPositions
-					];
+					'expectedSlotPositions' in article && breakpoint in article.expectedSlotPositions ? article.expectedSlotPositions[
+						breakpoint as keyof typeof article.expectedSlotPositions
+					] : undefined;
 
 				if (expectedMinSlotsOnPage) {
 					test(`Test article ${index} has at least ${expectedMinSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, async ({
@@ -29,7 +29,7 @@ test.describe('Slots and iframes load on article pages', () => {
 							height,
 						});
 
-						await loadPage(page, path);
+						await loadPage(page, article.path);
 						await cmpAcceptAll(page);
 
 						// wait for Spacefinder to place the first inline slot into the DOM
@@ -59,7 +59,7 @@ test.describe('Slots and iframes load on article pages', () => {
 							height,
 						});
 
-						await loadPage(page, path);
+						await loadPage(page, article.path);
 						await cmpAcceptAll(page);
 
 						await page

--- a/playwright/tests/article-inline-slots.spec.ts
+++ b/playwright/tests/article-inline-slots.spec.ts
@@ -21,7 +21,7 @@ test.describe('Slots and iframes load on article pages', () => {
 					article.expectedSlotPositions[breakpoint];
 
 				if (expectedMinSlotsOnPage) {
-					test(`Test article ${index} has at least ${expectedMinSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, async ({
+					test(`Test article ${index} has at least ${expectedMinSlotsOnPage} inline total slots at breakpoint ${breakpoint} on ${article.path}`, async ({
 						page,
 					}) => {
 						await page.setViewportSize({
@@ -53,7 +53,7 @@ test.describe('Slots and iframes load on article pages', () => {
 				} else if (expectedSlotPositionsForBreakpoint) {
 					test(`Test article ${index} has slots at positions ${expectedSlotPositionsForBreakpoint.join(
 						',',
-					)} at breakpoint ${breakpoint}`, async ({ page }) => {
+					)} at breakpoint ${breakpoint} on ${article.path}`, async ({ page }) => {
 						await page.setViewportSize({
 							width,
 							height,

--- a/playwright/tests/article-inline-slots.spec.ts
+++ b/playwright/tests/article-inline-slots.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { breakpoints } from '../fixtures/breakpoints';
+import { testAtBreakpoints } from '../fixtures/breakpoints';
 import { articles } from '../fixtures/pages';
 import { cmpAcceptAll } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
@@ -10,88 +10,82 @@ const pages = articles.filter(
 
 test.describe('Slots and iframes load on article pages', () => {
 	pages.forEach((article, index) => {
-		breakpoints.forEach(({ breakpoint, width, height }) => {
-			const expectedMinSlotsOnPage =
-				'expectedMinInlineSlots' in article &&
-				breakpoint in article.expectedMinInlineSlots
-					? article.expectedMinInlineSlots[
-							breakpoint as keyof typeof article.expectedMinInlineSlots
-						]
-					: undefined;
+		testAtBreakpoints(['mobile', 'tablet', 'desktop']).forEach(
+			({ breakpoint, width, height }) => {
+				const expectedMinSlotsOnPage =
+					'expectedMinInlineSlots' in article &&
+					article.expectedMinInlineSlots[breakpoint];
 
-			const expectedSlotPositionsForBreakpoint =
-				'expectedSlotPositions' in article &&
-				breakpoint in article.expectedSlotPositions
-					? article.expectedSlotPositions[
-							breakpoint as keyof typeof article.expectedSlotPositions
-						]
-					: undefined;
+				const expectedSlotPositionsForBreakpoint =
+					'expectedSlotPositions' in article &&
+					article.expectedSlotPositions[breakpoint];
 
-			if (expectedMinSlotsOnPage) {
-				test(`Test article ${index} has at least ${expectedMinSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, async ({
-					page,
-				}) => {
-					await page.setViewportSize({
-						width,
-						height,
-					});
+				if (expectedMinSlotsOnPage) {
+					test(`Test article ${index} has at least ${expectedMinSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, async ({
+						page,
+					}) => {
+						await page.setViewportSize({
+							width,
+							height,
+						});
 
-					await loadPage(page, article.path);
-					await cmpAcceptAll(page);
+						await loadPage(page, article.path);
+						await cmpAcceptAll(page);
 
-					// wait for Spacefinder to place the first inline slot into the DOM
-					await page
-						.locator('.ad-slot--inline1')
-						.waitFor({ state: 'attached' });
+						// wait for Spacefinder to place the first inline slot into the DOM
+						await page
+							.locator('.ad-slot--inline1')
+							.waitFor({ state: 'attached' });
 
-					// wait for Spacefinder to run a second time, to place the inline2+ slots
-					await page
-						.locator('.ad-slot--inline2')
-						.waitFor({ state: 'attached' });
+						// wait for Spacefinder to run a second time, to place the inline2+ slots
+						await page
+							.locator('.ad-slot--inline2')
+							.waitFor({ state: 'attached' });
 
-					const foundSlots = await page
-						.locator('.ad-slot--inline')
-						.count();
+						const foundSlots = await page
+							.locator('.ad-slot--inline')
+							.count();
 
-					expect(foundSlots).toBeGreaterThanOrEqual(
-						expectedMinSlotsOnPage,
-					);
-				});
-			} else if (expectedSlotPositionsForBreakpoint) {
-				test(`Test article ${index} has slots at positions ${expectedSlotPositionsForBreakpoint.join(
-					',',
-				)} at breakpoint ${breakpoint}`, async ({ page }) => {
-					await page.setViewportSize({
-						width,
-						height,
-					});
-
-					await loadPage(page, article.path);
-					await cmpAcceptAll(page);
-
-					await page
-						.locator('.ad-slot--inline2')
-						.waitFor({ state: 'attached' });
-
-					const slotPositions = await page
-						.locator('.article-body-commercial-selector')
-						.evaluate((el) =>
-							Array.from(el.children)
-								.map((child, index) =>
-									child.classList.contains(
-										'ad-slot-container',
-									)
-										? index
-										: undefined,
-								)
-								.filter((index) => index !== undefined),
+						expect(foundSlots).toBeGreaterThanOrEqual(
+							expectedMinSlotsOnPage,
 						);
+					});
+				} else if (expectedSlotPositionsForBreakpoint) {
+					test(`Test article ${index} has slots at positions ${expectedSlotPositionsForBreakpoint.join(
+						',',
+					)} at breakpoint ${breakpoint}`, async ({ page }) => {
+						await page.setViewportSize({
+							width,
+							height,
+						});
 
-					expect(slotPositions).toEqual(
-						expectedSlotPositionsForBreakpoint,
-					);
-				});
-			}
-		});
+						await loadPage(page, article.path);
+						await cmpAcceptAll(page);
+
+						await page
+							.locator('.ad-slot--inline2')
+							.waitFor({ state: 'attached' });
+
+						const slotPositions = await page
+							.locator('.article-body-commercial-selector')
+							.evaluate((el) =>
+								Array.from(el.children)
+									.map((child, index) =>
+										child.classList.contains(
+											'ad-slot-container',
+										)
+											? index
+											: undefined,
+									)
+									.filter((index) => index !== undefined),
+							);
+
+						expect(slotPositions).toEqual(
+							expectedSlotPositionsForBreakpoint,
+						);
+					});
+				}
+			},
+		);
 	});
 });

--- a/playwright/tests/liveblog-ad-limit.spec.ts
+++ b/playwright/tests/liveblog-ad-limit.spec.ts
@@ -7,7 +7,9 @@ import { cmpAcceptAll } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
 import { countLiveblogInlineSlots } from '../lib/util';
 
-const pages = blogs.filter(({ name }) => name === 'under-ad-limit');
+const pages = blogs.filter(
+	(blog) => 'name' in blog && blog.name === 'under-ad-limit',
+);
 
 const desktopBreakpoint = breakpoints.filter(
 	({ breakpoint }) => breakpoint === 'desktop',
@@ -76,11 +78,7 @@ test.describe('A minimum amount of ad slots load', () => {
 				false,
 			);
 
-			if (expectedMinInlineSlots) {
-				expect(initialSlotCount).toEqual(
-					expectedMinInlineSlots.desktop,
-				);
-			}
+			expect(initialSlotCount).toEqual(expectedMinInlineSlots.desktop);
 
 			await addAndAwaitNewBlocks(page, 'First batch of inserted blocks');
 			const slotCountAfterFirstInsert = await countLiveblogInlineSlots(

--- a/playwright/tests/liveblog-inline-slots.spec.ts
+++ b/playwright/tests/liveblog-inline-slots.spec.ts
@@ -5,49 +5,45 @@ import { cmpAcceptAll } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
 import { countLiveblogInlineSlots } from '../lib/util';
 
-const blogPages = blogs.filter(
-	(page) =>
-		'expectedMinInlineSlotsOnDesktop' in page &&
-		'expectedMinInlineSlotsOnMobile' in page,
-);
+const blogPages = blogs.filter((page) => 'expectedMinInlineSlots' in page);
 
 test.describe.serial('A minimum number of ad slots load', () => {
 	blogPages.forEach(({ path, expectedMinInlineSlots }) => {
 		breakpoints.forEach(({ breakpoint, width, height }) => {
 			const isMobile = breakpoint === 'mobile';
 			const expectedMinSlotsOnPage =
-				expectedMinInlineSlots?.[
+				expectedMinInlineSlots[
 					breakpoint as keyof typeof expectedMinInlineSlots
 				];
 
-			if (expectedMinSlotsOnPage) {
-				test(`There are at least ${expectedMinSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, async ({
-					page,
-				}) => {
-					await page.setViewportSize({
-						width,
-						height,
-					});
-
-					await loadPage(page, path);
-					await cmpAcceptAll(page);
-
-					const foundSlots = await countLiveblogInlineSlots(
-						page,
-						isMobile,
-					);
-
-					expect(foundSlots).toBeGreaterThanOrEqual(
-						expectedMinSlotsOnPage,
-					);
+			test(`There are at least ${expectedMinSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, async ({
+				page,
+			}) => {
+				await page.setViewportSize({
+					width,
+					height,
 				});
-			}
+
+				await loadPage(page, path);
+				await cmpAcceptAll(page);
+
+				const foundSlots = await countLiveblogInlineSlots(
+					page,
+					isMobile,
+				);
+
+				expect(foundSlots).toBeGreaterThanOrEqual(
+					expectedMinSlotsOnPage,
+				);
+			});
 		});
 	});
 });
 
 test.describe.serial('Correct set of slots are displayed', () => {
-	const testBlogs = blogs.filter(({ name }) => name === 'under-ad-limit');
+	const testBlogs = blogs.filter(
+		(blog) => 'name' in blog && blog.name === 'under-ad-limit',
+	);
 
 	const firstAdSlotSelectorDesktop = 'liveblog-inline--inline1';
 	const firstAdSlotSelectorMobile = 'liveblog-inline-mobile--top-above-nav';

--- a/playwright/tests/liveblog-inline-slots.spec.ts
+++ b/playwright/tests/liveblog-inline-slots.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { breakpoints } from '../fixtures/breakpoints';
+import { breakpoints, testAtBreakpoints } from '../fixtures/breakpoints';
 import { blogs } from '../fixtures/pages';
 import { cmpAcceptAll } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
@@ -9,34 +9,34 @@ const blogPages = blogs.filter((page) => 'expectedMinInlineSlots' in page);
 
 test.describe.serial('A minimum number of ad slots load', () => {
 	blogPages.forEach(({ path, expectedMinInlineSlots }) => {
-		breakpoints.forEach(({ breakpoint, width, height }) => {
-			const isMobile = breakpoint === 'mobile';
-			const expectedMinSlotsOnPage =
-				expectedMinInlineSlots[
-					breakpoint as keyof typeof expectedMinInlineSlots
-				];
+		testAtBreakpoints(['mobile', 'tablet', 'desktop']).forEach(
+			({ breakpoint, width, height }) => {
+				const isMobile = breakpoint === 'mobile';
+				const expectedMinSlotsOnPage =
+					expectedMinInlineSlots[breakpoint];
 
-			test(`There are at least ${expectedMinSlotsOnPage} inline total slots at breakpoint ${breakpoint}`, async ({
-				page,
-			}) => {
-				await page.setViewportSize({
-					width,
-					height,
-				});
-
-				await loadPage(page, path);
-				await cmpAcceptAll(page);
-
-				const foundSlots = await countLiveblogInlineSlots(
+				test(`There are at least ${expectedMinSlotsOnPage} inline total slots at breakpoint ${breakpoint} on `, async ({
 					page,
-					isMobile,
-				);
+				}) => {
+					await page.setViewportSize({
+						width,
+						height,
+					});
 
-				expect(foundSlots).toBeGreaterThanOrEqual(
-					expectedMinSlotsOnPage,
-				);
-			});
-		});
+					await loadPage(page, path);
+					await cmpAcceptAll(page);
+
+					const foundSlots = await countLiveblogInlineSlots(
+						page,
+						isMobile,
+					);
+
+					expect(foundSlots).toBeGreaterThanOrEqual(
+						expectedMinSlotsOnPage,
+					);
+				});
+			},
+		);
 	});
 });
 

--- a/playwright/tests/liveblog-inline-slots.spec.ts
+++ b/playwright/tests/liveblog-inline-slots.spec.ts
@@ -15,7 +15,7 @@ test.describe.serial('A minimum number of ad slots load', () => {
 				const expectedMinSlotsOnPage =
 					expectedMinInlineSlots[breakpoint];
 
-				test(`There are at least ${expectedMinSlotsOnPage} inline total slots at breakpoint ${breakpoint} on `, async ({
+				test(`There are at least ${expectedMinSlotsOnPage} inline total slots at breakpoint ${breakpoint} on ${path}`, async ({
 					page,
 				}) => {
 					await page.setViewportSize({
@@ -52,7 +52,7 @@ test.describe.serial('Correct set of slots are displayed', () => {
 		breakpoints
 			.filter(({ breakpoint }) => breakpoint === 'mobile')
 			.forEach(({ width, height }) => {
-				test('on mobile, the mobile ad slots are displayed and desktop ad slots are hidden', async ({
+				test(`on mobile, the mobile ad slots are displayed and desktop ad slots are hidden on ${path}`, async ({
 					page,
 				}) => {
 					await page.setViewportSize({

--- a/playwright/tests/liveblog-live-update.spec.ts
+++ b/playwright/tests/liveblog-live-update.spec.ts
@@ -10,12 +10,14 @@ import { countLiveblogInlineSlots } from '../lib/util';
  * - It would be good to see if these tests could be run in parallel in the future
  */
 
-const pages = blogs.filter(({ name }) => name === 'live-update');
+const pages = blogs.filter(
+	(blog) => 'name' in blog && blog.name === 'live-update',
+);
 
 test.describe.serial('Liveblog live updates', () => {
-	pages.forEach(({ path }) => {
+	pages.forEach(({ path }, i) => {
 		breakpoints.forEach(({ breakpoint, width, height }) => {
-			test(`Test ads are inserted when liveblogs update, breakpoint: ${breakpoint}`, async ({
+			test(`Test liveblog ${i} that ads are inserted when live updated, breakpoint: ${breakpoint}`, async ({
 				page,
 			}) => {
 				await page.setViewportSize({

--- a/playwright/tests/targeting.spec.ts
+++ b/playwright/tests/targeting.spec.ts
@@ -52,7 +52,7 @@ test.describe('GAM targeting', () => {
 			'top-above-nav',
 		);
 		const sensitivePage = allPages.find(
-			(page) => page.name === 'sensitive-content',
+			(page) => 'name' in page && page.name === 'sensitive-content',
 		);
 		if (!sensitivePage) {
 			throw new Error('No sensitive articles found to run test.');

--- a/playwright/tests/targeting.spec.ts
+++ b/playwright/tests/targeting.spec.ts
@@ -1,7 +1,6 @@
 import type { Request } from '@playwright/test';
 import { expect, test } from '@playwright/test';
 import { allPages, articles } from '../fixtures/pages';
-import type { GuPage } from '../fixtures/pages/Page';
 import {
 	bidderURLs,
 	criteoMockBidResponse,
@@ -16,7 +15,7 @@ import {
 } from '../lib/gam';
 import { loadPage } from '../lib/load-page';
 
-const article = articles[0] as unknown as GuPage;
+const article = articles[0];
 
 test.describe('GAM targeting', () => {
 	test('checks that a request is made', async ({ page }) => {


### PR DESCRIPTION
## What does this change?
use `as const` and `satisfies` to improve type safety

## Why?
This lets us remove several assertions.

This revealed an error in the first `liveblog-inline-blog.spec.ts` test, the filtering at the start conflicted with a check in the test resulting in the test not actually running!

The number of ad slots on the test blogs in that test has changed on tablet, I've updated the test as this was changed a while ago in https://github.com/guardian/commercial/pull/1550