### PR TITLE
Add GumGum winning bid logging for Amazon advertisements

### DIFF
--- a/src/events/render-advert.ts
+++ b/src/events/render-advert.ts
@@ -2,6 +2,7 @@ import type { Advert } from '../define/Advert';
 import { adSizes } from '../lib/ad-sizes';
 import { reportError } from '../lib/error/report-error';
 import fastdom from '../lib/fastdom-promise';
+import { logGumGumWinningBid } from '../lib/gumgum-winning-bid';
 import { renderAdvertLabel } from './render-advert-label';
 
 /**
@@ -200,6 +201,26 @@ const renderAdvert = (
 	advert: Advert,
 	slotRenderEndedEvent: googletag.events.SlotRenderEndedEvent,
 ): Promise<boolean> => {
+	const isA9GumGum =
+		(window.guardian.a9WinningBids?.[0]?.['amznp'] ?? '') === '1lsxjb4';
+
+	if (
+		slotRenderEndedEvent.advertiserId != null &&
+		slotRenderEndedEvent.advertiserId === 4751525411 &&
+		isA9GumGum
+	) {
+		const adSlotId = advert.node.id;
+		logGumGumWinningBid(
+			adSlotId,
+			slotRenderEndedEvent.advertiserId.toString(),
+		);
+	}
+
+	window.addEventListener('beforeunload', () => {
+		console.log(`User is clearing data in the browser`);
+		window.guardian.a9WinningBids = [];
+	});
+
 	addContentClass(advert.node);
 	return hasIframe(advert.node)
 		.then((isRendered) => {

--- a/src/events/render-advert.ts
+++ b/src/events/render-advert.ts
@@ -201,8 +201,11 @@ const renderAdvert = (
 	advert: Advert,
 	slotRenderEndedEvent: googletag.events.SlotRenderEndedEvent,
 ): Promise<boolean> => {
-	const isA9GumGum =
-		(window.guardian.a9WinningBids?.[0]?.['amznp'] ?? '') === '1lsxjb4';
+	const matchingAd = window.guardian.a9WinningBids?.find(
+		(bidResponse) => bidResponse.slotID == advert.id,
+	);
+
+	const isA9GumGum = matchingAd?.amznp === '1lsxjb4';
 
 	if (
 		slotRenderEndedEvent.advertiserId != null &&

--- a/src/events/render-advert.ts
+++ b/src/events/render-advert.ts
@@ -218,11 +218,7 @@ const renderAdvert = (
 
 		const isA9GumGum = matchingAd?.amznp === '1lsxjb4';
 
-		if (
-			slotRenderEndedEvent.advertiserId != null &&
-			slotRenderEndedEvent.advertiserId === 4751525411 &&
-			isA9GumGum
-		) {
+		if (slotRenderEndedEvent.advertiserId === 4751525411 && isA9GumGum) {
 			const adSlotId = advert.node.id;
 			logGumGumWinningBid(
 				adSlotId,

--- a/src/events/render-advert.ts
+++ b/src/events/render-advert.ts
@@ -205,7 +205,7 @@ const renderAdvert = (
 ): Promise<boolean> => {
 	const isInA9BidResponseWinnerTest = isUserInVariant(
 		a9BidResponseWinner,
-		'control',
+		'variant',
 	);
 
 	if (

--- a/src/events/render-advert.ts
+++ b/src/events/render-advert.ts
@@ -219,11 +219,6 @@ const renderAdvert = (
 		);
 	}
 
-	window.addEventListener('beforeunload', () => {
-		console.log(`User is clearing data in the browser`);
-		window.guardian.a9WinningBids = [];
-	});
-
 	addContentClass(advert.node);
 	return hasIframe(advert.node)
 		.then((isRendered) => {

--- a/src/events/render-advert.ts
+++ b/src/events/render-advert.ts
@@ -1,4 +1,6 @@
 import type { Advert } from '../define/Advert';
+import { isUserInVariant } from '../experiments/ab';
+import { a9BidResponseWinner } from '../experiments/tests/a9-bid-response-winner';
 import { adSizes } from '../lib/ad-sizes';
 import { reportError } from '../lib/error/report-error';
 import fastdom from '../lib/fastdom-promise';
@@ -201,22 +203,32 @@ const renderAdvert = (
 	advert: Advert,
 	slotRenderEndedEvent: googletag.events.SlotRenderEndedEvent,
 ): Promise<boolean> => {
-	const matchingAd = window.guardian.a9WinningBids?.find(
-		(bidResponse) => bidResponse.slotID == advert.id,
+	const isInA9BidResponseWinnerTest = isUserInVariant(
+		a9BidResponseWinner,
+		'control',
 	);
 
-	const isA9GumGum = matchingAd?.amznp === '1lsxjb4';
-
 	if (
-		slotRenderEndedEvent.advertiserId != null &&
-		slotRenderEndedEvent.advertiserId === 4751525411 &&
-		isA9GumGum
+		isInA9BidResponseWinnerTest &&
+		window.guardian.config.switches.a9BidResponseWinner
 	) {
-		const adSlotId = advert.node.id;
-		logGumGumWinningBid(
-			adSlotId,
-			slotRenderEndedEvent.advertiserId.toString(),
+		const matchingAd = window.guardian.commercial?.a9WinningBids?.find(
+			(bidResponse) => bidResponse.slotID == advert.id,
 		);
+
+		const isA9GumGum = matchingAd?.amznp === '1lsxjb4';
+
+		if (
+			slotRenderEndedEvent.advertiserId != null &&
+			slotRenderEndedEvent.advertiserId === 4751525411 &&
+			isA9GumGum
+		) {
+			const adSlotId = advert.node.id;
+			logGumGumWinningBid(
+				adSlotId,
+				slotRenderEndedEvent.advertiserId.toString(),
+			);
+		}
 	}
 
 	addContentClass(advert.node);

--- a/src/experiments/ab-tests.ts
+++ b/src/experiments/ab-tests.ts
@@ -1,4 +1,5 @@
 import type { ABTest } from '@guardian/ab-core';
+import { a9BidResponseWinner } from './tests/a9-bid-response-winner';
 import { deferPermutiveLoad } from './tests/defer-permutive-load';
 
 /**
@@ -9,4 +10,5 @@ import { deferPermutiveLoad } from './tests/defer-permutive-load';
 export const concurrentTests: ABTest[] = [
 	// one test per line
 	deferPermutiveLoad,
+	a9BidResponseWinner,
 ];

--- a/src/experiments/tests/a9-bid-response-winner.ts
+++ b/src/experiments/tests/a9-bid-response-winner.ts
@@ -1,0 +1,29 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const a9BidResponseWinner: ABTest = {
+	id: 'A9BidResponseWinner',
+	author: '@commercial-dev',
+	start: '2025-04-2',
+	expiry: '2025-04-18',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: '',
+	successMeasure: '',
+	description:
+		'Test the bid response from APS, to see when Gumgum wins the bid.',
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+	canRun: () => true,
+};

--- a/src/lib/gumgum-winning-bid.ts
+++ b/src/lib/gumgum-winning-bid.ts
@@ -1,0 +1,30 @@
+const logGumGumWinningBid = (slotID: string, advertiserId: string): void => {
+	const endpoint = window.guardian.config.page.isDev
+		? '//logs.code.dev-guardianapis.com/log'
+		: '//logs.guardianapis.com/log';
+
+	if (!slotID || !advertiserId) {
+		return;
+	}
+
+	void fetch(endpoint, {
+		method: 'POST',
+		body: JSON.stringify({
+			label: 'commercial.gumgum.winningBid',
+			properties: [
+				{ name: 'slotID', value: slotID },
+				{ name: 'advertiserId', value: advertiserId },
+				{ name: 'gumgumId', value: '1lsxjb4' },
+				{
+					name: 'pageviewId',
+					value: window.guardian.config.ophan.pageViewId,
+				},
+			],
+		}),
+		keepalive: true,
+		cache: 'no-store',
+		mode: 'no-cors',
+	});
+};
+
+export { logGumGumWinningBid };

--- a/src/lib/header-bidding/a9/a9.ts
+++ b/src/lib/header-bidding/a9/a9.ts
@@ -1,5 +1,7 @@
 import { flatten } from 'lodash-es';
 import type { Advert } from '../../../define/Advert';
+import { isUserInVariant } from '../../../experiments/ab';
+import { a9BidResponseWinner } from '../../../experiments/tests/a9-bid-response-winner';
 import { reportError } from '../../../lib/error/report-error';
 import type { A9AdUnitInterface } from '../../../types/global';
 import type { HeaderBiddingSlot, SlotFlatMap } from '../prebid-types';
@@ -77,10 +79,20 @@ const requestBids = async (
 					window.apstag?.fetchBids(
 						{ slots: adUnits },
 						(bidResponse) => {
-							window.guardian.commercial =
-								window.guardian.commercial ?? {};
-							window.guardian.commercial.a9WinningBids =
-								bidResponse;
+							const isInA9BidResponseWinnerTest = isUserInVariant(
+								a9BidResponseWinner,
+								'control',
+							);
+							if (
+								isInA9BidResponseWinnerTest &&
+								window.guardian.config.switches
+									.a9BidResponseWinner
+							) {
+								window.guardian.commercial =
+									window.guardian.commercial ?? {};
+								window.guardian.commercial.a9WinningBids =
+									bidResponse;
+							}
 							window.googletag.cmd.push(() => {
 								window.apstag?.setDisplayBids();
 								resolve();

--- a/src/lib/header-bidding/a9/a9.ts
+++ b/src/lib/header-bidding/a9/a9.ts
@@ -74,7 +74,9 @@ const requestBids = async (
 		.then(
 			() =>
 				new Promise<void>((resolve) => {
-					window.apstag?.fetchBids({ slots: adUnits }, () => {
+					window.apstag?.fetchBids({ slots: adUnits }, (res) => {
+						console.log('Bids Response:', res);
+						window.guardian.a9WinningBids = res;
 						window.googletag.cmd.push(() => {
 							window.apstag?.setDisplayBids();
 							resolve();

--- a/src/lib/header-bidding/a9/a9.ts
+++ b/src/lib/header-bidding/a9/a9.ts
@@ -88,9 +88,7 @@ const requestBids = async (
 								window.guardian.config.switches
 									.a9BidResponseWinner
 							) {
-								console.log(`So we are in CONTROL`);
-								window.guardian.commercial =
-									window.guardian.commercial ?? {};
+								window.guardian.commercial ??= {};
 								window.guardian.commercial.a9WinningBids =
 									bidResponse;
 							}

--- a/src/lib/header-bidding/a9/a9.ts
+++ b/src/lib/header-bidding/a9/a9.ts
@@ -74,14 +74,19 @@ const requestBids = async (
 		.then(
 			() =>
 				new Promise<void>((resolve) => {
-					window.apstag?.fetchBids({ slots: adUnits }, (res) => {
-						console.log('Bids Response:', res);
-						window.guardian.a9WinningBids = res;
-						window.googletag.cmd.push(() => {
-							window.apstag?.setDisplayBids();
-							resolve();
-						});
-					});
+					window.apstag?.fetchBids(
+						{ slots: adUnits },
+						(bidResponse) => {
+							window.guardian.commercial =
+								window.guardian.commercial ?? {};
+							window.guardian.commercial.a9WinningBids =
+								bidResponse;
+							window.googletag.cmd.push(() => {
+								window.apstag?.setDisplayBids();
+								resolve();
+							});
+						},
+					);
 				}),
 		)
 		.catch(() => {

--- a/src/lib/header-bidding/a9/a9.ts
+++ b/src/lib/header-bidding/a9/a9.ts
@@ -81,13 +81,14 @@ const requestBids = async (
 						(bidResponse) => {
 							const isInA9BidResponseWinnerTest = isUserInVariant(
 								a9BidResponseWinner,
-								'control',
+								'variant',
 							);
 							if (
 								isInA9BidResponseWinnerTest &&
 								window.guardian.config.switches
 									.a9BidResponseWinner
 							) {
+								console.log(`So we are in CONTROL`);
 								window.guardian.commercial =
 									window.guardian.commercial ?? {};
 								window.guardian.commercial.a9WinningBids =

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -480,6 +480,7 @@ declare global {
 			articleCounts?: ArticleCounts;
 			commercial?: {
 				dfpEnv?: DfpEnv;
+				a9WinningBids?: FetchBidResponse[];
 			};
 			notificationEventHistory?: HeaderNotification[][];
 			commercialTimer?: EventTimer;

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -258,9 +258,24 @@ type FetchBidsBidConfig = {
 	slots: A9AdUnitInterface[];
 };
 
+type FetchBidSizes = {
+	adSizes: `${number}x${number}`;
+};
+type FetchBidResponse = {
+	amznbid: string;
+	amzniid: string;
+	amznp: string;
+	amznsz: FetchBidSizes;
+	size: FetchBidSizes;
+	slotID: string;
+};
+
 type Apstag = {
 	init: (arg0: ApstagInitConfig) => void;
-	fetchBids: (arg0: FetchBidsBidConfig, callback: () => void) => void;
+	fetchBids: (
+		arg0: FetchBidsBidConfig,
+		callback: (res: FetchBidResponse[]) => void,
+	) => void;
 	setDisplayBids: () => void;
 };
 
@@ -479,6 +494,7 @@ declare global {
 					) => void;
 				};
 			};
+			a9WinningBids?: FetchBidResponse[];
 		};
 		ootag: {
 			queue: Array<() => void>;

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -495,7 +495,6 @@ declare global {
 					) => void;
 				};
 			};
-			a9WinningBids?: FetchBidResponse[];
 		};
 		ootag: {
 			queue: Array<() => void>;


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
This PR introduces functionality to log GumGum winning bids for Amazon advertisements. 
The implementation detects specific Amazon advertisement IDs and fetch bid responses (amznp ID) associated with GumGum, and sends this data to a logging endpoint. 
The logic is encapsulated in a newly created module: `gumgum-winning-bid.ts`

#### Detection:
- The renderAdvert function checks if:
- The `advertiserId` matches the Amazon advertiser ID for GumGum (4751525411).
- The amznp ID in `window.guardian.a9WinningBids` equals 1lsxjb4.
#### Logging:
- If the conditions are met, the `logGumGumWinningBid` function is called with:
- The ad slot ID (advert.node.id).
- The advertiser ID (slotRenderEndedEvent.advertiserId).
#### Endpoint:
- The logging endpoint dynamically switches between development and production environments:
- Development: //logs.code.dev-guardianapis.com/log
- Production: //logs.guardianapis.com/log
#### Cleanup:
- A `beforeunload` event listener clears `window.guardian.a9WinningBids` to prevent stale data from persisting across page navigations.

## Why?
Tracking GumGum Performance: This change enables tracking of GumGum winning bids for Amazon advertisements, providing valuable insights into ad performance.
Centralised Logging: By creating a dedicated module for GumGum logging, the logic is reusable and easier to maintain.

## Testing variant
- using `http://localhost:3030/Article/http:/localhost:9000/sport/2023/nov/22/ronnie-osullivan-warns-he-will-quit-snooker-if-he-cannot-play-in-china#ab-A9BidResponseWinner=variant`
- specifically tricky adding `#ab-A9BidResponseWinner=variant` (this is the test definition description in the commercial src not the switch name in frontend.