### PR TITLE
Update `inlineOpponentSelector` rule to include nested images

### DIFF
--- a/src/insert/spacefinder/rules.ts
+++ b/src/insert/spacefinder/rules.ts
@@ -52,7 +52,10 @@ const leftColumnOpponentSelector = ['richLink', 'thumbnail']
 const rightColumnOpponentSelector =
 	':scope > [data-spacefinder-role="immersive"]';
 const inlineOpponentSelector = ['inline', 'supporting', 'showcase', 'halfWidth']
-	.map((role) => `:scope > [data-spacefinder-role="${role}"]`)
+	.map(
+		(role) =>
+			`:scope > [data-spacefinder-role="${role}"], [data-spacefinder-role="nested"] > [data-spacefinder-role="${role}"]`,
+	)
 	.join(',');
 
 const headingSelector = `:scope > h2, [data-spacefinder-role="nested"] > h2, :scope > h3, [data-spacefinder-role="nested"] > h3`;


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR updates the inlineOpponentSelector rule in Spacefinder to avoid having an ad just after an image. There is a rule already for images which is included under `data-spacefinder-role=inline` but in this case it's nested so we had to update the rule to include the `inline` role when it's nested.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![Screenshot 2025-05-06 at 16 33 10](https://github.com/user-attachments/assets/6ade967e-6938-4e57-ad93-54ed30164bd7) | ![Screenshot 2025-05-06 at 16 34 22](https://github.com/user-attachments/assets/ed53d01f-f599-40d6-b7c7-21caa480bab4) |
| ![Screenshot 2025-05-06 at 16 34 49](https://github.com/user-attachments/assets/c3e1737b-3fd7-41ef-8e98-23eb332757ca) | ![Screenshot 2025-05-06 at 16 35 10](https://github.com/user-attachments/assets/6103a0ec-bc33-45c6-8021-67567d1dcde6) | 

## Why?

This will prevent having an ad straightaway after an image. 
