### PR TITLE
Bump @guardian/libs to 22.2.0

### DIFF
--- a/.changeset/better-rules-prove.md
+++ b/.changeset/better-rules-prove.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial': patch
+---
+
+Bump @guardian/libs version to 22.2.0

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"@guardian/core-web-vitals": "^11.0.0",
 		"@guardian/identity-auth": "^7.0.0",
 		"@guardian/identity-auth-frontend": "^9.0.0",
-		"@guardian/libs": "^22.0.0",
+		"@guardian/libs": "^22.2.0",
 		"@guardian/source": "^8.0.2",
 		"typescript": "~5.5.4"
 	},
@@ -49,7 +49,7 @@
 		"@guardian/core-web-vitals": "11.0.0",
 		"@guardian/identity-auth": "^7.0.0",
 		"@guardian/identity-auth-frontend": "9.0.0",
-		"@guardian/libs": "22.0.1",
+		"@guardian/libs": "22.2.0",
 		"@guardian/source": "8.0.2",
 		"fastdom": "^1.0.12",
 		"lodash-es": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,16 +13,16 @@ importers:
         version: 8.0.1(tslib@2.8.1)(typescript@5.5.4)
       '@guardian/core-web-vitals':
         specifier: 11.0.0
-        version: 11.0.0(@guardian/libs@22.0.1(tslib@2.8.1)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)(web-vitals@4.2.4)
+        version: 11.0.0(@guardian/libs@22.2.0(tslib@2.8.1)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)(web-vitals@4.2.4)
       '@guardian/identity-auth':
         specifier: ^7.0.0
-        version: 7.0.0(@guardian/libs@22.0.1(tslib@2.8.1)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)
+        version: 7.0.0(@guardian/libs@22.2.0(tslib@2.8.1)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)
       '@guardian/identity-auth-frontend':
         specifier: 9.0.0
-        version: 9.0.0(@guardian/identity-auth@7.0.0(@guardian/libs@22.0.1(tslib@2.8.1)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(@guardian/libs@22.0.1(tslib@2.8.1)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)
+        version: 9.0.0(@guardian/identity-auth@7.0.0(@guardian/libs@22.2.0(tslib@2.8.1)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(@guardian/libs@22.2.0(tslib@2.8.1)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)
       '@guardian/libs':
-        specifier: 22.0.1
-        version: 22.0.1(tslib@2.8.1)(typescript@5.5.4)
+        specifier: 22.2.0
+        version: 22.2.0(tslib@2.8.1)(typescript@5.5.4)
       '@guardian/source':
         specifier: 8.0.2
         version: 8.0.2(tslib@2.8.1)(typescript@5.5.4)
@@ -1024,8 +1024,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/libs@22.0.1':
-    resolution: {integrity: sha512-id/Z9mPb1zkW5G5EnTfuJrVWlgEobdlMbIty5htV1kklh/12N+74KTcFqdYheRqZRTZHb0xXjDNIaEc/zBBlbQ==}
+  '@guardian/libs@22.2.0':
+    resolution: {integrity: sha512-2PANHi+U7vv9jzYUU3czWgjqFYhhdD4jDBmophWL3LrQUTlJJdSI8rcOPfUH0kqVBOjVQZl/nVamGiMKoujUXw==}
     peerDependencies:
       tslib: ^2.6.2
       typescript: ~5.5.2
@@ -6568,9 +6568,9 @@ snapshots:
       browserslist: 4.24.4
       tslib: 2.8.1
 
-  '@guardian/core-web-vitals@11.0.0(@guardian/libs@22.0.1(tslib@2.8.1)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)(web-vitals@4.2.4)':
+  '@guardian/core-web-vitals@11.0.0(@guardian/libs@22.2.0(tslib@2.8.1)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)(web-vitals@4.2.4)':
     dependencies:
-      '@guardian/libs': 22.0.1(tslib@2.8.1)(typescript@5.5.4)
+      '@guardian/libs': 22.2.0(tslib@2.8.1)(typescript@5.5.4)
       tslib: 2.8.1
       web-vitals: 4.2.4
     optionalDependencies:
@@ -6597,22 +6597,22 @@ snapshots:
       - supports-color
       - typescript
 
-  '@guardian/identity-auth-frontend@9.0.0(@guardian/identity-auth@7.0.0(@guardian/libs@22.0.1(tslib@2.8.1)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(@guardian/libs@22.0.1(tslib@2.8.1)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)':
+  '@guardian/identity-auth-frontend@9.0.0(@guardian/identity-auth@7.0.0(@guardian/libs@22.2.0(tslib@2.8.1)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4))(@guardian/libs@22.2.0(tslib@2.8.1)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)':
     dependencies:
-      '@guardian/identity-auth': 7.0.0(@guardian/libs@22.0.1(tslib@2.8.1)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)
-      '@guardian/libs': 22.0.1(tslib@2.8.1)(typescript@5.5.4)
+      '@guardian/identity-auth': 7.0.0(@guardian/libs@22.2.0(tslib@2.8.1)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)
+      '@guardian/libs': 22.2.0(tslib@2.8.1)(typescript@5.5.4)
       tslib: 2.8.1
     optionalDependencies:
       typescript: 5.5.4
 
-  '@guardian/identity-auth@7.0.0(@guardian/libs@22.0.1(tslib@2.8.1)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)':
+  '@guardian/identity-auth@7.0.0(@guardian/libs@22.2.0(tslib@2.8.1)(typescript@5.5.4))(tslib@2.8.1)(typescript@5.5.4)':
     dependencies:
-      '@guardian/libs': 22.0.1(tslib@2.8.1)(typescript@5.5.4)
+      '@guardian/libs': 22.2.0(tslib@2.8.1)(typescript@5.5.4)
       tslib: 2.8.1
     optionalDependencies:
       typescript: 5.5.4
 
-  '@guardian/libs@22.0.1(tslib@2.8.1)(typescript@5.5.4)':
+  '@guardian/libs@22.2.0(tslib@2.8.1)(typescript@5.5.4)':
     dependencies:
       tslib: 2.8.1
     optionalDependencies:


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Bump @guardian/libs to 22.2.0

## Why?
Required to bump version in Frontend and DCR