### PR TITLE
Revert "Only run Prebid in GDPR regions if all TCF Prebid vendors have consent"

### DIFF
--- a/src/init/consented/prepare-prebid.spec.ts
+++ b/src/init/consented/prepare-prebid.spec.ts
@@ -7,7 +7,6 @@ import { getConsentFor, log, onConsent } from '@guardian/libs';
 import { commercialFeatures } from '../../lib/commercial-features';
 import { isInCanada } from '../../lib/geo/geo-utils';
 import { prebid } from '../../lib/header-bidding/prebid/prebid';
-import { allTcfPrebidVendorsConsented } from '../../lib/header-bidding/utils';
 import { _ } from './prepare-prebid';
 
 const { setupPrebid } = _;
@@ -45,8 +44,6 @@ jest.mock('lib/header-bidding/prebid/bid-config', () => ({
 }));
 
 jest.mock('lib/header-bidding/utils', () => ({
-	...jest.requireActual('lib/header-bidding/utils'),
-	allTcfPrebidVendorsConsented: jest.fn().mockReturnValue(true),
 	shouldIncludeOnlyA9: false,
 }));
 
@@ -162,7 +159,6 @@ describe('init', () => {
 		commercialFeatures.adFree = false;
 		mockOnConsent(tcfv2WithConsent);
 		mockGetConsentFor(true);
-		(allTcfPrebidVendorsConsented as jest.Mock).mockReturnValue(true);
 
 		await setupPrebid();
 		expect(prebid.initialise).toHaveBeenCalled();
@@ -178,7 +174,6 @@ describe('init', () => {
 		fakeUserAgent('Google Web Preview');
 		mockOnConsent(tcfv2WithConsent);
 		mockGetConsentFor(true);
-		(allTcfPrebidVendorsConsented as jest.Mock).mockReturnValue(true);
 
 		await setupPrebid();
 		expect(prebid.initialise).not.toHaveBeenCalled();
@@ -194,7 +189,6 @@ describe('init', () => {
 		};
 		mockOnConsent(tcfv2WithConsent);
 		mockGetConsentFor(true);
-		(allTcfPrebidVendorsConsented as jest.Mock).mockReturnValue(true);
 
 		await setupPrebid();
 		expect(prebid.initialise).not.toHaveBeenCalled();
@@ -210,7 +204,6 @@ describe('init', () => {
 		commercialFeatures.adFree = false;
 		mockOnConsent(tcfv2WithConsent);
 		mockGetConsentFor(true);
-		(allTcfPrebidVendorsConsented as jest.Mock).mockReturnValue(true);
 
 		await setupPrebid();
 		expect(prebid.initialise).toHaveBeenCalled();
@@ -262,38 +255,6 @@ describe('init', () => {
 		expect(prebid.initialise).not.toHaveBeenCalled();
 	});
 
-	it('should not initialise Prebid if shouldIncludeOnlyA9 is true', async () => {
-		jest.mock('lib/header-bidding/utils', () => ({
-			...jest.requireActual('lib/header-bidding/utils'),
-			allTcfPrebidVendorsConsented: jest.fn().mockReturnValue(true),
-			shouldIncludeOnlyA9: true,
-		}));
-
-		window.guardian.config.switches = {
-			prebidHeaderBidding: true,
-		};
-		commercialFeatures.shouldLoadGoogletag = true;
-		commercialFeatures.adFree = false;
-
-		mockOnConsent(tcfv2WithConsent);
-		mockGetConsentFor(true);
-
-		await setupPrebid();
-		expect(prebid.initialise).not.toHaveBeenCalled();
-	});
-
-	it('should not initialise Prebid if allTcfPrebidVendorsConsented is false', async () => {
-		window.guardian.config.switches = {
-			prebidHeaderBidding: true,
-		};
-		commercialFeatures.shouldLoadGoogletag = true;
-		commercialFeatures.adFree = false;
-		(allTcfPrebidVendorsConsented as jest.Mock).mockReturnValue(false);
-
-		await setupPrebid();
-		expect(prebid.initialise).not.toHaveBeenCalled();
-	});
-
 	it('should not initialise Prebid when the page has a pageskin', async () => {
 		expect.hasAssertions();
 
@@ -305,7 +266,6 @@ describe('init', () => {
 		window.guardian.config.page.hasPageSkin = true;
 		mockOnConsent(tcfv2WithConsent);
 		mockGetConsentFor(true);
-		(allTcfPrebidVendorsConsented as jest.Mock).mockReturnValue(true);
 
 		await setupPrebid();
 		expect(prebid.initialise).not.toHaveBeenCalled();
@@ -320,13 +280,12 @@ describe('init', () => {
 		window.guardian.config.page.hasPageSkin = false;
 		mockOnConsent(tcfv2WithConsent);
 		mockGetConsentFor(true);
-		(allTcfPrebidVendorsConsented as jest.Mock).mockReturnValue(true);
 
 		await setupPrebid();
 		expect(prebid.initialise).toHaveBeenCalled();
 	});
 
-	it('should initialise Prebid if TCFv2 consent with correct Sourcepoint Id is true', async () => {
+	it('should initialise Prebid if TCFv2 consent with correct Sourcepoint Id is true ', async () => {
 		expect.hasAssertions();
 
 		window.guardian.config.switches = {
@@ -336,7 +295,6 @@ describe('init', () => {
 		commercialFeatures.adFree = false;
 		mockOnConsent(tcfv2WithConsent);
 		mockGetConsentFor(true);
-		(allTcfPrebidVendorsConsented as jest.Mock).mockReturnValue(true);
 
 		await setupPrebid();
 		expect(prebid.initialise).toHaveBeenCalled();
@@ -352,7 +310,6 @@ describe('init', () => {
 		commercialFeatures.adFree = false;
 		mockOnConsent(tcfv2WithoutConsent);
 		mockGetConsentFor(false);
-		(allTcfPrebidVendorsConsented as jest.Mock).mockReturnValue(true);
 
 		await setupPrebid();
 		expect(log).toHaveBeenCalledWith(
@@ -467,7 +424,6 @@ describe('init', () => {
 		commercialFeatures.adFree = false;
 		mockOnConsent(tcfv2WithConsent);
 		mockGetConsentForWithCustom(true, false);
-		(allTcfPrebidVendorsConsented as jest.Mock).mockReturnValue(true);
 
 		await setupPrebid();
 		expect(prebid.initialise).toHaveBeenCalled();
@@ -483,7 +439,6 @@ describe('init', () => {
 		commercialFeatures.adFree = false;
 		mockOnConsent(tcfv2WithConsent);
 		mockGetConsentForWithCustom(false, true);
-		(allTcfPrebidVendorsConsented as jest.Mock).mockReturnValue(true);
 
 		await setupPrebid();
 		expect(prebid.initialise).toHaveBeenCalled();
@@ -499,7 +454,6 @@ describe('init', () => {
 		commercialFeatures.adFree = false;
 		mockOnConsent(tcfv2WithConsent);
 		mockGetConsentForWithCustom(false, false);
-		(allTcfPrebidVendorsConsented as jest.Mock).mockReturnValue(true);
 
 		await setupPrebid();
 		expect(log).toHaveBeenCalledWith(

--- a/src/init/consented/prepare-prebid.ts
+++ b/src/init/consented/prepare-prebid.ts
@@ -5,10 +5,7 @@ import { commercialFeatures } from '../../lib/commercial-features';
 import { isGoogleProxy } from '../../lib/detect/detect-google-proxy';
 import { isInCanada } from '../../lib/geo/geo-utils';
 import { prebid } from '../../lib/header-bidding/prebid/prebid';
-import {
-	allTcfPrebidVendorsConsented,
-	shouldIncludeOnlyA9,
-} from '../../lib/header-bidding/utils';
+import { shouldIncludeOnlyA9 } from '../../lib/header-bidding/utils';
 
 const shouldLoadPrebid = () =>
 	!isGoogleProxy() &&
@@ -44,24 +41,14 @@ const setupPrebid = async (): Promise<void> => {
 			'prebidCustom',
 			consentState,
 		);
-
 		log('commercial', 'Prebid consent:', {
 			hasConsentForGlobalPrebidVendor,
 			hasConsentForCustomPrebidVendor,
-			...(consentState.framework === 'tcfv2'
-				? {
-						hasConsentForAllTcfVendors:
-							allTcfPrebidVendorsConsented(consentState),
-					}
-				: {}),
 		});
-
 		if (
-			(consentState.framework === 'tcfv2' &&
-				!allTcfPrebidVendorsConsented(consentState)) ||
 			// Check if we do NOT have consent to BOTH the old global and custom prebid vendor
-			(!hasConsentForGlobalPrebidVendor &&
-				!hasConsentForCustomPrebidVendor)
+			!hasConsentForGlobalPrebidVendor &&
+			!hasConsentForCustomPrebidVendor
 		) {
 			throw new Error('No consent for prebid');
 		}

--- a/src/lib/header-bidding/prebid-types.ts
+++ b/src/lib/header-bidding/prebid-types.ts
@@ -126,21 +126,6 @@ export type BidderCode =
 	| 'xhb'
 	| 'ttd';
 
-export type TcfBidderCode = Extract<
-	BidderCode,
-	| 'adyoulike'
-	| 'and'
-	| 'appnexus'
-	| 'criteo'
-	| 'ix'
-	| 'rubicon'
-	| 'oxd'
-	| 'ozone'
-	| 'pubmatic'
-	| 'xhb'
-	| 'ttd'
->;
-
 export type PrebidParams =
 	| PrebidAdYouLikeParams
 	| PrebidAppNexusParams

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -21,7 +21,11 @@ import type {
 	SlotFlatMap,
 } from '../prebid-types';
 import { getHeaderBiddingAdSlots } from '../slot-config';
-import { isSwitchedOn, stripDfpAdPrefixFrom } from '../utils';
+import {
+	isSwitchedOn,
+	shouldIncludePermutive,
+	stripDfpAdPrefixFrom,
+} from '../utils';
 import { bids } from './bid-config';
 import type { PrebidPriceGranularity } from './price-config';
 import {
@@ -266,7 +270,7 @@ declare global {
 }
 
 const shouldEnableAnalytics = (): boolean => {
-	if (!isSwitchedOn('prebidAnalytics')) {
+	if (!window.guardian.config.switches.prebidAnalytics) {
 		return false;
 	}
 
@@ -301,7 +305,7 @@ const initialise = (window: Window, consentState: ConsentState): void => {
 	}
 	initialised = true;
 
-	const userSync: UserSync = isSwitchedOn('prebidUserSync')
+	const userSync: UserSync = window.guardian.config.switches.prebidUserSync
 		? {
 				syncsPerBidder: 0, // allow all syncs
 				filterSettings: {
@@ -366,15 +370,11 @@ const initialise = (window: Window, consentState: ConsentState): void => {
 
 	window.pbjs.bidderSettings = {};
 
-	if (isSwitchedOn('consentManagement')) {
+	if (window.guardian.config.switches.consentManagement) {
 		pbjsConfig.consentManagement = consentManagement();
 	}
 
-	if (
-		isSwitchedOn('permutive') &&
-		// this switch specifically controls whether or not the Permutive Audience Connector can run with Prebid
-		isSwitchedOn('prebidPermutiveAudience')
-	) {
+	if (shouldIncludePermutive(consentState)) {
 		pbjsConfig.realTimeData = {
 			dataProviders: [
 				{
@@ -551,7 +551,7 @@ const requestBids = async (
 		return requestQueue;
 	}
 
-	if (!isSwitchedOn('prebidHeaderBidding')) {
+	if (!window.guardian.config.switches.prebidHeaderBidding) {
 		return requestQueue;
 	}
 

--- a/src/lib/header-bidding/utils.spec.ts
+++ b/src/lib/header-bidding/utils.spec.ts
@@ -13,7 +13,6 @@ import {
 } from '../detect/detect-breakpoint';
 import { getCountryCode as getCountryCode_ } from '../geo/country-code';
 import {
-	allTcfPrebidVendorsConsented,
 	getBreakpointKey,
 	getLargestSize,
 	removeFalsyValues,
@@ -309,24 +308,6 @@ describe('Utils', () => {
 				getConsentFor.mockReturnValue(true);
 				expect(shouldIncludeXaxis(mockConsentState)).toBe(false);
 			}
-		});
-	});
-
-	describe('allTcfPrebidVendorsConsented', () => {
-		it('returns true if all of the vendors have consented', () => {
-			getConsentFor.mockReturnValue(true);
-			expect(allTcfPrebidVendorsConsented(mockConsentState)).toBe(true);
-		});
-
-		it('returns false if one of the vendors has not consented', () => {
-			getConsentFor.mockReturnValue(true);
-			getConsentFor.mockReturnValueOnce(false);
-			expect(allTcfPrebidVendorsConsented(mockConsentState)).toBe(false);
-		});
-
-		it('returns false if all of the vendors have not consented', () => {
-			getConsentFor.mockReturnValue(false);
-			expect(allTcfPrebidVendorsConsented(mockConsentState)).toBe(false);
 		});
 	});
 

--- a/src/lib/header-bidding/utils.ts
+++ b/src/lib/header-bidding/utils.ts
@@ -1,9 +1,4 @@
-import {
-	type ConsentState,
-	getConsentFor,
-	isString,
-	log,
-} from '@guardian/libs';
+import { type ConsentState, getConsentFor, isString } from '@guardian/libs';
 import { once } from 'lodash-es';
 import { createAdSize } from '../../lib/ad-sizes';
 import {
@@ -18,7 +13,7 @@ import {
 	getCurrentTweakpoint,
 	matchesBreakpoints,
 } from '../detect/detect-breakpoint';
-import type { HeaderBiddingSize, TcfBidderCode } from './prebid-types';
+import type { HeaderBiddingSize } from './prebid-types';
 
 type StringManipulation = (a: string, b: string) => string;
 type RegExpRecords = Record<string, RegExp | undefined>;
@@ -227,38 +222,6 @@ export const shouldIncludePermutive = (consentState: ConsentState): boolean =>
 	/** this switch specifically controls whether or not the Permutive Audience Connector can run with Prebid */
 	isSwitchedOn('prebidPermutiveAudience') &&
 	getConsentFor('permutive', consentState);
-
-export const allTcfPrebidVendorsConsented = (
-	consentState: ConsentState,
-): boolean => {
-	const tcfVendorConsent: Record<TcfBidderCode, boolean> = {
-		adyoulike: getConsentFor('adYouLike', consentState),
-		appnexus: getConsentFor('xandr', consentState),
-		and: getConsentFor('xandr', consentState),
-		criteo: getConsentFor('criteo', consentState),
-		ix: getConsentFor('indexExchange', consentState),
-		rubicon: getConsentFor('magnite', consentState),
-		oxd: getConsentFor('openX', consentState),
-		ozone: getConsentFor('ozone', consentState),
-		pubmatic: getConsentFor('pubmatic', consentState),
-		xhb: getConsentFor('groupM', consentState),
-		ttd: getConsentFor('theTradeDesk', consentState),
-	};
-
-	const hasConsentForAllVendors =
-		Object.values(tcfVendorConsent).every(Boolean);
-
-	if (!hasConsentForAllVendors) {
-		log(
-			'commercial',
-			'Some Prebid bidders do not have consent to run',
-			Object.entries(tcfVendorConsent)
-				.filter(([, hasConsent]) => !hasConsent)
-				.map(([bidder]) => bidder),
-		);
-	}
-	return hasConsentForAllVendors;
-};
 
 export const shouldIncludeMobileSticky = once(
 	(): boolean =>


### PR DESCRIPTION
Reverts guardian/commercial#1824

We don't actually want to do this. If there are new vendors added to the vendor list and a user is not prompted to re-consent, this will prevent us being able to run Prebid at all for those users. Since users are not prompted to re-consent for every new vendor added, this poses a revenue risk. It will be better to manage this on a more granular basis
