### PR TITLE
Fix types for `ttd` Prebid bidder

### DIFF
--- a/src/lib/header-bidding/prebid-types.ts
+++ b/src/lib/header-bidding/prebid-types.ts
@@ -105,8 +105,8 @@ export type PrebidMagniteParams = {
 };
 
 export type PrebidTheTradeDeskParams = {
-	supplySourceId: number;
-	publisherId: number;
+	supplySourceId: string;
+	publisherId: string;
 	placementId: string;
 };
 

--- a/src/lib/header-bidding/prebid/bid-config.ts
+++ b/src/lib/header-bidding/prebid/bid-config.ts
@@ -25,6 +25,7 @@ import type {
 	PrebidOpenXParams,
 	PrebidOzoneParams,
 	PrebidPubmaticParams,
+	PrebidTheTradeDeskParams,
 	PrebidTripleLiftParams,
 	PrebidTrustXParams,
 	PrebidXaxisParams,
@@ -608,7 +609,7 @@ const magniteBidder: PrebidBidder = {
 const theTradeDeskBidder = (gpid: string): PrebidBidder => ({
 	name: 'ttd',
 	switchName: 'prebidTheTradeDesk',
-	bidParams: () => ({
+	bidParams: (): PrebidTheTradeDeskParams => ({
 		supplySourceId: 'theguardian',
 		publisherId: '1',
 		placementId: gpid,


### PR DESCRIPTION
## What does this change?

Fixes the types for the Trade Desk Prebid bidder
See https://docs.prebid.org/dev-docs/bidders/ttd.html

<img width="896" alt="image" src="https://github.com/user-attachments/assets/c0b27436-a035-40a4-acbf-7d3653a53f9b" />


## Why?

Two fields were listed as `number` type when they should have been `string`. Our type system wasn't picking this up until the type `PrebidTheTradeDeskParams` was explicitly used as a return type of the `bidParams` function
