### PR TITLE
Fix slot id `dfp-ad--inline0` for tablet breakpoint

### DIFF
--- a/src/insert/spacefinder/article.ts
+++ b/src/insert/spacefinder/article.ts
@@ -216,7 +216,9 @@ const addMobileAndTabletInlineAds = (
 			const name =
 				currentBreakpoint === 'mobile' && i === 0
 					? 'top-above-nav'
-					: `inline${i}`;
+					: currentBreakpoint === 'tablet'
+						? `inline${i + 1}`
+						: `inline${i}`;
 			const type =
 				currentBreakpoint === 'mobile' && i === 0
 					? 'top-above-nav'

--- a/src/insert/spacefinder/article.ts
+++ b/src/insert/spacefinder/article.ts
@@ -213,12 +213,15 @@ const addMobileAndTabletInlineAds = (
 ): Promise<boolean> => {
 	const insertAds: SpacefinderWriter = async (paras) => {
 		const slots = paras.map(async (para, i) => {
+			//Mobile top-above-nav is the first ad in the body and the inline1 is the second ad in the body.
+			//Tablet top-above-nav is above the website's navigation and the inline1 is the first ad in the body.
 			const name =
 				currentBreakpoint === 'mobile' && i === 0
 					? 'top-above-nav'
 					: currentBreakpoint === 'tablet'
 						? `inline${i + 1}`
 						: `inline${i}`;
+
 			const type =
 				currentBreakpoint === 'mobile' && i === 0
 					? 'top-above-nav'


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR fixes the error we have for tablet breakpoint with slot id `dfp-ad--inline0` which doesn't exist. 

I tested it locally and in CODE and the error doesn't show up anymore. I also confirmed with the DOM element id.

## Why?

Fix a slot id that shouldn't exist and reduce sentry errors. 
