### PR TITLE
Improve ophan record of test events

### DIFF
--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -153,7 +153,7 @@ type EnableAnalyticsConfig = {
 	provider: string;
 	options: {
 		ajaxUrl: string;
-		pv: string;
+		pv?: string;
 	};
 };
 
@@ -521,7 +521,7 @@ const initialise = (window: Window, consentState: ConsentState): void => {
 					ajaxUrl: window.guardian.config.page.isDev
 						? `//performance-events.code.dev-guardianapis.com/header-bidding`
 						: `//performance-events.guardianapis.com/header-bidding`,
-					pv: window.guardian.ophan.pageViewId,
+					pv: window.guardian.ophan?.pageViewId,
 				},
 			},
 		]);

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -454,7 +454,7 @@ declare global {
 	}
 	interface Window {
 		guardian: {
-			ophan: Ophan;
+			ophan?: Ophan;
 			config: Config;
 			queue: Array<() => Promise<void>>;
 			mustardCut?: boolean;
@@ -472,7 +472,7 @@ declare global {
 			modules: {
 				sentry?: {
 					reportError?: (
-						error: unknown,
+						error: Error,
 						feature: string,
 						tags?: Record<string, string>,
 					) => void;


### PR DESCRIPTION
## What does this change?
Refactor `ophanRecord` function

## Why?
Sentry is reporting that `window.guardian.ophan` is sometimes undefined here, perhaps not loaded yet or could be blocked so changing it to be optional.

We're also wrapping the ophan functions just for logging purposes that we don't really need, we can tidy it up.

I've also added a simple queue so that all events will be sent if ophan becomes available the next time it tries to record.