### PR TITLE
extend permutive test expiry

### DIFF
--- a/src/experiments/tests/defer-permutive-load.ts
+++ b/src/experiments/tests/defer-permutive-load.ts
@@ -4,7 +4,7 @@ export const deferPermutiveLoad: ABTest = {
 	id: 'DeferPermutiveLoad',
 	author: '@commercial-dev',
 	start: '2025-03-10',
-	expiry: '2025-03-31',
+	expiry: '2025-04-18',
 	audience: 20 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Extends the expiry for the `DeferPermutiveLoad` AB test to ensure we get the desired volumes, for analysis.

