### PR TITLE
Add consent helper to make it easier to check consent for TCF vendors safely

### DIFF
--- a/src/lib/consent.spec.ts
+++ b/src/lib/consent.spec.ts
@@ -1,0 +1,72 @@
+import { type ConsentState, getConsentFor } from '@guardian/libs';
+import { hasConsentFor } from './consent';
+
+jest.mock('@guardian/libs', () => ({
+	...jest.requireActual('@guardian/libs'),
+	getConsentFor: jest.fn().mockReturnValue(true),
+}));
+
+describe('consent', () => {
+	describe('hasConsentFor', () => {
+		it('returns true if in TCF region and consent granted for specific vendor', () => {
+			const mockConsentState: ConsentState = {
+				canTarget: true,
+				framework: 'tcfv2',
+			};
+			expect(hasConsentFor('criteo', mockConsentState)).toBe(true);
+		});
+
+		it('returns false if in TCF region and consent not granted for specific vendor', () => {
+			const mockConsentState: ConsentState = {
+				canTarget: true,
+				framework: 'tcfv2',
+			};
+			(getConsentFor as jest.Mock).mockReturnValueOnce(false);
+			expect(hasConsentFor('criteo', mockConsentState)).toBe(false);
+		});
+
+		it('returns true if in AUS region and personalisedAdvertising value is true', () => {
+			const mockConsentState: ConsentState = {
+				canTarget: true,
+				framework: 'aus',
+				aus: { personalisedAdvertising: true },
+			};
+			expect(hasConsentFor('criteo', mockConsentState)).toBe(true);
+		});
+
+		it('returns false if in AUS region and personalisedAdvertising value is false', () => {
+			const mockConsentState: ConsentState = {
+				canTarget: true,
+				framework: 'aus',
+				aus: { personalisedAdvertising: false },
+			};
+			expect(hasConsentFor('criteo', mockConsentState)).toBe(false);
+		});
+
+		it('returns true if in US region and doNotSell value is false', () => {
+			const mockConsentState: ConsentState = {
+				canTarget: true,
+				framework: 'usnat',
+				usnat: { doNotSell: false, signalStatus: 'ready' },
+			};
+			expect(hasConsentFor('criteo', mockConsentState)).toBe(true);
+		});
+
+		it('returns false if in US region and doNotSell value is true', () => {
+			const mockConsentState: ConsentState = {
+				canTarget: true,
+				framework: 'usnat',
+				usnat: { doNotSell: true, signalStatus: 'ready' },
+			};
+			expect(hasConsentFor('criteo', mockConsentState)).toBe(false);
+		});
+
+		it('returns false if in unknown consent framework', () => {
+			const mockConsentState: ConsentState = {
+				canTarget: true,
+				framework: null,
+			};
+			expect(hasConsentFor('criteo', mockConsentState)).toBe(false);
+		});
+	});
+});

--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -1,0 +1,25 @@
+import {
+	type ConsentState,
+	getConsentFor,
+	type VendorName,
+} from '@guardian/libs';
+
+/**
+ * Helper function to check consent for a known TCF vendor that also
+ * takes into account global consent frameworks (USNAT & AUS)
+ * */
+export const hasConsentFor = (
+	vendorName: VendorName,
+	consentState: ConsentState,
+): boolean => {
+	switch (consentState.framework) {
+		case 'tcfv2':
+			return getConsentFor(vendorName, consentState);
+		case 'aus':
+			return !!consentState.aus?.personalisedAdvertising;
+		case 'usnat':
+			return !consentState.usnat?.doNotSell;
+		default:
+			return false;
+	}
+};

--- a/src/lib/header-bidding/a9/a9.spec.ts
+++ b/src/lib/header-bidding/a9/a9.spec.ts
@@ -1,46 +1,4 @@
-import { getConsentFor, onConsentChange } from '@guardian/libs';
-import type {
-	OnConsentChangeCallback,
-	USNATConsentState,
-} from '@guardian/libs';
 import { _, a9 } from './a9';
-
-const tcfv2WithConsentMock = (callback: OnConsentChangeCallback) =>
-	callback({
-		tcfv2: {
-			consents: {
-				1: true,
-				2: true,
-				3: true,
-				4: true,
-				5: true,
-				6: true,
-				7: true,
-				8: true,
-				9: true,
-				10: true,
-			},
-			vendorConsents: { '5edf9a821dc4e95986b66df4': true },
-			eventStatus: 'tcloaded',
-			addtlConsent: '',
-			gdprApplies: true,
-			tcString: 'blablabla',
-		},
-		canTarget: true,
-		framework: 'tcfv2',
-	});
-
-const usnatConsent: USNATConsentState = {
-	doNotSell: false,
-	signalStatus: 'ready',
-};
-
-const usnatWithConsentMock = (callback: OnConsentChangeCallback) =>
-	callback({
-		usnat: usnatConsent,
-		canTarget: true,
-		framework: 'usnat',
-	});
 
 jest.mock('define/Advert', () =>
 	jest.fn().mockImplementation(() => ({ advert: jest.fn() })),
@@ -66,13 +24,6 @@ jest.mock('@guardian/libs', () => ({
 	onConsentChange: jest.fn(),
 }));
 
-const mockOnConsentChange = (
-	mfn: (callback: OnConsentChangeCallback) => void,
-) => (onConsentChange as jest.Mock).mockImplementation(mfn);
-
-const mockGetConsentFor = (hasConsent: boolean) =>
-	(getConsentFor as jest.Mock).mockReturnValueOnce(hasConsent);
-
 beforeEach(() => {
 	jest.resetModules();
 	_.resetModule();
@@ -89,16 +40,12 @@ afterAll(() => {
 
 describe('initialise', () => {
 	it('should generate initialise A9 library when TCFv2 consent has been given', () => {
-		mockOnConsentChange(tcfv2WithConsentMock);
-		mockGetConsentFor(true);
 		a9.initialise();
 		expect(window.apstag).toBeDefined();
 		expect(window.apstag?.init).toHaveBeenCalled();
 	});
 
 	it('should generate initialise A9 library when USNAT consent has been given', () => {
-		mockOnConsentChange(usnatWithConsentMock);
-		mockGetConsentFor(true);
 		a9.initialise();
 		expect(window.apstag).toBeDefined();
 		expect(window.apstag?.init).toHaveBeenCalled();

--- a/src/lib/header-bidding/prebid/prebid.spec.ts
+++ b/src/lib/header-bidding/prebid/prebid.spec.ts
@@ -35,8 +35,6 @@ const mockGetConsentFor = (hasConsent: boolean) =>
 		.mockReturnValueOnce(hasConsent)
 		.mockReturnValueOnce(hasConsent);
 
-// const mockGetConsentFor2 = jest.mock('@guardian', () => {});
-
 const resetPrebid = () => {
 	delete window.pbjs;
 	// @ts-expect-error -- there’s no types for this

--- a/src/lib/header-bidding/utils.spec.ts
+++ b/src/lib/header-bidding/utils.spec.ts
@@ -1,10 +1,7 @@
-import {
-	type ConsentState,
-	type CountryCode,
-	getConsentFor as getConsentFor_,
-} from '@guardian/libs';
+import { type ConsentState, type CountryCode } from '@guardian/libs';
 import { isUserInVariant as isUserInVariant_ } from '../../experiments/ab';
 import { createAdSize } from '../../lib/ad-sizes';
+import { hasConsentFor } from '../../lib/consent';
 import { _ } from '../../lib/geo/geo-utils';
 import type { SourceBreakpoint } from '../detect/detect-breakpoint';
 import {
@@ -39,10 +36,6 @@ const isUserInVariant = isUserInVariant_ as jest.MockedFunction<
 	typeof isUserInVariant_
 >;
 
-const getConsentFor = getConsentFor_ as jest.MockedFunction<
-	typeof getConsentFor_
->;
-
 const mockConsentState = {
 	tcfv2: {
 		consents: { '': true },
@@ -56,13 +49,6 @@ const mockConsentState = {
 	canTarget: true,
 	framework: 'tcfv2',
 } satisfies ConsentState;
-
-jest.mock('@guardian/libs', () => {
-	return {
-		...jest.requireActual('@guardian/libs'),
-		getConsentFor: jest.fn(),
-	};
-});
 
 jest.mock('lodash-es/once', () => (fn: (...args: unknown[]) => unknown) => fn);
 
@@ -80,6 +66,10 @@ jest.mock('lib/detect/detect-breakpoint', () => ({
 }));
 
 jest.mock('experiments/ab-tests');
+
+jest.mock('lib/consent', () => ({
+	hasConsentFor: jest.fn().mockReturnValue(true),
+}));
 
 const resetConfig = () => {
 	window.guardian.config.switches.prebidAppnexus = true;
@@ -188,7 +178,7 @@ describe('Utils', () => {
 				window.guardian.config.switches.prebidAppnexusUkRow =
 					switchState === 'on';
 				getCountryCode.mockReturnValue(region);
-				getConsentFor.mockReturnValue(true);
+				(hasConsentFor as jest.Mock).mockReturnValue(true);
 				expect(shouldIncludeAppNexus(mockConsentState)).toBe(expected);
 			},
 		);
@@ -196,7 +186,7 @@ describe('Utils', () => {
 		test('If consent denied should not load in GB region', () => {
 			window.guardian.config.switches.prebidAppnexusUkRow = true;
 			getCountryCode.mockReturnValue('GB');
-			getConsentFor.mockReturnValue(false);
+			(hasConsentFor as jest.Mock).mockReturnValue(false);
 			expect(shouldIncludeAppNexus(mockConsentState)).toBe(false);
 		});
 	});
@@ -204,13 +194,13 @@ describe('Utils', () => {
 	describe('shouldIncludeOpenX', () => {
 		test('should return true if geolocation is GB', () => {
 			getCountryCode.mockReturnValueOnce('GB');
-			getConsentFor.mockReturnValue(true);
+			(hasConsentFor as jest.Mock).mockReturnValue(true);
 			expect(shouldIncludeOpenx(mockConsentState)).toBe(true);
 		});
 
 		test('should return false if consent not given', () => {
 			getCountryCode.mockReturnValueOnce('GB');
-			getConsentFor.mockReturnValue(false);
+			(hasConsentFor as jest.Mock).mockReturnValue(false);
 			expect(shouldIncludeOpenx(mockConsentState)).toBe(false);
 		});
 
@@ -226,7 +216,7 @@ describe('Utils', () => {
 			];
 			for (const testGeo of testGeos) {
 				getCountryCode.mockReturnValueOnce(testGeo);
-				getConsentFor.mockReturnValue(true);
+				(hasConsentFor as jest.Mock).mockReturnValue(true);
 				expect(shouldIncludeOpenx(mockConsentState)).toBe(true);
 			}
 		});
@@ -235,7 +225,7 @@ describe('Utils', () => {
 			const testGeos: CountryCode[] = ['CA', 'US'];
 			for (const testGeo of testGeos) {
 				getCountryCode.mockReturnValue(testGeo);
-				getConsentFor.mockReturnValue(true);
+				(hasConsentFor as jest.Mock).mockReturnValue(true);
 				expect(shouldIncludeOpenx(mockConsentState)).toBe(false);
 			}
 		});
@@ -244,7 +234,7 @@ describe('Utils', () => {
 			const testGeos: CountryCode[] = ['NZ', 'AU'];
 			for (const testGeo of testGeos) {
 				getCountryCode.mockReturnValue(testGeo);
-				getConsentFor.mockReturnValue(true);
+				(hasConsentFor as jest.Mock).mockReturnValue(true);
 				expect(shouldIncludeOpenx(mockConsentState)).toBe(true);
 			}
 		});
@@ -285,7 +275,7 @@ describe('Utils', () => {
 			);
 			window.guardian.config.page.isDev = true;
 			getCountryCode.mockReturnValue('GB');
-			getConsentFor.mockReturnValue(true);
+			(hasConsentFor as jest.Mock).mockReturnValue(true);
 			expect(shouldIncludeXaxis(mockConsentState)).toBe(true);
 		});
 
@@ -305,7 +295,7 @@ describe('Utils', () => {
 			];
 			for (const testGeo of testGeos) {
 				getCountryCode.mockReturnValue(testGeo);
-				getConsentFor.mockReturnValue(true);
+				(hasConsentFor as jest.Mock).mockReturnValue(true);
 				expect(shouldIncludeXaxis(mockConsentState)).toBe(false);
 			}
 		});

--- a/src/lib/header-bidding/utils.ts
+++ b/src/lib/header-bidding/utils.ts
@@ -1,4 +1,4 @@
-import { type ConsentState, getConsentFor, isString } from '@guardian/libs';
+import { type ConsentState, isString } from '@guardian/libs';
 import { once } from 'lodash-es';
 import { createAdSize } from '../../lib/ad-sizes';
 import {
@@ -9,6 +9,7 @@ import {
 	isInUsOrCa,
 } from '../../lib/geo/geo-utils';
 import { pbTestNameMap } from '../../lib/url';
+import { hasConsentFor } from '../consent';
 import {
 	getCurrentTweakpoint,
 	matchesBreakpoints,
@@ -161,7 +162,7 @@ export const isSwitchedOn = (switchName: string): boolean =>
 
 export const shouldIncludeOpenx = (consentState: ConsentState): boolean =>
 	isSwitchedOn('prebidOpenx') &&
-	getConsentFor('openX', consentState) &&
+	hasConsentFor('openX', consentState) &&
 	!isInUsOrCa();
 
 export const shouldIncludeTrustX = (): boolean =>
@@ -173,7 +174,7 @@ export const shouldIncludeTripleLift = (): boolean =>
 // TODO: Check is we want regional restrictions on where we load the ozoneBidAdapter
 export const shouldIncludeOzone = (consentState: ConsentState): boolean =>
 	isSwitchedOn('prebidOzone') &&
-	getConsentFor('ozone', consentState) &&
+	hasConsentFor('ozone', consentState) &&
 	!isInCanada() &&
 	!isInAuOrNz();
 
@@ -181,47 +182,47 @@ export const shouldIncludeAppNexus = (consentState: ConsentState): boolean =>
 	isSwitchedOn('prebidAppnexus') &&
 	(isInAuOrNz() ||
 		(isSwitchedOn('prebidAppnexusUkRow') &&
-			getConsentFor('xandr', consentState) &&
+			hasConsentFor('xandr', consentState) &&
 			!isInUsOrCa()) ||
 		!!pbTestNameMap().and);
 
 export const shouldIncludeXaxis = (consentState: ConsentState): boolean =>
 	isSwitchedOn('prebidXaxis') &&
-	getConsentFor('xandr', consentState) &&
+	hasConsentFor('xandr', consentState) &&
 	isInUk();
 
 export const shouldIncludeKargo = (): boolean =>
 	isSwitchedOn('prebidKargo') && isInUsa();
 
 export const shouldIncludeMagnite = (consentState: ConsentState): boolean =>
-	isSwitchedOn('prebidMagnite') && getConsentFor('magnite', consentState);
+	isSwitchedOn('prebidMagnite') && hasConsentFor('magnite', consentState);
 
 export const shouldIncludeCriteo = (consentState: ConsentState): boolean =>
-	isSwitchedOn('prebidCriteo') && getConsentFor('criteo', consentState);
+	isSwitchedOn('prebidCriteo') && hasConsentFor('criteo', consentState);
 
 export const shouldIncludePubmatic = (consentState: ConsentState): boolean =>
-	isSwitchedOn('prebidPubmatic') && getConsentFor('pubmatic', consentState);
+	isSwitchedOn('prebidPubmatic') && hasConsentFor('pubmatic', consentState);
 
 export const shouldIncludeAdYouLike = (consentState: ConsentState): boolean =>
-	isSwitchedOn('prebidAdYouLike') && getConsentFor('adYouLike', consentState);
+	isSwitchedOn('prebidAdYouLike') && hasConsentFor('adYouLike', consentState);
 
 export const shouldIncludeTheTradeDesk = (
 	consentState: ConsentState,
 ): boolean =>
 	isSwitchedOn('prebidTheTradeDesk') &&
-	getConsentFor('theTradeDesk', consentState);
+	hasConsentFor('theTradeDesk', consentState);
 
 export const shouldIncludeIndexExchange = (
 	consentState: ConsentState,
 ): boolean =>
 	isSwitchedOn('prebidIndexExchange') &&
-	getConsentFor('indexExchange', consentState);
+	hasConsentFor('indexExchange', consentState);
 
 export const shouldIncludePermutive = (consentState: ConsentState): boolean =>
 	isSwitchedOn('permutive') &&
 	/** this switch specifically controls whether or not the Permutive Audience Connector can run with Prebid */
 	isSwitchedOn('prebidPermutiveAudience') &&
-	getConsentFor('permutive', consentState);
+	hasConsentFor('permutive', consentState);
 
 export const shouldIncludeMobileSticky = once(
 	(): boolean =>


### PR DESCRIPTION
## What does this change?

Adds `hasConsentFor` function to wrap the `@guardian/libs` `getConsentFor` function that also takes into account the non TCF frameworks

Uses this in the Prebid `utils` file helpers

There are quite a few instances where we want to use the same logic so we can start to use this function in other places in this repo if successful

## Why?

There's a possible mistake in https://github.com/guardian/commercial/pull/1797 because it only checks consent for vendors in TCF regions, without taking into account whether it needs to or not
