### PR TITLE
Remove top-above-nav at tablet breakpoint on consentless

### DIFF
--- a/src/init/consentless/init-fixed-slots.ts
+++ b/src/init/consentless/init-fixed-slots.ts
@@ -2,12 +2,18 @@ import { getCurrentBreakpoint } from '../../lib/detect/detect-breakpoint';
 import { removeDisabledSlots } from '../consented/remove-slots';
 import { defineSlot } from './define-slot';
 
+const isTabletOrMobile = () => {
+	const breakpoint = getCurrentBreakpoint();
+	return breakpoint === 'mobile' || breakpoint === 'tablet';
+};
+
 const initFixedSlots = async (): Promise<void> => {
 	await removeDisabledSlots();
 
-	const isDCRMobile =
-		window.guardian.config.isDotcomRendering &&
-		getCurrentBreakpoint() === 'mobile';
+	// We remove top-above-nav on both tablet and mobile for consentless
+	// due to issues with ad sizing in OptOut at the tablet breakpoint
+	const shouldHideTopAboveNav =
+		window.guardian.config.isDotcomRendering && isTabletOrMobile();
 
 	const adverts = [
 		...document.querySelectorAll<HTMLElement>(
@@ -17,7 +23,11 @@ const initFixedSlots = async (): Promise<void> => {
 		// we need to not init top-above-nav on mobile view in DCR
 		// as the DOM element needs to be removed and replaced to be inline
 		.filter(
-			(adSlot) => !(isDCRMobile && adSlot.id === 'dfp-ad--top-above-nav'),
+			(adSlot) =>
+				!(
+					shouldHideTopAboveNav &&
+					adSlot.id === 'dfp-ad--top-above-nav'
+				),
 		);
 
 	// define slots

--- a/src/init/consentless/init-fixed-slots.ts
+++ b/src/init/consentless/init-fixed-slots.ts
@@ -30,6 +30,12 @@ const initFixedSlots = async (): Promise<void> => {
 				),
 		);
 
+	if (getCurrentBreakpoint() === 'tablet') {
+		// We need to explicitly remove the element as there are no styles to hide it on tablet
+		const topAboveNav = document.querySelector('.top-banner-ad-container');
+		topAboveNav?.remove();
+	}
+
 	// define slots
 	adverts.forEach((slotElement) => {
 		const slotName = slotElement.dataset.name;

--- a/src/init/consentless/init-fixed-slots.ts
+++ b/src/init/consentless/init-fixed-slots.ts
@@ -12,7 +12,7 @@ const initFixedSlots = async (): Promise<void> => {
 
 	// We remove top-above-nav on both tablet and mobile for consentless
 	// due to issues with ad sizing in OptOut at the tablet breakpoint
-	const shouldHideTopAboveNav =
+	const isDCRMobileOrTablet =
 		window.guardian.config.isDotcomRendering && isTabletOrMobile();
 
 	const adverts = [
@@ -20,14 +20,11 @@ const initFixedSlots = async (): Promise<void> => {
 			'.js-ad-slot:not(.ad-slot--survey)',
 		),
 	]
-		// we need to not init top-above-nav on mobile view in DCR
+		// we need to not init top-above-nav on mobile and tablet view in DCR
 		// as the DOM element needs to be removed and replaced to be inline
 		.filter(
 			(adSlot) =>
-				!(
-					shouldHideTopAboveNav &&
-					adSlot.id === 'dfp-ad--top-above-nav'
-				),
+				!(isDCRMobileOrTablet && adSlot.id === 'dfp-ad--top-above-nav'),
 		);
 
 	if (getCurrentBreakpoint() === 'tablet') {


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This removes the top-above-nav slot at the tablet breakpoint in the consentless flow.

## Why?

Since we cannot pass ad sizes to OptOut in the same way as we do Google, the top-above-nave ad in this slot was served at desktop breakpoint size, causing horizontal scroll. The proportion of unconsented users on a tablet browser is extremely small (and likely to become smaller with consent or pay), so simply removing the slot as we do on mobile is a simpler solution than either trying to implement tablet top-above-nav ads in OptOut, or adding styling to cut off oversized ads with possible knock-on effects on consented advertising.

**Before**
![Screenshot 2025-02-25 at 14 06 45](https://github.com/user-attachments/assets/1400cd62-81d7-4aa7-a56e-7795740285d3)

**After**
![Screenshot 2025-02-25 at 14 06 54](https://github.com/user-attachments/assets/20856b47-078f-4ef4-a4af-13d26ef60931)
