### PR TITLE
Fix the trade desk test expiry

### DIFF
--- a/src/experiments/tests/the-trade-desk.ts
+++ b/src/experiments/tests/the-trade-desk.ts
@@ -4,7 +4,7 @@ export const theTradeDesk: ABTest = {
 	id: 'TheTradeDesk',
 	author: '@commercial-dev',
 	start: '2025-03-12',
-	expiry: '2024-04-30',
+	expiry: '2025-04-30',
 	audience: 10 / 100,
 	audienceOffset: 40 / 100,
 	audienceCriteria: '',


### PR DESCRIPTION
## What does this change?
Fix expiry date for the test in #1864 :S

## Why?
It's not 2024 anymore