### PR TITLE
Unify handling of the empty ad size and actually empty slots

### DIFF
--- a/playwright/fixtures/pages/articles.ts
+++ b/playwright/fixtures/pages/articles.ts
@@ -67,4 +67,12 @@ const articles = [
 	},
 ] as const satisfies GuPage[];
 
-export { articles };
+const articleWithCollapsedSlots = {
+	path: getTestUrl({
+		stage,
+		path: '/politics/2022/feb/10/keir-starmer-says-stop-the-war-coalition-gives-help-to-authoritarians-like-putin',
+		adtest: 'collapse-slot',
+	}),
+} as const satisfies GuPage;
+
+export { articles, articleWithCollapsedSlots };

--- a/playwright/fixtures/pages/articles.ts
+++ b/playwright/fixtures/pages/articles.ts
@@ -70,7 +70,7 @@ const articles = [
 const articleWithCollapsedSlots = {
 	path: getTestUrl({
 		stage,
-		path: '/politics/2022/feb/10/keir-starmer-says-stop-the-war-coalition-gives-help-to-authoritarians-like-putin',
+		path: '/technology/2020/jan/20/jabra-elite-75t-review-small-and-long-lasting-airpod-beaters',
 		adtest: 'collapse-slot',
 	}),
 } as const satisfies GuPage;

--- a/playwright/tests/collapse-slot.spec.ts
+++ b/playwright/tests/collapse-slot.spec.ts
@@ -7,9 +7,7 @@ import { loadPage } from '../lib/load-page';
 const { path } = articleWithCollapsedSlots;
 
 test.describe('Ad slot removal', () => {
-	test(`Empty ad slots should be removed from the DOM`, async ({
-		page,
-	}) => {
+	test(`Empty ad slots should be removed from the DOM`, async ({ page }) => {
 		const gamResponse = waitForGAMResponseForSlot(page, 'top-above-nav');
 
 		await loadPage(page, path);

--- a/playwright/tests/collapse-slot.spec.ts
+++ b/playwright/tests/collapse-slot.spec.ts
@@ -7,7 +7,9 @@ import { loadPage } from '../lib/load-page';
 const { path } = articleWithCollapsedSlots;
 
 test.describe('Ad slot removal', () => {
-	test(`Empty ad slots should be removed from the DOM`, async ({ page }) => {
+	test(`Empty ad slots should be removed from the DOM`, async ({
+		page,
+	}) => {
 		const gamResponse = waitForGAMResponseForSlot(page, 'top-above-nav');
 
 		await loadPage(page, path);
@@ -30,16 +32,27 @@ test.describe('Ad slot removal', () => {
 			}),
 		).toBeFalsy();
 
+		// The '..' selector selects the parent, in this case the <aside> tag wrapping the ad
+		const topBannerBox = await page.locator('.top-banner-ad-container').locator('..').boundingBox({
+			timeout: 3000,
+		});
+
 		expect(
-			await page.locator('.ad-slot-right').isVisible({
+			topBannerBox?.height
+		).toEqual(0);
+
+		expect(
+			await page.locator('.ad-slot--right').isVisible({
 				timeout: 3000,
 			}),
 		).toBeFalsy();
 
+		const rightSlotBox = await page.locator('.ad-slot--right').locator('..').boundingBox({
+			timeout: 3000,
+		});
+
 		expect(
-			await page.locator('.ad-slot-merchandising').isVisible({
-				timeout: 3000,
-			}),
-		).toBeFalsy();
+			rightSlotBox?.height
+		).toEqual(0);
 	});
 });

--- a/playwright/tests/collapse-slot.spec.ts
+++ b/playwright/tests/collapse-slot.spec.ts
@@ -45,5 +45,11 @@ test.describe('Ad slot removal', () => {
 				timeout: 3000,
 			}),
 		).toBeFalsy();
+
+		expect(
+			await page.locator('.ad-slot--merchandising').isVisible({
+				timeout: 3000,
+			}),
+		).toBeFalsy();
 	});
 });

--- a/playwright/tests/collapse-slot.spec.ts
+++ b/playwright/tests/collapse-slot.spec.ts
@@ -7,9 +7,7 @@ import { loadPage } from '../lib/load-page';
 const { path } = articleWithCollapsedSlots;
 
 test.describe('Ad slot removal', () => {
-	test(`Empty ad slots should be removed from the DOM`, async ({
-		page,
-	}) => {
+	test(`Empty ad slots should be removed from the DOM`, async ({ page }) => {
 		const gamResponse = waitForGAMResponseForSlot(page, 'top-above-nav');
 
 		await loadPage(page, path);
@@ -33,26 +31,19 @@ test.describe('Ad slot removal', () => {
 		).toBeFalsy();
 
 		// The '..' selector selects the parent, in this case the <aside> tag wrapping the ad
-		const topBannerBox = await page.locator('.top-banner-ad-container').locator('..').boundingBox({
-			timeout: 3000,
-		});
+		const topBannerBox = await page
+			.locator('.top-banner-ad-container')
+			.locator('..')
+			.boundingBox({
+				timeout: 3000,
+			});
 
-		expect(
-			topBannerBox?.height
-		).toEqual(0);
+		expect(topBannerBox?.height).toEqual(0);
 
 		expect(
 			await page.locator('.ad-slot--right').isVisible({
 				timeout: 3000,
 			}),
 		).toBeFalsy();
-
-		const rightSlotBox = await page.locator('.ad-slot--right').locator('..').boundingBox({
-			timeout: 3000,
-		});
-
-		expect(
-			rightSlotBox?.height
-		).toEqual(0);
 	});
 });

--- a/playwright/tests/collapse-slot.spec.ts
+++ b/playwright/tests/collapse-slot.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+import { articleWithCollapsedSlots } from '../fixtures/pages/articles';
+import { cmpAcceptAll } from '../lib/cmp';
+import { assertHeader, waitForGAMResponseForSlot } from '../lib/gam';
+import { loadPage } from '../lib/load-page';
+
+const { path } = articleWithCollapsedSlots;
+
+test.describe('Ad slot removal', () => {
+	test(`Empty ad slots should be removed from the DOM`, async ({
+		page,
+	}) => {
+		const gamResponse = waitForGAMResponseForSlot(page, 'top-above-nav');
+
+		await loadPage(page, path);
+
+		await cmpAcceptAll(page);
+
+		const response = await gamResponse;
+
+		const matched = await assertHeader(
+			response,
+			'google-lineitem-id',
+			(value) => value === '6966767669',
+		);
+
+		expect(matched).toBeTruthy();
+
+		expect(
+			await page.locator('.top-banner-ad-container').isVisible({
+				timeout: 3000,
+			}),
+		).toBeFalsy();
+
+		expect(
+			await page.locator('.ad-slot-right').isVisible({
+				timeout: 3000,
+			}),
+		).toBeFalsy();
+
+		expect(
+			await page.locator('.ad-slot-merchandising').isVisible({
+				timeout: 3000,
+			}),
+		).toBeFalsy();
+	});
+});

--- a/src/events/empty-advert.ts
+++ b/src/events/empty-advert.ts
@@ -37,7 +37,7 @@ const findElementToRemove = (advertNode: HTMLElement): HTMLElement => {
 
 const removeSlotFromDom = (slotElement: HTMLElement) => {
 	const elementToRemove = findElementToRemove(slotElement);
-	elementToRemove.remove();
+	elementToRemove.style.display = 'none';
 };
 
 const emptyAdvert = (advert: Advert): void => {

--- a/src/events/render-advert.ts
+++ b/src/events/render-advert.ts
@@ -5,6 +5,7 @@ import { adSizes } from '../lib/ad-sizes';
 import { reportError } from '../lib/error/report-error';
 import fastdom from '../lib/fastdom-promise';
 import { logGumGumWinningBid } from '../lib/gumgum-winning-bid';
+import { emptyAdvert } from './empty-advert';
 import { renderAdvertLabel } from './render-advert-label';
 
 /**
@@ -130,7 +131,8 @@ const outOfPageCallback = (advert: Advert) => {
 	});
 };
 sizeCallbacks[adSizes.outOfPage.toString()] = outOfPageCallback;
-sizeCallbacks[adSizes.empty.toString()] = outOfPageCallback;
+sizeCallbacks[adSizes.empty.toString()] = (ad: Advert) =>
+	Promise.resolve(emptyAdvert(ad));
 
 /**
  * Commercial components with merch sizing get fluid-250 styling

--- a/src/insert/comments-expanded-advert.ts
+++ b/src/insert/comments-expanded-advert.ts
@@ -1,11 +1,11 @@
 import { log } from '@guardian/libs';
+import { emptyAdvert } from '../events/empty-advert';
 import { adSizes } from '../lib/ad-sizes';
 import { commercialFeatures } from '../lib/commercial-features';
 import { AD_LABEL_HEIGHT } from '../lib/constants/ad-label-height';
 import { createAdSlot } from '../lib/create-ad-slot';
 import { getBreakpoint } from '../lib/detect/detect-breakpoint';
 import { getViewport } from '../lib/detect/detect-viewport';
-import { dfpEnv } from '../lib/dfp/dfp-env';
 import { getAdvertById } from '../lib/dfp/get-advert-by-id';
 import fastdom from '../lib/fastdom-promise';
 import { fillDynamicAdSlot } from './fill-dynamic-advert-slot';
@@ -121,13 +121,8 @@ const removeMobileCommentsExpandedAds = (): Promise<void> => {
 			log('commercial', `Removing ad slot: ${node.id}`);
 			const advert = getAdvertById(node.id);
 			if (advert) {
-				window.googletag.destroySlots([advert.slot]);
+				emptyAdvert(advert);
 			}
-			node.remove();
-			dfpEnv.adverts.delete(node.id);
-			dfpEnv.advertsToLoad = dfpEnv.advertsToLoad.filter(
-				(_) => _ !== advert,
-			);
 		}),
 	);
 };


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This changes our handling of the 2x2 'empty' ad size to treat them in the same way as we do slots where nothing is returned from GAM/OptOut, and changes the collapsing of any kind of empty slot to use `display: none` rather than removing elements from the DOM. It also adds Playwright tests for this code path.

## Why?

We decided after some investigation that standardising around collapsing slots with `display: none` was more desirable for increased visibility. We also required tests for slot collapsing behaviour to help prevent a repeat of a regression in which slots for which no ad could be provided were not collapsed and remained as blank space on the page, but due to the differences in how genuinely empty ads and the 'empty' size were handled, it was not possible to test for how empty slots got collapsed.

This PR standardises slot collapsing behaviour across the board, makes it testable, and removes code duplication.
