### PR TITLE
Send full Prebid events array to Sentry when first event is invalid

### DIFF
--- a/src/lib/header-bidding/prebid/modules/analyticsAdapter.ts
+++ b/src/lib/header-bidding/prebid/modules/analyticsAdapter.ts
@@ -1,4 +1,4 @@
-// see http://prebid.org/dev-docs/integrate-with-the-prebid-analytics-api.html
+// see http://docs.prebid.org/dev-docs/integrate-with-the-prebid-analytics-api.html
 import { log } from '@guardian/libs';
 import adapter from 'prebid.js/libraries/analyticsAdapter/AnalyticsAdapter.js';
 import adapterManager from 'prebid.js/src/adapterManager.js';
@@ -211,7 +211,7 @@ const createPayload = (events: EventData[], pv: string): AnalyticsPayload => {
 			'commercial',
 			{},
 			{
-				firstEventType: events[0]?.ev,
+				invalidEventsList: JSON.stringify(events),
 			},
 		);
 	}


### PR DESCRIPTION
## What does this change?

This sends the full Prebid events array to Sentry when the first event is considered invalid and an error is reported.

## Why?

We've had an elevated rate of errors being reported since this module was converted to Typescript in #1929. It's unclear as to what exactly is causing this, and whether the data causing the reports is in a genuinely unusable state. This change should give us more visibility to better understand the issue and what we ned to do to address it.