### PR TITLE
Adjust Playwright breakpoint types

### DIFF
--- a/playwright/fixtures/breakpoints.ts
+++ b/playwright/fixtures/breakpoints.ts
@@ -39,7 +39,7 @@ const getBreakpointSize = <T extends TestingBreakpoint>(
 const allBreakpointSizes = allBreakpoints.map(getBreakpointSize);
 
 export {
-	allBreakpointSizes as breakpoints,
+	allBreakpointSizes,
 	getBreakpointSize,
 	type BreakpointSize,
 	type TestingBreakpoint,

--- a/playwright/fixtures/breakpoints.ts
+++ b/playwright/fixtures/breakpoints.ts
@@ -1,43 +1,46 @@
-import { breakpoints } from '@guardian/source/foundations';
+import {
+	type Breakpoint,
+	breakpoints as BREAKPOINTS,
+} from '@guardian/source/foundations';
 
-type BreakpointKeys = Pick<
-	typeof breakpoints,
+type TestingBreakpoint = Extract<
+	Breakpoint,
 	'mobile' | 'tablet' | 'desktop' | 'wide'
 >;
 
-type BreakpointSizes = {
-	breakpoint: keyof BreakpointKeys;
-	width: (typeof breakpoints)[keyof BreakpointKeys];
-	height: number;
-};
-
-const allBreakpoints: Array<keyof BreakpointKeys> = [
-	'mobile',
-	'tablet',
-	'desktop',
-	'wide',
-];
-
-const heights = {
+const HEIGHTS = {
 	mobile: 600,
 	tablet: 1024,
 	desktop: 1100,
 	wide: 1100,
 } as const;
 
-const testAtBreakpoints = <T extends Array<keyof BreakpointKeys>>(
-	breakpointsToTest: T,
-) =>
-	breakpointsToTest.map((b) => ({
-		breakpoint: b as T[number],
-		width: breakpoints[b],
-		height: heights[b],
-	}));
+type BreakpointSize<T extends TestingBreakpoint> = {
+	breakpoint: T;
+	width: (typeof BREAKPOINTS)[T];
+	height: (typeof HEIGHTS)[T];
+};
 
-const breakpointSizes: BreakpointSizes[] = testAtBreakpoints(allBreakpoints);
+const allBreakpoints = [
+	'mobile',
+	'tablet',
+	'desktop',
+	'wide',
+] satisfies TestingBreakpoint[];
+
+const getBreakpointSize = <T extends TestingBreakpoint>(
+	breakpoint: T,
+): BreakpointSize<T> => ({
+	breakpoint,
+	width: BREAKPOINTS[breakpoint],
+	height: HEIGHTS[breakpoint],
+});
+
+const allBreakpointSizes = allBreakpoints.map(getBreakpointSize);
 
 export {
-	breakpointSizes as breakpoints,
-	testAtBreakpoints,
-	type BreakpointSizes,
+	allBreakpointSizes as breakpoints,
+	getBreakpointSize,
+	type BreakpointSize,
+	type TestingBreakpoint,
 };

--- a/playwright/fixtures/breakpoints.ts
+++ b/playwright/fixtures/breakpoints.ts
@@ -36,10 +36,10 @@ const getBreakpointSize = <T extends TestingBreakpoint>(
 	height: HEIGHTS[breakpoint],
 });
 
-const allBreakpointSizes = allBreakpoints.map(getBreakpointSize);
+const breakpointSizes = allBreakpoints.map(getBreakpointSize);
 
 export {
-	allBreakpointSizes,
+	breakpointSizes,
 	getBreakpointSize,
 	type BreakpointSize,
 	type TestingBreakpoint,

--- a/playwright/fixtures/pages/Page.ts
+++ b/playwright/fixtures/pages/Page.ts
@@ -1,14 +1,11 @@
+import { type TestingBreakpoint } from '../breakpoints';
+
 export type GuPage = {
 	path: string;
 	name?: string;
-	expectedMinInlineSlots?: {
-		mobile: number;
-		tablet: number;
-		desktop: number;
-	};
-	expectedSlotPositions?: {
-		mobile: number[];
-		tablet: number[];
-		desktop: number[];
-	};
+	expectedMinInlineSlots?: Record<Exclude<TestingBreakpoint, 'wide'>, number>;
+	expectedSlotPositions?: Record<
+		Exclude<TestingBreakpoint, 'wide'>,
+		number[]
+	>;
 };

--- a/playwright/tests/article-inline-slots.spec.ts
+++ b/playwright/tests/article-inline-slots.spec.ts
@@ -13,13 +13,7 @@ const pages = articles.filter(
 
 test.describe('Slots and iframes load on article pages', () => {
 	pages.forEach((article, index) => {
-		const testingBreakpoints = [
-			'mobile',
-			'tablet',
-			'desktop',
-		] satisfies TestingBreakpoint[];
-
-		testingBreakpoints
+		(['mobile', 'tablet', 'desktop'] satisfies TestingBreakpoint[])
 			.map(getBreakpointSize)
 			.forEach(({ breakpoint, width, height }) => {
 				const expectedMinSlotsOnPage =

--- a/playwright/tests/article-inline-slots.spec.ts
+++ b/playwright/tests/article-inline-slots.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test } from '@playwright/test';
-import { testAtBreakpoints } from '../fixtures/breakpoints';
+import {
+	getBreakpointSize,
+	type TestingBreakpoint,
+} from '../fixtures/breakpoints';
 import { articles } from '../fixtures/pages';
 import { cmpAcceptAll } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
@@ -10,8 +13,15 @@ const pages = articles.filter(
 
 test.describe('Slots and iframes load on article pages', () => {
 	pages.forEach((article, index) => {
-		testAtBreakpoints(['mobile', 'tablet', 'desktop']).forEach(
-			({ breakpoint, width, height }) => {
+		const testingBreakpoints = [
+			'mobile',
+			'tablet',
+			'desktop',
+		] satisfies TestingBreakpoint[];
+
+		testingBreakpoints
+			.map(getBreakpointSize)
+			.forEach(({ breakpoint, width, height }) => {
 				const expectedMinSlotsOnPage =
 					'expectedMinInlineSlots' in article &&
 					article.expectedMinInlineSlots[breakpoint];
@@ -87,7 +97,6 @@ test.describe('Slots and iframes load on article pages', () => {
 						);
 					});
 				}
-			},
-		);
+			});
 	});
 });

--- a/playwright/tests/liveblog-ad-limit.spec.ts
+++ b/playwright/tests/liveblog-ad-limit.spec.ts
@@ -1,7 +1,6 @@
 import type { Page } from '@playwright/test';
 import { expect, test } from '@playwright/test';
-import type { BreakpointSizes } from '../fixtures/breakpoints';
-import { breakpoints } from '../fixtures/breakpoints';
+import { getBreakpointSize } from '../fixtures/breakpoints';
 import { blogs } from '../fixtures/pages';
 import { cmpAcceptAll } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
@@ -11,9 +10,7 @@ const pages = blogs.filter(
 	(blog) => 'name' in blog && blog.name === 'under-ad-limit',
 );
 
-const desktopBreakpoint = breakpoints.filter(
-	({ breakpoint }) => breakpoint === 'desktop',
-)[0] as unknown as BreakpointSizes;
+const desktopBreakpoint = getBreakpointSize('desktop');
 
 const MAX_AD_SLOTS = 8;
 

--- a/playwright/tests/liveblog-inline-slots.spec.ts
+++ b/playwright/tests/liveblog-inline-slots.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { breakpoints, testAtBreakpoints } from '../fixtures/breakpoints';
+import {
+	breakpoints,
+	getBreakpointSize,
+	type TestingBreakpoint,
+} from '../fixtures/breakpoints';
 import { blogs } from '../fixtures/pages';
 import { cmpAcceptAll } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
@@ -9,8 +13,15 @@ const blogPages = blogs.filter((page) => 'expectedMinInlineSlots' in page);
 
 test.describe.serial('A minimum number of ad slots load', () => {
 	blogPages.forEach(({ path, expectedMinInlineSlots }) => {
-		testAtBreakpoints(['mobile', 'tablet', 'desktop']).forEach(
-			({ breakpoint, width, height }) => {
+		const testingBreakpoints = [
+			'mobile',
+			'tablet',
+			'desktop',
+		] satisfies TestingBreakpoint[];
+
+		testingBreakpoints
+			.map(getBreakpointSize)
+			.forEach(({ breakpoint, width, height }) => {
 				const isMobile = breakpoint === 'mobile';
 				const expectedMinSlotsOnPage =
 					expectedMinInlineSlots[breakpoint];
@@ -35,8 +46,7 @@ test.describe.serial('A minimum number of ad slots load', () => {
 						expectedMinSlotsOnPage,
 					);
 				});
-			},
-		);
+			});
 	});
 });
 

--- a/playwright/tests/liveblog-inline-slots.spec.ts
+++ b/playwright/tests/liveblog-inline-slots.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import {
-	breakpoints,
+	allBreakpointSizes,
 	getBreakpointSize,
 	type TestingBreakpoint,
 } from '../fixtures/breakpoints';
@@ -13,13 +13,7 @@ const blogPages = blogs.filter((page) => 'expectedMinInlineSlots' in page);
 
 test.describe.serial('A minimum number of ad slots load', () => {
 	blogPages.forEach(({ path, expectedMinInlineSlots }) => {
-		const testingBreakpoints = [
-			'mobile',
-			'tablet',
-			'desktop',
-		] satisfies TestingBreakpoint[];
-
-		testingBreakpoints
+		(['mobile', 'tablet', 'desktop'] satisfies TestingBreakpoint[])
 			.map(getBreakpointSize)
 			.forEach(({ breakpoint, width, height }) => {
 				const isMobile = breakpoint === 'mobile';
@@ -59,7 +53,7 @@ test.describe.serial('Correct set of slots are displayed', () => {
 	const firstAdSlotSelectorMobile = 'liveblog-inline-mobile--top-above-nav';
 
 	testBlogs.forEach(({ path }) => {
-		breakpoints
+		allBreakpointSizes
 			.filter(({ breakpoint }) => breakpoint === 'mobile')
 			.forEach(({ width, height }) => {
 				test(`on mobile, the mobile ad slots are displayed and desktop ad slots are hidden on ${path}`, async ({
@@ -90,7 +84,7 @@ test.describe.serial('Correct set of slots are displayed', () => {
 	});
 
 	testBlogs.forEach(({ path }) => {
-		breakpoints
+		allBreakpointSizes
 			.filter(({ breakpoint }) => breakpoint !== 'mobile')
 			.forEach(({ breakpoint, width, height }) => {
 				test(`on ${breakpoint}, the desktop ad slots are displayed and the mobile ad slots are hidden on ${path}`, async ({

--- a/playwright/tests/liveblog-inline-slots.spec.ts
+++ b/playwright/tests/liveblog-inline-slots.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import {
-	allBreakpointSizes,
+	breakpointSizes,
 	getBreakpointSize,
 	type TestingBreakpoint,
 } from '../fixtures/breakpoints';
@@ -53,7 +53,7 @@ test.describe.serial('Correct set of slots are displayed', () => {
 	const firstAdSlotSelectorMobile = 'liveblog-inline-mobile--top-above-nav';
 
 	testBlogs.forEach(({ path }) => {
-		allBreakpointSizes
+		breakpointSizes
 			.filter(({ breakpoint }) => breakpoint === 'mobile')
 			.forEach(({ width, height }) => {
 				test(`on mobile, the mobile ad slots are displayed and desktop ad slots are hidden on ${path}`, async ({
@@ -84,7 +84,7 @@ test.describe.serial('Correct set of slots are displayed', () => {
 	});
 
 	testBlogs.forEach(({ path }) => {
-		allBreakpointSizes
+		breakpointSizes
 			.filter(({ breakpoint }) => breakpoint !== 'mobile')
 			.forEach(({ breakpoint, width, height }) => {
 				test(`on ${breakpoint}, the desktop ad slots are displayed and the mobile ad slots are hidden on ${path}`, async ({

--- a/playwright/tests/liveblog-live-update.spec.ts
+++ b/playwright/tests/liveblog-live-update.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { breakpoints } from '../fixtures/breakpoints';
+import { allBreakpointSizes } from '../fixtures/breakpoints';
 import { blogs } from '../fixtures/pages';
 import { cmpAcceptAll } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
@@ -16,7 +16,7 @@ const pages = blogs.filter(
 
 test.describe.serial('Liveblog live updates', () => {
 	pages.forEach(({ path }, i) => {
-		breakpoints.forEach(({ breakpoint, width, height }) => {
+		allBreakpointSizes.forEach(({ breakpoint, width, height }) => {
 			test(`Test liveblog ${i} that ads are inserted when live updated, breakpoint: ${breakpoint}`, async ({
 				page,
 			}) => {

--- a/playwright/tests/liveblog-live-update.spec.ts
+++ b/playwright/tests/liveblog-live-update.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { allBreakpointSizes } from '../fixtures/breakpoints';
+import { breakpointSizes } from '../fixtures/breakpoints';
 import { blogs } from '../fixtures/pages';
 import { cmpAcceptAll } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
@@ -16,7 +16,7 @@ const pages = blogs.filter(
 
 test.describe.serial('Liveblog live updates', () => {
 	pages.forEach(({ path }, i) => {
-		allBreakpointSizes.forEach(({ breakpoint, width, height }) => {
+		breakpointSizes.forEach(({ breakpoint, width, height }) => {
 			test(`Test liveblog ${i} that ads are inserted when live updated, breakpoint: ${breakpoint}`, async ({
 				page,
 			}) => {

--- a/playwright/tests/merchandising-high.spec.ts
+++ b/playwright/tests/merchandising-high.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test';
 import { isDefined } from '../../src/lib/types';
-import { breakpoints } from '../fixtures/breakpoints';
+import { allBreakpointSizes } from '../fixtures/breakpoints';
 import { articles, blogs } from '../fixtures/pages';
 import type { GuPage } from '../fixtures/pages/Page';
 import { cmpAcceptAll } from '../lib/cmp';
@@ -11,7 +11,7 @@ const pages = [articles[0], blogs[0]].filter<GuPage>(isDefined);
 
 test.describe('merchandising high slot', () => {
 	pages.forEach(({ path }, index) => {
-		breakpoints.forEach(({ breakpoint, width, height }) => {
+		allBreakpointSizes.forEach(({ breakpoint, width, height }) => {
 			test(`Test page ${index} has slot and iframe at breakpoint ${breakpoint}`, async ({
 				page,
 			}) => {

--- a/playwright/tests/merchandising-high.spec.ts
+++ b/playwright/tests/merchandising-high.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test';
 import { isDefined } from '../../src/lib/types';
-import { allBreakpointSizes } from '../fixtures/breakpoints';
+import { breakpointSizes } from '../fixtures/breakpoints';
 import { articles, blogs } from '../fixtures/pages';
 import type { GuPage } from '../fixtures/pages/Page';
 import { cmpAcceptAll } from '../lib/cmp';
@@ -11,7 +11,7 @@ const pages = [articles[0], blogs[0]].filter<GuPage>(isDefined);
 
 test.describe('merchandising high slot', () => {
 	pages.forEach(({ path }, index) => {
-		allBreakpointSizes.forEach(({ breakpoint, width, height }) => {
+		breakpointSizes.forEach(({ breakpoint, width, height }) => {
 			test(`Test page ${index} has slot and iframe at breakpoint ${breakpoint}`, async ({
 				page,
 			}) => {

--- a/playwright/tests/merchandising.spec.ts
+++ b/playwright/tests/merchandising.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test';
 import { isDefined } from '../../src/lib/types';
-import { breakpoints } from '../fixtures/breakpoints';
+import { allBreakpointSizes } from '../fixtures/breakpoints';
 import { articles, blogs } from '../fixtures/pages';
 import type { GuPage } from '../fixtures/pages/Page';
 import { cmpAcceptAll } from '../lib/cmp';
@@ -11,7 +11,7 @@ const pages = [articles[0], blogs[0]].filter<GuPage>(isDefined);
 
 test.describe('merchandising slot', () => {
 	pages.forEach(({ path }, index) => {
-		breakpoints.forEach(({ breakpoint, width, height }) => {
+		allBreakpointSizes.forEach(({ breakpoint, width, height }) => {
 			test(`Test page ${index} has slot and iframe at breakpoint ${breakpoint}`, async ({
 				page,
 			}) => {

--- a/playwright/tests/merchandising.spec.ts
+++ b/playwright/tests/merchandising.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test';
 import { isDefined } from '../../src/lib/types';
-import { allBreakpointSizes } from '../fixtures/breakpoints';
+import { breakpointSizes } from '../fixtures/breakpoints';
 import { articles, blogs } from '../fixtures/pages';
 import type { GuPage } from '../fixtures/pages/Page';
 import { cmpAcceptAll } from '../lib/cmp';
@@ -11,7 +11,7 @@ const pages = [articles[0], blogs[0]].filter<GuPage>(isDefined);
 
 test.describe('merchandising slot', () => {
 	pages.forEach(({ path }, index) => {
-		allBreakpointSizes.forEach(({ breakpoint, width, height }) => {
+		breakpointSizes.forEach(({ breakpoint, width, height }) => {
 			test(`Test page ${index} has slot and iframe at breakpoint ${breakpoint}`, async ({
 				page,
 			}) => {

--- a/playwright/tests/mostpop.spec.ts
+++ b/playwright/tests/mostpop.spec.ts
@@ -1,7 +1,9 @@
 import { test } from '@playwright/test';
 import { isDefined } from '../../src/lib/types';
-import type { TestingBreakpoint } from '../fixtures/breakpoints';
-import { getBreakpointSize } from '../fixtures/breakpoints';
+import {
+	getBreakpointSize,
+	type TestingBreakpoint,
+} from '../fixtures/breakpoints';
 import { articles, blogs } from '../fixtures/pages';
 import type { GuPage } from '../fixtures/pages/Page';
 import { cmpAcceptAll } from '../lib/cmp';
@@ -16,13 +18,7 @@ test.describe('mostpop slot', () => {
 		 * Since the introduction of non-house advertising in the merchandising slot,
 		 * we now hide the most pop slot until the tablet breakpoint
 		 */
-		const testingBreakpoints = [
-			'tablet',
-			'desktop',
-			'wide',
-		] satisfies TestingBreakpoint[];
-
-		testingBreakpoints
+		(['tablet', 'desktop', 'wide'] satisfies TestingBreakpoint[])
 			.map(getBreakpointSize)
 			.forEach(({ breakpoint, width, height }) => {
 				test(`Test page ${index} has slot and iframe at breakpoint ${breakpoint}`, async ({

--- a/playwright/tests/mostpop.spec.ts
+++ b/playwright/tests/mostpop.spec.ts
@@ -1,6 +1,7 @@
 import { test } from '@playwright/test';
 import { isDefined } from '../../src/lib/types';
-import { testAtBreakpoints } from '../fixtures/breakpoints';
+import type { TestingBreakpoint } from '../fixtures/breakpoints';
+import { getBreakpointSize } from '../fixtures/breakpoints';
 import { articles, blogs } from '../fixtures/pages';
 import type { GuPage } from '../fixtures/pages/Page';
 import { cmpAcceptAll } from '../lib/cmp';
@@ -15,8 +16,15 @@ test.describe('mostpop slot', () => {
 		 * Since the introduction of non-house advertising in the merchandising slot,
 		 * we now hide the most pop slot until the tablet breakpoint
 		 */
-		testAtBreakpoints(['tablet', 'desktop', 'wide']).forEach(
-			({ breakpoint, width, height }) => {
+		const testingBreakpoints = [
+			'tablet',
+			'desktop',
+			'wide',
+		] satisfies TestingBreakpoint[];
+
+		testingBreakpoints
+			.map(getBreakpointSize)
+			.forEach(({ breakpoint, width, height }) => {
 				test(`Test page ${index} has slot and iframe at breakpoint ${breakpoint}`, async ({
 					page,
 				}) => {
@@ -30,7 +38,6 @@ test.describe('mostpop slot', () => {
 
 					await waitForSlot(page, 'mostpop');
 				});
-			},
-		);
+			});
 	});
 });

--- a/playwright/tests/pageskin.spec.ts
+++ b/playwright/tests/pageskin.spec.ts
@@ -1,17 +1,17 @@
 import type { Page } from '@playwright/test';
 import { expect, test } from '@playwright/test';
-import { breakpoints } from '../fixtures/breakpoints';
+import { allBreakpointSizes } from '../fixtures/breakpoints';
 import { frontWithPageSkin } from '../fixtures/pages';
 import { cmpAcceptAll } from '../lib/cmp';
 import { assertHeader, waitForGAMResponseForSlot } from '../lib/gam';
 import { loadPage } from '../lib/load-page';
 import { waitForSlot } from '../lib/util';
 
-const large = breakpoints.filter(
+const large = allBreakpointSizes.filter(
 	({ breakpoint }) => breakpoint === 'desktop' || breakpoint === 'wide',
 );
 
-const small = breakpoints.filter(
+const small = allBreakpointSizes.filter(
 	({ breakpoint }) => breakpoint === 'mobile' || breakpoint === 'tablet',
 );
 

--- a/playwright/tests/pageskin.spec.ts
+++ b/playwright/tests/pageskin.spec.ts
@@ -1,17 +1,17 @@
 import type { Page } from '@playwright/test';
 import { expect, test } from '@playwright/test';
-import { allBreakpointSizes } from '../fixtures/breakpoints';
+import { breakpointSizes } from '../fixtures/breakpoints';
 import { frontWithPageSkin } from '../fixtures/pages';
 import { cmpAcceptAll } from '../lib/cmp';
 import { assertHeader, waitForGAMResponseForSlot } from '../lib/gam';
 import { loadPage } from '../lib/load-page';
 import { waitForSlot } from '../lib/util';
 
-const large = allBreakpointSizes.filter(
+const large = breakpointSizes.filter(
 	({ breakpoint }) => breakpoint === 'desktop' || breakpoint === 'wide',
 );
 
-const small = allBreakpointSizes.filter(
+const small = breakpointSizes.filter(
 	({ breakpoint }) => breakpoint === 'mobile' || breakpoint === 'tablet',
 );
 


### PR DESCRIPTION
## What does this change?

- Stops renaming exported `breakpointSizes` from the Playwright breakpoint fixtures file
- Adjusts the type definitions slightly
- Exports `getBreakpointSize` rather than the function to do this for an array of sizes
- Uses upper case for constants in the Playwright fixtures file
- Updates consumers of the breakpoint fixtures file

## Why?

Tidying a bit whilst working on improving Typescript types knowledge in 10% time
