### PR TITLE
Handle DuckDuckGo Mobile errors 🦆

### DIFF
--- a/src/define/create-advert.ts
+++ b/src/define/create-advert.ts
@@ -20,7 +20,13 @@ const createAdvert = (
 
 		log('commercial', errMsg);
 
-		if (!navigator.userAgent.includes('DuckDuckGo')) {
+		// The DuckDuckGo browser blocks ads from loading by default, so it causes a lot of noise in Sentry.
+		// We filter these errors out here - DuckDuckGo is in the user agent string if someone is using the
+		// desktop browser, and Ddg is present for those using the mobile browser, so we filter out both.
+		if (
+			!navigator.userAgent.includes('DuckDuckGo') &&
+			!navigator.userAgent.includes('Ddg')
+		) {
 			reportError(new Error(errMsg), 'commercial');
 		}
 

--- a/src/init/consented/prepare-googletag.ts
+++ b/src/init/consented/prepare-googletag.ts
@@ -102,14 +102,18 @@ export const init = (): Promise<void> => {
 				() => void fillStaticAdvertSlots(),
 			);
 
-			//DuckDuckGo blocks googletag request by default, creating a lot of noise in Sentry
-			//This flow allows us to handle errors originating from DuckDuckGo without spamming Sentry
+			// The DuckDuckGo browser blocks ads from loading by default, so it causes a lot of noise in Sentry.
+			// We filter these errors out here - DuckDuckGo is in the user agent string if someone is using the
+			// desktop browser, and Ddg is present for those using the mobile browser, so we filter out both.
 			loadScript(
 				window.guardian.config.page.libs?.googletag ??
 					'//securepubads.g.doubleclick.net/tag/js/gpt.js',
 				{ async: false },
 			).catch((error: Error) => {
-				if (navigator.userAgent.includes('DuckDuckGo')) {
+				if (
+					navigator.userAgent.includes('DuckDuckGo') ||
+					navigator.userAgent.includes('Ddg')
+				) {
 					log(
 						'commercial',
 						'🦆 Caught loadScript error on DuckDuckGo',


### PR DESCRIPTION
## What does this change?
Filters out `loadScript` and `createAdvert` errors that are caused by the DuckDuckGo Mobile browser to reduce noise on Sentry. I've also updated the comments from the ones I made a few years back to explain where the string values we look for come from.

## Why?
DuckDuckGo strikes again. Found an error in Sentry with these stats:

<img width="321" alt="Screenshot 2025-03-05 at 16 42 19" src="https://github.com/user-attachments/assets/22600a78-fbf8-4cd4-9ced-e0f74735471c" />
<img width="307" alt="Screenshot 2025-03-05 at 16 42 23" src="https://github.com/user-attachments/assets/35d6c30c-6586-4813-a5da-1f130581513a" />

DuckDuckGo is massively overrepresented in Sentry errors because it blocks ads by default, so we filter out the desktop browsers to reduce noise in Sentry. The mobile browser is now causing similar issues, so it's worth filtering these out too.