### PR TITLE
Define separate Dependabot grouping for prebid.js

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,12 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+      prebid:
+        patterns:
+          - 'prebid.js'
+        update-types:
+          - 'minor'
+          - 'patch'
       types:
         patterns:
           - '@types/*'


### PR DESCRIPTION
## What does this change?

Use separate Dependabot grouping for Prebid.js

## Why?

To ensure we bump Prebid version separately from other dependency updates