### PR TITLE
Ignore analytics abort error

### DIFF
--- a/src/lib/header-bidding/prebid/modules/analyticsAdapter.ts
+++ b/src/lib/header-bidding/prebid/modules/analyticsAdapter.ts
@@ -244,6 +244,10 @@ const analyticsAdapter = Object.assign(adapter({ analyticsType: 'endpoint' }), {
 			}
 			logEvents(events);
 		} catch (error) {
+			if (error instanceof Error && error.name === 'AbortError') {
+				// Ignore abort errors, they are expected when the fetch times out
+				return;
+			}
 			reportError(
 				error,
 				'commercial',


### PR DESCRIPTION
## What does this change?
Throw away `AbortError` errors, they happen when prebid times out the request for taking to long.

## Why?
Tidy up sentry errors.