### PR TITLE
Make Playwright timeouts clearer

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
 	workers: process.env.CI ? 4 : undefined,
 	// Reporter to use. See https://playwright.dev/docs/test-reporters
 	reporter: [['line'], ['html', { open: 'never' }]],
+	// Default timeout is 30 seconds
+	timeout: 30_000,
 	// Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions
 	use: {
 		// Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer

--- a/playwright/lib/cmp.ts
+++ b/playwright/lib/cmp.ts
@@ -13,7 +13,12 @@ const cmpAcceptAll = async (page: Page) => {
 		.frameLocator(SP_LAYER1_IFRAME)
 		.locator(SP_LAYER1_ACCEPT_ALL_BUTTON);
 	await acceptAllButton.click();
-	await new Promise((r) => setTimeout(r, 2000));
+	await new Promise((r) =>
+		setTimeout(
+			r,
+			2_000, // 2s
+		),
+	);
 };
 
 const cmpRejectAll = async (page: Page) => {
@@ -21,7 +26,12 @@ const cmpRejectAll = async (page: Page) => {
 		.frameLocator(SP_LAYER1_IFRAME)
 		.locator(SP_LAYER1_REJECT_ALL_BUTTON);
 	await rejectAllButton.click();
-	await new Promise((r) => setTimeout(r, 2000));
+	await new Promise((r) =>
+		setTimeout(
+			r,
+			2_000, // 2s
+		),
+	);
 };
 
 const cmpReconsent = async (page: Page) => {
@@ -33,7 +43,12 @@ const cmpReconsent = async (page: Page) => {
 		.frameLocator(SP_LAYER2_IFRAME)
 		.locator(SP_LAYER2_ACCEPT_ALL_BUTTON);
 	await acceptAllButton.click();
-	await new Promise((r) => setTimeout(r, 2000));
+	await new Promise((r) =>
+		setTimeout(
+			r,
+			2_000, // 2s
+		),
+	);
 };
 
 export { cmpAcceptAll, cmpReconsent, cmpRejectAll };

--- a/playwright/lib/util.ts
+++ b/playwright/lib/util.ts
@@ -134,8 +134,8 @@ const waitForSlot = async (page: Page, slot: string, waitForIframe = true) => {
 	if (waitForIframe) {
 		// iframe locator
 		const iframe = page.locator(`${slotId} iframe:first-child`);
-		// wait for the iframe
-		await iframe.waitFor({ state: 'visible', timeout: 120000 });
+		// wait for the iframe to be visible
+		await iframe.waitFor();
 	}
 };
 
@@ -150,7 +150,7 @@ const waitForIsland = async (page: Page, island: string) => {
 	// wait for it to be hydrated
 	const hyrdatedIslandSelector = `gu-island[name="${island}"][data-island-status="hydrated"]`;
 	const hyrdatedIslandLocator = page.locator(hyrdatedIslandSelector);
-	await hyrdatedIslandLocator.waitFor({ state: 'visible', timeout: 120000 });
+	await hyrdatedIslandLocator.waitFor();
 };
 
 const countLiveblogInlineSlots = async (page: Page, isMobile: boolean) => {

--- a/playwright/tests/comments-expanded.spec.ts
+++ b/playwright/tests/comments-expanded.spec.ts
@@ -25,7 +25,7 @@ test.describe('desktop comments-expanded slot', () => {
 		await expect(
 			page.locator('[data-testid=comment-counts]').nth(0),
 		).toBeVisible({
-			timeout: 10000,
+			timeout: 10_000, // 10s
 		});
 
 		// Click the comment count to expand the comments
@@ -53,7 +53,7 @@ test.describe('mobile comments-expanded slot', () => {
 		await expect(
 			page.locator('[data-testid=comment-counts]').nth(0),
 		).toBeVisible({
-			timeout: 10000,
+			timeout: 10_000, // 10s
 		});
 
 		// Click the comment count to expand the comments

--- a/playwright/tests/exclusion.spec.ts
+++ b/playwright/tests/exclusion.spec.ts
@@ -28,7 +28,7 @@ test.describe('Exclusion targeting', () => {
 
 		expect(
 			await page.locator('.top-banner-ad-container').isVisible({
-				timeout: 3000,
+				timeout: 3_000, // 3s
 			}),
 		).toBeFalsy();
 	});

--- a/playwright/tests/googletag-switch.spec.ts
+++ b/playwright/tests/googletag-switch.spec.ts
@@ -49,6 +49,6 @@ test.describe('shouldLoadGoogletagSwitch', () => {
 		// by the commercial runtime
 		await page
 			.locator('#dfp-ad--top-above-nav')
-			.waitFor({ state: 'detached', timeout: 30000 });
+			.waitFor({ state: 'detached' });
 	});
 });

--- a/playwright/tests/prebid.spec.ts
+++ b/playwright/tests/prebid.spec.ts
@@ -35,7 +35,9 @@ test.describe('Prebid', () => {
 						),
 				);
 			},
-			{ timeout: 10000 },
+			{
+				timeout: 10_000, // 10s
+			},
 		);
 
 		const topAboveNavBidderRequests = await page.evaluate(() => {
@@ -86,7 +88,9 @@ test.describe('Prebid', () => {
 				const events = window.pbjs?.getEvents() ?? [];
 				return events.find((event) => event.eventType === 'auctionEnd');
 			},
-			{ timeout: 10000 },
+			{
+				timeout: 10_000, // 10s
+			},
 		);
 
 		const bidderErrors = await page.evaluate(() => {


### PR DESCRIPTION
## What does this change?

Makes timeouts defined in Playwright tests easier to read in seconds
Explicitly defines the default timeout in the Playwright config

## Why?

Some tests were setting a timeout of 120000 (120 seconds) which was never reached due to the base timeout being set at 30000 (30 seconds)

Making the base timeout explicit in the config and reformatting other timeouts should help with readability
