### PR TITLE
Fix prebid ozone/index/criteo custom price bucketing

### DIFF
--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -262,14 +262,6 @@ declare global {
 				bidders: BidderCode[];
 				config: {
 					customPriceBucket?: PrebidPriceGranularity;
-					/**
-					 * This is a custom property that has been added to our fork of prebid.js
-					 * to select a price bucket based on the width and height of the slot.
-					 */
-					guCustomPriceBucket?: (bid: {
-						width: number;
-						height: number;
-					}) => PrebidPriceGranularity | undefined;
 				};
 			}) => void;
 			getConfig: (item?: string) => PbjsConfig & {
@@ -465,17 +457,14 @@ const initialise = (window: Window, consentState: ConsentState): void => {
 			adserverTargeting: [
 				{
 					key: 'hb_pb',
-					val({ bidder, width, height, cpm, pbCg }) {
-						if (bidder === 'ozone') {
-							return overridePriceBucket(
-								'ozone',
-								width,
-								height,
-								cpm,
-								pbCg,
-							);
-						}
-						return pbCg;
+					val({ width, height, cpm, pbCg }) {
+						return overridePriceBucket(
+							'ozone',
+							width,
+							height,
+							cpm,
+							pbCg,
+						);
 					},
 				},
 			],
@@ -488,17 +477,14 @@ const initialise = (window: Window, consentState: ConsentState): void => {
 			adserverTargeting: [
 				{
 					key: 'hb_pb',
-					val({ bidder, width, height, cpm, pbCg }) {
-						if (bidder === 'ix') {
-							return overridePriceBucket(
-								'ix',
-								width,
-								height,
-								cpm,
-								pbCg,
-							);
-						}
-						return pbCg;
+					val({ width, height, cpm, pbCg }) {
+						return overridePriceBucket(
+							'ix',
+							width,
+							height,
+							cpm,
+							pbCg,
+						);
 					},
 				},
 			],

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -479,7 +479,7 @@ const initialise = (window: Window, consentState: ConsentState): void => {
 			adserverTargeting: [
 				{
 					key: 'hb_pb',
-					val({ width, height, cpm, pbCg }) {
+					val: ({ width, height, cpm, pbCg }) => {
 						return overridePriceBucket(
 							'ozone',
 							width,

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -30,11 +30,7 @@ import {
 } from '../utils';
 import { bids } from './bid-config';
 import type { PrebidPriceGranularity } from './price-config';
-import {
-	criteoPriceGranularity,
-	overridePriceBucket,
-	priceGranularity,
-} from './price-config';
+import { overridePriceBucket, priceGranularity } from './price-config';
 
 type CmpApi = 'iab' | 'static';
 /** @see https://docs.prebid.org/dev-docs/modules/consentManagementTcf.html */
@@ -439,16 +435,22 @@ const initialise = (window: Window, consentState: ConsentState): void => {
 	if (shouldInclude('criteo')) {
 		window.pbjs.bidderSettings.criteo = {
 			storageAllowed: true,
+			// Use a custom price granularity, which is based upon the size of the slot being auctioned
+			adserverTargeting: [
+				{
+					key: 'hb_pb',
+					val({ width, height, cpm, pbCg }) {
+						return overridePriceBucket(
+							'criteo',
+							width,
+							height,
+							cpm,
+							pbCg,
+						);
+					},
+				},
+			],
 		};
-
-		// Use a custom price granularity for Criteo
-		// Criteo has a different line item structure and so bids should be rounded to match these
-		window.pbjs.setBidderConfig({
-			bidders: ['criteo'],
-			config: {
-				customPriceBucket: criteoPriceGranularity,
-			},
-		});
 	}
 
 	if (shouldInclude('ozone')) {

--- a/src/lib/header-bidding/prebid/price-config.spec.ts
+++ b/src/lib/header-bidding/prebid/price-config.spec.ts
@@ -1,6 +1,7 @@
 import {
 	criteoPriceGranularity,
 	indexPriceGranularity,
+	overridePriceBucket,
 	ozonePriceGranularity,
 	priceGranularity,
 } from './price-config';
@@ -95,6 +96,55 @@ describe('price granularity', () => {
 				);
 			},
 		);
+
+		describe('price bucket override compared to default granularity', () => {
+			// The default granularity has buckets: [0-10: 0.01], [10-15: 0.1], [15-100: 1]
+			// Ozone billboard (970x250) has: [0-12: 0.01], [12-20: 0.1], [20-50: 1]
+			// Ozone halfpage (300x600) has: [0-10: 0.01], [10-15: 0.1], [15-50: 1]
+
+			test.each([
+				// Cases where Ozone billboard differs from default
+				// Different max in first bucket (12 vs 10)
+				[[970, 250], 10.5, '10.50', '10.50'], // Default: 10.50 (0.1 increment), Ozone: 10.50 (0.01 increment)
+				[[970, 250], 11.23, '11.20', '11.23'], // Default: 11.20 (0.1 increment), Ozone: 11.23 (0.01 increment)
+
+				// Different max in second bucket (20 vs 15)
+				[[970, 250], 15.5, '15.00', '15.50'], // Default: 15.00 (1 increment), Ozone: 15.50 (0.1 increment)
+				[[970, 250], 19.7, '19.00', '19.70'], // Default: 19.00 (1 increment), Ozone: 19.70 (0.1 increment)
+
+				// Different max in third bucket (50 vs 100)
+				[[970, 250], 60, '60.00', '50.00'], // Default: 60.00 (1 increment), Ozone: 50.00 (max value)
+				[[970, 250], 99, '99.00', '50.00'], // Default: 99.00 (1 increment), Ozone: 50.00 (max value)
+
+				// Cases where Ozone halfpage is different from default
+				// Same max in first bucket (10) but then different behavior
+				[[300, 600], 10.5, '10.50', '10.50'], // Default: 10.50 (0.1 increment), Ozone halfpage: 10.50 (0.1 increment)
+
+				// Same max in second bucket (15) but then different behavior
+				[[300, 600], 15.5, '15.00', '15.00'], // Default: 15.00 (1 increment), Ozone halfpage: 15.00 (1 increment)
+
+				// Different max in third bucket (50 vs 100)
+				[[300, 600], 60, '60.00', '50.00'], // Default: 60.00 (1 increment), Ozone halfpage: 50.00 (max value)
+			] as const)(
+				'Ozone slot with size %s and cpm %s should have default price bucket %s but returns %s',
+				(
+					[width, height],
+					cpm,
+					defaultPriceBucket,
+					expectedOzoneBucket,
+				) => {
+					expect(
+						overridePriceBucket(
+							'ozone',
+							width,
+							height,
+							cpm,
+							defaultPriceBucket,
+						),
+					).toEqual(expectedOzoneBucket);
+				},
+			);
+		});
 	});
 
 	describe('Index Prebid', () => {
@@ -147,5 +197,55 @@ describe('price granularity', () => {
 				);
 			},
 		);
+		describe('price bucket override compared to default granularity', () => {
+			// The default granularity has buckets: [0-10: 0.01], [10-15: 0.1], [15-100: 1]
+			// Index MPU (300x250) has: [0-12: 0.01], [12-20: 0.05], [20-50: 1]
+			// Index halfpage (300x600) has: [0-10: 0.01], [10-15: 0.05], [15-50: 1]
+
+			test.each([
+				// Cases where Index MPU differs from default
+				// Different max in first bucket (12 vs 10)
+				[[300, 250], 10.5, '10.50', '10.50'], // Default: 10.50 (0.1 increment), Index: 10.50 (0.01 increment)
+				[[300, 250], 11.23, '11.20', '11.23'], // Default: 11.20 (0.1 increment), Index: 11.23 (0.01 increment)
+
+				// Different increment in second bucket (0.05 vs 0.1)
+				[[300, 250], 12.07, '12.00', '12.05'], // Default: 12.00 (0.1 increment), Index: 12.05 (0.05 increment)
+				[[300, 250], 14.88, '14.80', '14.85'], // Default: 14.80 (0.1 increment), Index: 14.85 (0.05 increment)
+
+				// Different max and increment in second bucket
+				[[300, 250], 15.5, '15.00', '15.50'], // Default: 15.00 (1 increment), Index: 15.50 (0.05 increment)
+				[[300, 250], 19.93, '19.00', '19.90'], // Default: 19.00 (1 increment), Index: 19.90 (0.05 increment)
+
+				// Different max in third bucket (50 vs 100)
+				[[300, 250], 60, '60.00', '50.00'], // Default: 60.00 (1 increment), Index: 50.00 (max value)
+
+				// Cases where Index halfpage differs from default
+				// Same max in first bucket (10) but different second bucket
+				[[300, 600], 10.07, '10.00', '10.05'], // Default: 10.00 (0.1 increment), Index: 10.05 (0.05 increment)
+				[[300, 600], 12.77, '12.70', '12.75'], // Default: 12.70 (0.1 increment), Index: 12.75 (0.05 increment)
+				[[300, 600], 14.99, '14.90', '14.95'], // Default: 14.90 (0.1 increment), Index: 14.95 (0.05 increment)
+
+				// Different max in third bucket (50 vs 100)
+				[[300, 600], 75, '75.00', '50.00'], // Default: 75.00 (1 increment), Index: 50.00 (max value)
+			] as const)(
+				'Index slot with size %s and cpm %s should have default price bucket %s but returns %s',
+				(
+					[width, height],
+					cpm,
+					defaultPriceBucket,
+					expectedIndexBucket,
+				) => {
+					expect(
+						overridePriceBucket(
+							'ix',
+							width,
+							height,
+							cpm,
+							defaultPriceBucket,
+						),
+					).toEqual(expectedIndexBucket);
+				},
+			);
+		});
 	});
 });

--- a/src/lib/header-bidding/prebid/price-config.ts
+++ b/src/lib/header-bidding/prebid/price-config.ts
@@ -166,13 +166,16 @@ export const getPriceGranularityForSize = (
 };
 
 export const overridePriceBucket = (
-	bidder: 'ozone' | 'ix',
+	bidder: 'ozone' | 'ix' | 'criteo',
 	width: number,
 	height: number,
 	cpm: number,
 	defaultPriceBucket: string,
 ): string | undefined => {
-	const priceGranularity = getPriceGranularityForSize(bidder, width, height);
+	const priceGranularity =
+		bidder === 'criteo'
+			? criteoPriceGranularity
+			: getPriceGranularityForSize(bidder, width, height);
 	const priceBucket = getPriceBucketString(cpm, priceGranularity).custom;
 	if (priceBucket !== defaultPriceBucket) {
 		log(

--- a/src/lib/header-bidding/prebid/price-config.ts
+++ b/src/lib/header-bidding/prebid/price-config.ts
@@ -1,3 +1,5 @@
+import { log } from '@guardian/libs';
+import { getPriceBucketString } from 'prebid.js/src/cpmBucketManager';
 import { adSizes } from '../../../lib/ad-sizes';
 
 export type PrebidPriceGranularity = {
@@ -150,4 +152,38 @@ export const indexPriceGranularity = (
 	}
 
 	return undefined;
+};
+
+export const getPriceGranularityForSize = (
+	bidder: 'ozone' | 'ix',
+	width: number,
+	height: number,
+): PrebidPriceGranularity | undefined => {
+	if (bidder === 'ozone') {
+		return ozonePriceGranularity(width, height);
+	}
+	return indexPriceGranularity(width, height);
+};
+
+export const overridePriceBucket = (
+	bidder: 'ozone' | 'ix',
+	width: number,
+	height: number,
+	cpm: number,
+	defaultPriceBucket: string,
+): string | undefined => {
+	const priceGranularity = getPriceGranularityForSize(bidder, width, height);
+	const priceBucket = getPriceBucketString(cpm, priceGranularity).custom;
+	if (priceBucket !== defaultPriceBucket) {
+		log(
+			'commercial',
+			`${bidder} price bucket for size (${width}x${height}) with cpm ${cpm} overriden from ${defaultPriceBucket} to ${priceBucket}`,
+		);
+	} else {
+		log(
+			'commercial',
+			`${bidder} price bucket for size (${width}x${height}) with cpm ${cpm} not overriden (${priceBucket})`,
+		);
+	}
+	return priceBucket;
 };

--- a/src/types/modules.d.ts
+++ b/src/types/modules.d.ts
@@ -32,3 +32,16 @@ declare module 'prebid.js/adapters/bidderFactory' {
 
 	export { registerBidder };
 }
+
+declare module 'prebid.js/src/cpmBucketManager' {
+	import type { PrebidPriceGranularity } from '../lib/header-bidding/prebid/price-config';
+
+	const getPriceBucketString: (
+		cpm: number,
+		priceBuckets: PrebidPriceGranularity,
+	) => {
+		custom: string;
+	};
+
+	export { getPriceBucketString };
+}


### PR DESCRIPTION
## What does this change?
Restore width/height price bucketing for ozone and index

This can be done by overriding the `hb_pb` targeting for these bidders rather than modifying the prebid source code.
https://docs.prebid.org/dev-docs/publisher-api-reference/bidderSettings.html

Added test cases for this.

## Why?
This was accidently removed when I [deprecated our custom prebid](https://github.com/guardian/commercial/pull/1737) `@guardian/prebid` (it wasn't in the readme but I should have checked!)

We had added `guCustomPriceBuckets` long ago in https://github.com/guardian/Prebid.js/pull/126 which allowed us to set the priceBuckets based on the creative size.

Now this can be done without needing to modify the prebid.js source code as mentioned above.

The background on this is that we have different a price bucket for these bidders to reduce the line-item count.

Without this, for certain edge cases (now in the unit test) it would be possible for the price buckets to not exist in GAM for a winning bid from ozone/index and not serve from GAM when it should have.