### PR TITLE
Remove manual `corepack` version setting from workflows

### DIFF
--- a/.github/workflows/beta-release-on-label.yml
+++ b/.github/workflows/beta-release-on-label.yml
@@ -34,10 +34,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
-
       - name: Set up Node
         uses: ./.github/actions/setup-node-env
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4.2.2
 
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
-
       - name: Set up Node
         uses: ./.github/actions/setup-node-env
 
@@ -33,10 +29,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4.2.2
-
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
 
       - name: Set up Node
         uses: ./.github/actions/setup-node-env
@@ -54,10 +46,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4.2.2
 
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
-
       - name: Set up Node
         uses: ./.github/actions/setup-node-env
 
@@ -70,10 +58,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4.2.2
-
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
 
       - name: Set up Node
         uses: ./.github/actions/setup-node-env
@@ -98,10 +82,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
 
       - name: Set up Node
         uses: ./.github/actions/setup-node-env
@@ -151,10 +131,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
 
       - name: Set up Node
         uses: ./.github/actions/setup-node-env

--- a/.github/workflows/compressed-size-action.yml
+++ b/.github/workflows/compressed-size-action.yml
@@ -14,10 +14,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4.2.2
 
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
-
       - name: Set up Node
         uses: ./.github/actions/setup-node-env
 

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -26,10 +26,6 @@ jobs:
         with:
           path: ./commercial
 
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
-
       - run: corepack enable
         working-directory: ./commercial
 


### PR DESCRIPTION
## What does this change?

Removes lines that pin version of corepack to use in Github workflows

## Why?

These shouldn't be needed any more