### PR TITLE
fixes the unblocking of gumgum for articles - non fronts

### DIFF
--- a/src/lib/header-bidding/a9/a9.spec.ts
+++ b/src/lib/header-bidding/a9/a9.spec.ts
@@ -171,6 +171,6 @@ describe('shouldBlockGumGum', () => {
 			blockedBidders: [],
 		};
 		const result = a9.shouldBlockGumGum(mockAdUnit);
-		expect(result).toBe(true);
+		expect(result).toBe(false);
 	});
 });

--- a/src/lib/header-bidding/a9/a9.ts
+++ b/src/lib/header-bidding/a9/a9.ts
@@ -64,7 +64,8 @@ const shouldBlockGumGum = (adUnit: A9AdUnit): boolean => {
 
 	const blockGumGum =
 		!(isNetworkFront && adUnit.slotID === 'dfp-ad--inline1--mobile') &&
-		!(isSectionFront && adUnit.slotID === 'dfp-ad--top-above-nav');
+		!(isSectionFront && adUnit.slotID === 'dfp-ad--top-above-nav') &&
+		!!isFront;
 	return blockGumGum;
 };
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
This extends the work done in [PR](https://github.com/guardian/commercial/pull/1799) 
## Why?
This PR unblocks GumGum for non fronts pages (articles).