### PR TITLE
Add compressed size action

### DIFF
--- a/.github/workflows/compressed-size-action.yml
+++ b/.github/workflows/compressed-size-action.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  compressed_size:
     runs-on: ubuntu-latest
 
     steps:
@@ -20,3 +20,6 @@ jobs:
 
       - name: Compressed Size
         uses: preactjs/compressed-size-action@v2
+        with:
+          repo-token: ${{secrets.GITHUB_TOKEN}}
+          build-script: build:prod

--- a/.github/workflows/compressed-size-action.yml
+++ b/.github/workflows/compressed-size-action.yml
@@ -29,4 +29,4 @@ jobs:
           # having a higher change threshold makes the reporting a little less sensitive and more reliable
           minimum-change-threshold: 50
           # filenames are hashed so we need to strip that, or it thinks we've created new files every build
-          strip-hash: "\\.(\\w{20})\\.js$"
+          strip-hash: "dist/prod/artifacts/commercial/(\\w{20})/graun\\.[^.]+\\.commercial\\.js$"

--- a/.github/workflows/compressed-size-action.yml
+++ b/.github/workflows/compressed-size-action.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@@v4.2.2
+        uses: actions/checkout@v4.2.2
 
       # Temporarily force newer version of corepack
       # See https://github.com/guardian/support-service-lambdas/pull/2666

--- a/.github/workflows/compressed-size-action.yml
+++ b/.github/workflows/compressed-size-action.yml
@@ -26,5 +26,7 @@ jobs:
         with:
           repo-token: ${{secrets.GITHUB_TOKEN}}
           build-script: build:prod
-          # https://github.com/preactjs/compressed-size-action#increasing-the-required-threshold
+          # having a higher change threshold makes the reporting a little less sensitive and more reliable
           minimum-change-threshold: 50
+          # filenames are hashed so we need to strip that, or it thinks we've created new files every build
+          strip-hash: "\\.(\\w{20})\\.js$"

--- a/.github/workflows/compressed-size-action.yml
+++ b/.github/workflows/compressed-size-action.yml
@@ -1,0 +1,14 @@
+name: Compressed Size
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@@v4.2.2
+
+      - name: Compressed Size
+        uses: preactjs/compressed-size-action@v2

--- a/.github/workflows/compressed-size-action.yml
+++ b/.github/workflows/compressed-size-action.yml
@@ -23,3 +23,5 @@ jobs:
         with:
           repo-token: ${{secrets.GITHUB_TOKEN}}
           build-script: build:prod
+          # https://github.com/preactjs/compressed-size-action#increasing-the-required-threshold
+          minimum-change-threshold: 50

--- a/.github/workflows/compressed-size-action.yml
+++ b/.github/workflows/compressed-size-action.yml
@@ -1,5 +1,8 @@
 name: Compressed Size
 
+permissions:
+  pull-requests: write
+
 on:
   pull_request:
 

--- a/.github/workflows/compressed-size-action.yml
+++ b/.github/workflows/compressed-size-action.yml
@@ -29,4 +29,4 @@ jobs:
           # having a higher change threshold makes the reporting a little less sensitive and more reliable
           minimum-change-threshold: 50
           # filenames are hashed so we need to strip that, or it thinks we've created new files every build
-          strip-hash: "dist/prod/artifacts/commercial/(\\w{20})/graun\\.[^.]+\\.commercial\\.js$"
+          strip-hash: "dist/prod/artifacts/commercial/(\\w{20})/graun\\.[a-zA-Z0-9-._]+\\.commercial\\.js$"

--- a/.github/workflows/compressed-size-action.yml
+++ b/.github/workflows/compressed-size-action.yml
@@ -1,6 +1,7 @@
 name: Compressed Size
 
-on: [pull_request]
+on:
+  pull_request:
 
 jobs:
   build:
@@ -9,6 +10,13 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@@v4.2.2
+
+      # Temporarily force newer version of corepack
+      # See https://github.com/guardian/support-service-lambdas/pull/2666
+      - run: npm install --global corepack@0.31.0
+
+      - name: Set up Node
+        uses: ./.github/actions/setup-node-env
 
       - name: Compressed Size
         uses: preactjs/compressed-size-action@v2


### PR DESCRIPTION
## What does this change?
Adds the compressed size action to pull request workflows.

## Why?
We've recently made some changes that have reduced the bundle size (eg. removing unused Prebid adapters) and this action will give us immediate feedback on future PRs to help quantify the impact of a change on the bundle size.

## Example
I temporarily downgraded the Prebid version to 9.27.0 on this branch, and the compressed size action showed that doing that resulted in an increase in bundle size, as the previous version includes extra adapters.

<img width="929" alt="Screenshot 2025-02-21 at 16 25 54" src="https://github.com/user-attachments/assets/206683dd-0000-4576-b88f-048d2313a54e" />
