### PR TITLE
Add event type to invalid analytics payload error

### DIFF
--- a/src/lib/header-bidding/prebid/modules/analyticsAdapter.ts
+++ b/src/lib/header-bidding/prebid/modules/analyticsAdapter.ts
@@ -211,7 +211,7 @@ const createPayload = (events: EventData[], pv: string): AnalyticsPayload => {
 			'commercial',
 			{},
 			{
-				payload,
+				firstEventType: events[0]?.ev,
 			},
 		);
 	}


### PR DESCRIPTION
## What does this change?
Passes in the type of the first prebid event into the invalid analytics payload error to help with debugging. This is the data used by the code to check the validity of the payload, so it should help us see what the issue could be.

## Why?
At the moment the Sentry logs aren't giving much helpful info as the payload isn't readable in the error. See the screenshot of the payload data in the Sentry error below:

<img width="125" alt="Screenshot 2025-04-11 at 14 16 57" src="https://github.com/user-attachments/assets/1219a909-b68f-4db6-ba08-4e8cee13d3e1" />
