### PR TITLE
addition of logs to see the fetchBid resp code from APS

### DIFF
--- a/src/events/render-advert.ts
+++ b/src/events/render-advert.ts
@@ -201,6 +201,9 @@ const renderAdvert = (
 	slotRenderEndedEvent: googletag.events.SlotRenderEndedEvent,
 ): Promise<boolean> => {
 	addContentClass(advert.node);
+	console.log(
+		`Here is the advert: ${JSON.stringify(advert)} and slotRenderEndedEvent: ${JSON.stringify(slotRenderEndedEvent)}`,
+	);
 	return hasIframe(advert.node)
 		.then((isRendered) => {
 			const creativeTemplateId =

--- a/src/lib/header-bidding/a9/a9.ts
+++ b/src/lib/header-bidding/a9/a9.ts
@@ -74,7 +74,8 @@ const requestBids = async (
 		.then(
 			() =>
 				new Promise<void>((resolve) => {
-					window.apstag?.fetchBids({ slots: adUnits }, () => {
+					window.apstag?.fetchBids({ slots: adUnits }, (res) => {
+						console.log('Bids Response:', res);
 						window.googletag.cmd.push(() => {
 							window.apstag?.setDisplayBids();
 							resolve();

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -258,9 +258,22 @@ type FetchBidsBidConfig = {
 	slots: A9AdUnitInterface[];
 };
 
+type FetchBidsResponse = [
+	{
+		amznbid: string;
+		amzniid: string;
+		amznnp: string;
+		amznsz: `${number}x${number}`;
+		size: `${number}x${number}`;
+		slotID: string;
+	},
+];
+
+type FetchBidsCallback = (resp: FetchBidsResponse[]) => void;
+
 type Apstag = {
 	init: (arg0: ApstagInitConfig) => void;
-	fetchBids: (arg0: FetchBidsBidConfig, callback: () => void) => void;
+	fetchBids: (arg0: FetchBidsBidConfig, callback: FetchBidsCallback) => void;
 	setDisplayBids: () => void;
 };
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
At the moment this is a draft PR to test the fetchBids response from APS, in order to ensure we can accurately establish the winning APS bidder, (we are concerned with Gumgum: `1lsxjb4`.

So we shall test this in CODE intially.

## Why?
At the moment we are getting a response of "2" which does not align with any of the bidders, we are assuming this is because fetchBids does not respond to localhost.