### PR TITLE
Make sure firstvisit targeting is added for opt out ads

### DIFF
--- a/src/lib/targeting/build-page-targeting.ts
+++ b/src/lib/targeting/build-page-targeting.ts
@@ -1,6 +1,6 @@
 import type { Participations } from '@guardian/ab-core';
 import type { ConsentState, CountryCode } from '@guardian/libs';
-import { cmp, getCookie, isString } from '@guardian/libs';
+import { cmp, getConsentFor, getCookie, isString } from '@guardian/libs';
 import { supportsPerformanceAPI } from '../event-timer';
 import { getLocale } from '../geo/get-locale';
 import type { False, True } from '../types';
@@ -168,7 +168,7 @@ const buildPageTargeting = ({
 
 	const consentlessTargeting: Partial<PageTargeting> = {};
 
-	if (!consentState.canTarget) {
+	if (!getConsentFor('googletag', consentState)) {
 		consentlessTargeting.firstvisit = isFirstVisit(referrer) ? 't' : 'f';
 	}
 


### PR DESCRIPTION
## What does this change?
Checks consent state for `googletag` instead of `consentState.canTarget` before adding the `firstvisit` custom targeting value for opt out ads.

## Why?
This is because we check the consent for `googletag` before launching opt out ads, not `canTarget`, so by checking the same consent permissions, we can make sure the targeting is reliably added. I think following consent or pay, there's some misalignment between these consent permissions, which means in the UK the `firstvisit` targeting value is not currently being sent.

## Before
<img width="527" alt="Screenshot 2025-03-18 at 18 16 15" src="https://github.com/user-attachments/assets/a9a8a632-a83c-4c5b-a4ff-36565f313611" />

## After
<img width="529" alt="Screenshot 2025-03-18 at 18 17 43" src="https://github.com/user-attachments/assets/87ff220d-1dd6-4e5c-ac08-72865f072af9" />
