### PR TITLE
remove redundant feature switch for a9 bidding winner

### DIFF
--- a/src/events/render-advert.ts
+++ b/src/events/render-advert.ts
@@ -208,10 +208,7 @@ const renderAdvert = (
 		'variant',
 	);
 
-	if (
-		isInA9BidResponseWinnerTest &&
-		window.guardian.config.switches.a9BidResponseWinner
-	) {
+	if (isInA9BidResponseWinnerTest) {
 		const matchingAd = window.guardian.commercial?.a9WinningBids?.find(
 			(bidResponse) => bidResponse.slotID == advert.id,
 		);

--- a/src/lib/header-bidding/a9/a9.ts
+++ b/src/lib/header-bidding/a9/a9.ts
@@ -83,11 +83,7 @@ const requestBids = async (
 								a9BidResponseWinner,
 								'variant',
 							);
-							if (
-								isInA9BidResponseWinnerTest &&
-								window.guardian.config.switches
-									.a9BidResponseWinner
-							) {
+							if (isInA9BidResponseWinnerTest) {
 								window.guardian.commercial ??= {};
 								window.guardian.commercial.a9WinningBids =
 									bidResponse;


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
We are us ign the AB test switch in frontend now, so no need for the feature switch to make the feature available.
Related [PR](https://github.com/guardian/commercial/pull/1898)
## Why?
Now switching the AB switch on, will automatically opt in any forced URL's such as: http://localhost:3030/Article/http:/localhost:9000/sport/2023/nov/22/ronnie-osullivan-warns-he-will-quit-snooker-if-he-cannot-play-in-china#ab-A9BidResponseWinner=variant

As long as users are in the variant - we are initially at 0% to enable dev testing in PROD for the winning bid.