### PR TITLE
Update peer dependency ranges for core-web-vitals and identity-auth packages

### DIFF
--- a/.changeset/loud-moose-beam.md
+++ b/.changeset/loud-moose-beam.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': major
+---
+
+Updates peer dependency ranges for @guardian/core-web-vitals and @guardian/identity-auth

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
 	},
 	"peerDependencies": {
 		"@guardian/ab-core": "^8.0.0",
-		"@guardian/core-web-vitals": "^8.0.1",
-		"@guardian/identity-auth": "^4.0.0",
-		"@guardian/identity-auth-frontend": "^6.0.0",
+		"@guardian/core-web-vitals": "^11.0.0",
+		"@guardian/identity-auth": "^7.0.0",
+		"@guardian/identity-auth-frontend": "^6.0.2",
 		"@guardian/libs": "^22.0.0",
-		"@guardian/source": "^8.0.0",
-		"typescript": "~5.5.2"
+		"@guardian/source": "^8.0.2",
+		"typescript": "~5.5.4"
 	},
 	"dependencies": {
 		"@guardian/ab-core": "8.0.1",


### PR DESCRIPTION
## What does this change?

Updates `peerDependencies` to match the versions listed in `dependencies` or `devDependencies`

Also adds changeset to bump commercial package as a major release due to major changes in the peer dependencies

## Why?

We merged some Dependabot PRs to bump package versions but this did not automatically update the peer dependency ranges for these packages.

