### PR TITLE
Add `multibid` to prebid config and AB test

### DIFF
--- a/src/experiments/ab-tests.ts
+++ b/src/experiments/ab-tests.ts
@@ -1,5 +1,6 @@
 import type { ABTest } from '@guardian/ab-core';
 import { a9BidResponseWinner } from './tests/a9-bid-response-winner';
+import { prebidMultibid } from './tests/prebid-multibid';
 
 /**
  * You only need to add tests to this file if the code you are testing is here in
@@ -9,4 +10,5 @@ import { a9BidResponseWinner } from './tests/a9-bid-response-winner';
 export const concurrentTests: ABTest[] = [
 	// one test per line
 	a9BidResponseWinner,
+	prebidMultibid,
 ];

--- a/src/experiments/tests/prebid-multibid.ts
+++ b/src/experiments/tests/prebid-multibid.ts
@@ -3,14 +3,14 @@ import type { ABTest } from '@guardian/ab-core';
 export const prebidMultibid: ABTest = {
 	id: 'PrebidMultibid',
 	author: '@commercial-dev',
-	start: '2025-04-28',
+	start: '2025-04-24',
 	expiry: '2025-05-12',
 	audience: 0 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',
 	successMeasure: '',
 	description:
-		'Test multibid feature that allows configured bidders for bid cache to pass more than one bid per AdUnit through to the ad server.',
+		'Test multibid feature with useBicCache to allows configured bidders to pass more than one bid per AdUnit through to the ad server.',
 	variants: [
 		{
 			id: 'control',

--- a/src/experiments/tests/prebid-multibid.ts
+++ b/src/experiments/tests/prebid-multibid.ts
@@ -1,0 +1,29 @@
+import type { ABTest } from '@guardian/ab-core';
+
+export const prebidMultibid: ABTest = {
+	id: 'PrebidMultibid',
+	author: '@commercial-dev',
+	start: '2025-04-28',
+	expiry: '2025-05-12',
+	audience: 0 / 100,
+	audienceOffset: 0 / 100,
+	audienceCriteria: '',
+	successMeasure: '',
+	description:
+		'Test multibid feature that allows configured bidders for bid cache to pass more than one bid per AdUnit through to the ad server.',
+	variants: [
+		{
+			id: 'control',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+		{
+			id: 'variant',
+			test: (): void => {
+				/* no-op */
+			},
+		},
+	],
+	canRun: () => true,
+};

--- a/src/experiments/tests/prebid-multibid.ts
+++ b/src/experiments/tests/prebid-multibid.ts
@@ -3,9 +3,9 @@ import type { ABTest } from '@guardian/ab-core';
 export const prebidMultibid: ABTest = {
 	id: 'PrebidMultibid',
 	author: '@commercial-dev',
-	start: '2025-04-24',
+	start: '2025-04-28',
 	expiry: '2025-05-12',
-	audience: 0 / 100,
+	audience: 10 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',
 	successMeasure: '',

--- a/src/lib/header-bidding/prebid/pbjs.ts
+++ b/src/lib/header-bidding/prebid/pbjs.ts
@@ -15,7 +15,7 @@ import 'prebid.js/modules/tripleliftBidAdapter';
 import 'prebid.js/modules/kargoBidAdapter';
 import 'prebid.js/modules/rubiconBidAdapter';
 import 'prebid.js/modules/ttdBidAdapter';
-import 'prebid.js/modules/multibid/index'; // I need to check because it looks different in the docs https://docs.prebid.org/dev-docs/modules/multibid.html
+// import 'prebid.js/modules/multibid/index';
 
 // Guardian specific adapters that we have modified or created
 import './modules/appnexusBidAdapter';

--- a/src/lib/header-bidding/prebid/pbjs.ts
+++ b/src/lib/header-bidding/prebid/pbjs.ts
@@ -15,7 +15,7 @@ import 'prebid.js/modules/tripleliftBidAdapter';
 import 'prebid.js/modules/kargoBidAdapter';
 import 'prebid.js/modules/rubiconBidAdapter';
 import 'prebid.js/modules/ttdBidAdapter';
-// import 'prebid.js/modules/multibid/index';
+import 'prebid.js/modules/multibid';
 
 // Guardian specific adapters that we have modified or created
 import './modules/appnexusBidAdapter';

--- a/src/lib/header-bidding/prebid/pbjs.ts
+++ b/src/lib/header-bidding/prebid/pbjs.ts
@@ -15,6 +15,7 @@ import 'prebid.js/modules/tripleliftBidAdapter';
 import 'prebid.js/modules/kargoBidAdapter';
 import 'prebid.js/modules/rubiconBidAdapter';
 import 'prebid.js/modules/ttdBidAdapter';
+import 'prebid.js/modules/multibid/index'; // I need to check because it looks different in the docs https://docs.prebid.org/dev-docs/modules/multibid.html
 
 // Guardian specific adapters that we have modified or created
 import './modules/appnexusBidAdapter';

--- a/src/lib/header-bidding/prebid/prebid.spec.ts
+++ b/src/lib/header-bidding/prebid/prebid.spec.ts
@@ -26,7 +26,7 @@ jest.mock('lib/dfp/get-advert-by-id', () => ({
 jest.mock('../utils', () => ({
 	...jest.requireActual('../utils.ts'),
 	shouldIncludePermutive: jest.fn().mockReturnValue(true),
-	shouldIncludePrebidBidCache: jest.fn().mockReturnValue(false),
+	shouldIncludePrebidBidCache: jest.fn().mockReturnValue(true),
 	shouldIncludeBidder: jest
 		.fn()
 		.mockReturnValue(jest.fn().mockReturnValue(true)),
@@ -71,6 +71,7 @@ describe('initialise', () => {
 		jest.mocked(shouldIncludeBidder).mockReturnValue(
 			jest.fn().mockReturnValue(true),
 		);
+		jest.mocked(isUserInVariant).mockReturnValue(false);
 		prebid.initialise(window, mockConsentState);
 
 		expect(window.pbjs?.getConfig()).toEqual({
@@ -136,7 +137,7 @@ describe('initialise', () => {
 				syncUrlModifier: {},
 			},
 			timeoutBuffer: 400,
-			useBidCache: false,
+			useBidCache: true,
 			multibid: undefined,
 			userSync: {
 				syncDelay: 3000,
@@ -223,25 +224,30 @@ describe('initialise', () => {
 	test('should generate correct Prebid config when shouldIncludePrebidBidCache and prebidMultibid is variant', () => {
 		jest.mocked(shouldIncludePrebidBidCache).mockReturnValue(true);
 		jest.mocked(isUserInVariant).mockReturnValue(true);
+		jest.mocked(shouldIncludeBidder).mockReturnValue(
+			jest.fn().mockReturnValue(true),
+		);
 		prebid.initialise(window, mockConsentState);
 		expect(window.pbjs?.getConfig()).toMatchObject({
 			multibid: [
 				{
-					bidder: 'adyoulike',
+					bidders: [
+						'adyoulike',
+						'and',
+						'criteo',
+						'ix',
+						'kargo',
+						'rubicon',
+						'oxd',
+						'ozone',
+						'pubmatic',
+						'triplelift',
+						'trustx',
+						'xhb',
+						'ttd',
+					],
 					maxBids: 9,
 				},
-				{ bidder: 'and', maxBids: 9 },
-				{ bidder: 'criteo', maxBids: 9 },
-				{ bidder: 'ix', maxBids: 9 },
-				{ bidder: 'kargo', maxBids: 9 },
-				{ bidder: 'rubicon', maxBids: 9 },
-				{ bidder: 'oxd', maxBids: 9 },
-				{ bidder: 'ozone', maxBids: 9 },
-				{ bidder: 'pubmatic', maxBids: 9 },
-				{ bidder: 'triplelift', maxBids: 9 },
-				{ bidder: 'trustx', maxBids: 9 },
-				{ bidder: 'xhb', maxBids: 9 },
-				{ bidder: 'ttd', maxBids: 9 },
 			],
 		});
 	});

--- a/src/lib/header-bidding/prebid/prebid.spec.ts
+++ b/src/lib/header-bidding/prebid/prebid.spec.ts
@@ -227,23 +227,21 @@ describe('initialise', () => {
 		expect(window.pbjs?.getConfig()).toMatchObject({
 			multibid: [
 				{
-					bidders: [
-						'adyoulike',
-						'and',
-						'criteo',
-						'ix',
-						'kargo',
-						'rubicon',
-						'oxd',
-						'ozone',
-						'pubmatic',
-						'triplelift',
-						'trustx',
-						'xhb',
-						'ttd',
-					],
+					bidder: 'adyoulike',
 					maxBids: 9,
 				},
+				{ bidder: 'and', maxBids: 9 },
+				{ bidder: 'criteo', maxBids: 9 },
+				{ bidder: 'ix', maxBids: 9 },
+				{ bidder: 'kargo', maxBids: 9 },
+				{ bidder: 'rubicon', maxBids: 9 },
+				{ bidder: 'oxd', maxBids: 9 },
+				{ bidder: 'ozone', maxBids: 9 },
+				{ bidder: 'pubmatic', maxBids: 9 },
+				{ bidder: 'triplelift', maxBids: 9 },
+				{ bidder: 'trustx', maxBids: 9 },
+				{ bidder: 'xhb', maxBids: 9 },
+				{ bidder: 'ttd', maxBids: 9 },
 			],
 		});
 	});

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -3,7 +3,8 @@ import { isString, log, onConsent } from '@guardian/libs';
 import { flatten } from 'lodash-es';
 import type { PrebidPriceGranularity } from 'prebid.js/src/cpmBucketManager';
 import type { Advert } from '../../../define/Advert';
-import { getParticipations } from '../../../experiments/ab';
+import { getParticipations, isUserInVariant } from '../../../experiments/ab';
+import { prebidMultibid } from '../../../experiments/tests/prebid-multibid';
 import type { AdSize } from '../../../lib/ad-sizes';
 import { createAdSize } from '../../../lib/ad-sizes';
 import { PREBID_TIMEOUT } from '../../../lib/constants/prebid-timeout';
@@ -87,6 +88,13 @@ type UserSync =
 			syncEnabled: false;
 	  };
 
+type Multibid = [
+	{
+		bidders: BidderCode[];
+		maxBids: number;
+	},
+];
+
 type PbjsConfig = {
 	bidderTimeout: number;
 	timeoutBuffer?: number;
@@ -111,6 +119,7 @@ type PbjsConfig = {
 	consentManagement?: ConsentManagement;
 	realTimeData?: unknown;
 	useBidCache?: boolean;
+	multibid?: Multibid;
 	customPriceBucket?: PrebidPriceGranularity;
 	/**
 	 * This is a custom property that has been added to our fork of prebid.js
@@ -393,6 +402,35 @@ const initialise = (window: Window, consentState: ConsentState): void => {
 	 */
 	const useBidCache = shouldIncludePrebidBidCache();
 
+	/**
+	 * multibid is a feature that allows Prebid to request multiple bids
+	 * from the same bidder
+	 */
+	const multibid = (): Multibid => {
+		const multibidBidders = [
+			'adyoulike',
+			'and',
+			'criteo',
+			'ix',
+			'kargo',
+			'rubicon',
+			'oxd',
+			'ozone',
+			'pubmatic',
+			'triplelift',
+			'trustx',
+			'xhb',
+			'ttd',
+		] satisfies BidderCode[];
+
+		return [
+			{
+				bidders: multibidBidders,
+				maxBids: 9,
+			},
+		];
+	};
+
 	/** Helper function to decide if a bidder should be included.
 	 * It is a curried function prepared with the consent state
 	 * at the time of initialisation to avoid unnecessary repetition
@@ -426,6 +464,10 @@ const initialise = (window: Window, consentState: ConsentState): void => {
 
 	if (isSwitchedOn('consentManagement')) {
 		pbjsConfig.consentManagement = consentManagement();
+	}
+
+	if (useBidCache && isUserInVariant(prebidMultibid, 'variant')) {
+		pbjsConfig.multibid = multibid();
 	}
 
 	if (shouldIncludePermutive(consentState)) {

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -88,10 +88,16 @@ type UserSync =
 			syncEnabled: false;
 	  };
 
-type Multibid = {
-	bidder: BidderCode;
-	maxBids: number;
-};
+type Multibid =
+	| {
+			bidders: BidderCode[];
+			maxBids: number;
+	  }
+	| {
+			bidder: BidderCode;
+			maxBids: number;
+			targetBiddercodePrefix?: string;
+	  };
 
 type PbjsConfig = {
 	bidderTimeout: number;
@@ -395,6 +401,12 @@ const initialise = (window: Window, consentState: ConsentState): void => {
 		}
 	};
 
+	/** Helper function to decide if a bidder should be included.
+	 * It is a curried function prepared with the consent state
+	 * at the time of initialisation to avoid unnecessary repetition
+	 * of consent state throughout */
+	const shouldInclude = shouldIncludeBidder(consentState);
+
 	/**
 	 * useBidCache is a feature that allows Prebid to cache bids
 	 */
@@ -405,34 +417,24 @@ const initialise = (window: Window, consentState: ConsentState): void => {
 	 * from the same bidder
 	 */
 	const multibid = (): Multibid[] => {
-		if (!useBidCache || !isUserInVariant(prebidMultibid, 'variant')) {
-			return [];
-		}
-		return [
-			{
-				bidder: 'adyoulike',
-				maxBids: 9,
-			},
-			{ bidder: 'and', maxBids: 9 },
-			{ bidder: 'criteo', maxBids: 9 },
-			{ bidder: 'ix', maxBids: 9 },
-			{ bidder: 'kargo', maxBids: 9 },
-			{ bidder: 'rubicon', maxBids: 9 },
-			{ bidder: 'oxd', maxBids: 9 },
-			{ bidder: 'ozone', maxBids: 9 },
-			{ bidder: 'pubmatic', maxBids: 9 },
-			{ bidder: 'triplelift', maxBids: 9 },
-			{ bidder: 'trustx', maxBids: 9 },
-			{ bidder: 'xhb', maxBids: 9 },
-			{ bidder: 'ttd', maxBids: 9 },
-		];
-	};
+		const allBidders = [
+			'adyoulike',
+			'and',
+			'criteo',
+			'ix',
+			'kargo',
+			'rubicon',
+			'oxd',
+			'ozone',
+			'pubmatic',
+			'triplelift',
+			'trustx',
+			'xhb',
+			'ttd',
+		] satisfies BidderCode[];
 
-	/** Helper function to decide if a bidder should be included.
-	 * It is a curried function prepared with the consent state
-	 * at the time of initialisation to avoid unnecessary repetition
-	 * of consent state throughout */
-	const shouldInclude = shouldIncludeBidder(consentState);
+		return [{ bidders: allBidders.filter(shouldInclude), maxBids: 9 }];
+	};
 
 	const pbjsConfig: PbjsConfig = Object.assign(
 		{},

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -88,12 +88,10 @@ type UserSync =
 			syncEnabled: false;
 	  };
 
-type Multibid = [
-	{
-		bidders: BidderCode[];
-		maxBids: number;
-	},
-];
+type Multibid = {
+	bidder: BidderCode;
+	maxBids: number;
+};
 
 type PbjsConfig = {
 	bidderTimeout: number;
@@ -119,7 +117,7 @@ type PbjsConfig = {
 	consentManagement?: ConsentManagement;
 	realTimeData?: unknown;
 	useBidCache?: boolean;
-	multibid?: Multibid;
+	multibid?: Multibid[];
 	customPriceBucket?: PrebidPriceGranularity;
 	/**
 	 * This is a custom property that has been added to our fork of prebid.js
@@ -406,28 +404,27 @@ const initialise = (window: Window, consentState: ConsentState): void => {
 	 * multibid is a feature that allows Prebid to request multiple bids
 	 * from the same bidder
 	 */
-	const multibid = (): Multibid => {
-		const multibidBidders = [
-			'adyoulike',
-			'and',
-			'criteo',
-			'ix',
-			'kargo',
-			'rubicon',
-			'oxd',
-			'ozone',
-			'pubmatic',
-			'triplelift',
-			'trustx',
-			'xhb',
-			'ttd',
-		] satisfies BidderCode[];
-
+	const multibid = (): Multibid[] => {
+		if (!useBidCache || !isUserInVariant(prebidMultibid, 'variant')) {
+			return [];
+		}
 		return [
 			{
-				bidders: multibidBidders,
+				bidder: 'adyoulike',
 				maxBids: 9,
 			},
+			{ bidder: 'and', maxBids: 9 },
+			{ bidder: 'criteo', maxBids: 9 },
+			{ bidder: 'ix', maxBids: 9 },
+			{ bidder: 'kargo', maxBids: 9 },
+			{ bidder: 'rubicon', maxBids: 9 },
+			{ bidder: 'oxd', maxBids: 9 },
+			{ bidder: 'ozone', maxBids: 9 },
+			{ bidder: 'pubmatic', maxBids: 9 },
+			{ bidder: 'triplelift', maxBids: 9 },
+			{ bidder: 'trustx', maxBids: 9 },
+			{ bidder: 'xhb', maxBids: 9 },
+			{ bidder: 'ttd', maxBids: 9 },
 		];
 	};
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR adds the `multibid` feature to the Prebid config when in variant and `useBidCache` is switched on.

The `useBidCache` is switched on for some time now so `multibid` relies on the switch and the AB test when `userIsInVariant` is true.

`multibid` allows configured bidders to pass more than one bid per AdUnit through to the ad server when `useBidCache` is true. 

In order for `multibid` to work we need to include the module with Prebid.js. Check [Prebid docs](https://docs.prebid.org/dev-docs/modules/multibid.html). 

The Frontend related PR https://github.com/guardian/frontend/pull/27930

## Why?

We want to test if `multibid` will have a revenue uplift for prebid bid caching or not. It was also recommended in Google meeting that happened few weeks ago to add this `multibid` feature to get the most use from prebid bid cache.


