### PR TITLE
Add keywords to ortb2.site.ext.data in Prebid config

### DIFF
--- a/src/lib/header-bidding/prebid/prebid.spec.ts
+++ b/src/lib/header-bidding/prebid/prebid.spec.ts
@@ -52,6 +52,7 @@ describe('initialise', () => {
 		window.guardian.config.switches.prebidUserSync = true;
 		window.guardian.config.switches.prebidAppNexus = true;
 		window.guardian.config.switches.prebidXaxis = true;
+		window.guardian.config.page.keywords = 'Key,Words';
 		getAdvertById.mockReset();
 	});
 
@@ -91,6 +92,15 @@ describe('initialise', () => {
 			maxBid: 5000,
 			maxNestedIframes: 10,
 			mediaTypePriceGranularity: {},
+			ortb2: {
+				site: {
+					ext: {
+						data: {
+							keywords: ['Key', 'Words'],
+						},
+					},
+				},
+			},
 			priceGranularity: 'custom',
 			s2sConfig: {
 				adapter: 'prebidServer',

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -93,6 +93,15 @@ type PbjsConfig = {
 	timeoutBuffer?: number;
 	priceGranularity: PrebidPriceGranularity;
 	userSync: UserSync;
+	ortb2?: {
+		site: {
+			ext: {
+				data: {
+					keywords: string[];
+				};
+			};
+		};
+	};
 	consentManagement?: ConsentManagement;
 	realTimeData?: unknown;
 };
@@ -367,6 +376,18 @@ const initialise = (window: Window, consentState: ConsentState): void => {
 			userSync,
 		},
 	);
+
+	const keywordsArray = window.guardian.config.page.keywords.split(',');
+
+	pbjsConfig.ortb2 = {
+		site: {
+			ext: {
+				data: {
+					keywords: keywordsArray,
+				},
+			},
+		},
+	};
 
 	window.pbjs.bidderSettings = {};
 


### PR DESCRIPTION
## What does this change?
Adds page keywords to `ortb2.site.ext.data` in the Prebid bid config. Example of how this looks:

<img width="683" alt="Screenshot 2025-03-05 at 17 51 29" src="https://github.com/user-attachments/assets/7fb58a5c-c71f-45bb-90f5-7bfdcb15b9eb" />


## Why?
Magnite and Index access keywords through `ortb2.site.ext.data`, and these are the bidders that we want to receive keywords. We're not adding keywords to `ortb2.site` because there is no revenue benefit.