### PR TITLE
Tidy up error handling when creating an advert

### DIFF
--- a/src/define/define-slot.ts
+++ b/src/define/define-slot.ts
@@ -1,7 +1,6 @@
 import { breakpoints as sourceBreakpoints } from '@guardian/source/foundations';
 import { once } from 'lodash-es';
 import type { AdSize, SizeMapping, SlotName } from '../lib/ad-sizes';
-import { reportError } from '../lib/error/report-error';
 import { EventTimer } from '../lib/event-timer';
 import { isEligibleForTeads } from '../lib/targeting/teads-eligibility';
 import { getUrlVars } from '../lib/url';
@@ -127,6 +126,18 @@ const allowSafeFrameToExpand = (slot: googletag.Slot) => {
 	return slot;
 };
 
+class DefineSlotError extends Error {
+	sizeMapping: string;
+	report: boolean;
+
+	constructor(message: string, sizeMapping: SizeMapping, report = true) {
+		super(message);
+		this.name = 'DefineSlotError';
+		this.sizeMapping = JSON.stringify(sizeMapping);
+		this.report = report;
+	}
+}
+
 const defineSlot = (
 	adSlotNode: HTMLElement,
 	sizeMapping: SizeMapping,
@@ -139,25 +150,14 @@ const defineSlot = (
 
 	const googletagSizeMapping = buildGoogletagSizeMapping(sizeMapping);
 	if (!googletagSizeMapping) {
-		if (!canDefineSlot()) {
-			throw new Error(
-				'Could not define slot. googletag.sizeMapping has been shimmed.',
-			);
-		} else {
-			const error = new Error(
-				'A googletag size mapping could not be created.',
-			);
-			reportError(
-				error,
-				'commercial',
-				{},
-				{
-					slot: id,
-					sizeMapping: JSON.stringify(sizeMapping),
-				},
-			);
-			throw error;
-		}
+		const errorMessage = canDefineSlot()
+			? 'googletag.sizeMapping did not return a size mapping'
+			: 'Could not define slot. googletag.sizeMapping has been shimmed.';
+		throw new DefineSlotError(
+			errorMessage,
+			sizeMapping,
+			canDefineSlot() ? false : true,
+		);
 	}
 
 	const sizes = collectSizes(googletagSizeMapping);
@@ -177,7 +177,10 @@ const defineSlot = (
 	}
 
 	if (!slot) {
-		throw new Error(`Could not define slot for ${id}`);
+		throw new DefineSlotError(
+			`googletag.defineSlot did not return a slot`,
+			sizeMapping,
+		);
 	}
 
 	const slotReady = initSlotIas(id, slot);
@@ -228,4 +231,10 @@ const defineSlot = (
 	};
 };
 
-export { buildGoogletagSizeMapping, collectSizes, defineSlot, canDefineSlot };
+export {
+	buildGoogletagSizeMapping,
+	collectSizes,
+	defineSlot,
+	canDefineSlot,
+	DefineSlotError,
+};

--- a/src/define/define-slot.ts
+++ b/src/define/define-slot.ts
@@ -150,14 +150,18 @@ const defineSlot = (
 
 	const googletagSizeMapping = buildGoogletagSizeMapping(sizeMapping);
 	if (!googletagSizeMapping) {
-		const errorMessage = canDefineSlot()
-			? 'googletag.sizeMapping did not return a size mapping'
-			: 'Could not define slot. googletag.sizeMapping has been shimmed.';
-		throw new DefineSlotError(
-			errorMessage,
-			sizeMapping,
-			canDefineSlot() ? false : true,
-		);
+		if (canDefineSlot()) {
+			throw new DefineSlotError(
+				'googletag.sizeMapping did not return a size mapping',
+				sizeMapping,
+			);
+		} else {
+			throw new DefineSlotError(
+				'Could not define slot. googletag.sizeMapping has been shimmed.',
+				sizeMapping,
+				false,
+			);
+		}
 	}
 
 	const sizes = collectSizes(googletagSizeMapping);


### PR DESCRIPTION
## What does this change?
Errors are reported from `createAdvert` only.

Stop wrapping errors in a new error, it's unnecessary and the `Could not create advert` prefix makes it harder to see the actual error.

Created a new `DefineSlotError` that is thrown from `defineSlot` and handled in create-slot.

The shim detection added in #1887 appears to be most cases - so we can silence these errors, and still report if sizeMapping creation failed for another reason.

## Why?
The messages coming from this area are a little all over the place.
