### PR TITLE
stringify the sizemapping for the reportError

### DIFF
--- a/src/define/define-slot.ts
+++ b/src/define/define-slot.ts
@@ -136,7 +136,7 @@ const defineSlot = (
 			{},
 			{
 				slot: id,
-				sizeMapping: sizeMapping,
+				sizeMapping: JSON.stringify(sizeMapping),
 			},
 		);
 		throw error;


### PR DESCRIPTION
## What does this change?
Adding a stringify just to make sure this isn't a weird sentry encoding issue

## Why
This is reporting weird sizeMappings such as:
```
{"desktop":["[o]","[o]","[o]","[o]","[o]","[o]","[o]","[o]"],"mobile":["[o]","[o]","[o]","[o]","[o]","[o]"],"tablet":["[o]","[o]","[o]","[o]","[o]"]}
```


