### PR TITLE
Remove the isPayloadValid check and associated error from Prebid analytics adapter

### DIFF
--- a/src/lib/header-bidding/prebid/modules/analyticsAdapter.spec.ts
+++ b/src/lib/header-bidding/prebid/modules/analyticsAdapter.spec.ts
@@ -1,10 +1,9 @@
 import * as guardianLibs from '@guardian/libs';
 import { EVENTS } from 'prebid.js/src/constants.js';
 import * as errorReporting from '../../../../lib/error/report-error';
-import type { EventData } from '../../prebid-types';
 import analyticsAdapter, { _ } from './analyticsAdapter';
 
-const { createEvent, isPayloadValid, handlers } = _;
+const { createEvent, handlers } = _;
 
 // Mock dependencies
 jest.mock('prebid.js/libraries/analyticsAdapter/AnalyticsAdapter.js', () => ({
@@ -109,29 +108,6 @@ describe('analyticsAdapter', () => {
 				ev: 'init',
 				sid: 'slotId',
 			});
-		});
-	});
-
-	describe('isPayloadValid', () => {
-		test('returns true for valid init event', () => {
-			const events = [{ ev: 'init' }];
-			expect(isPayloadValid(events)).toBe(true);
-		});
-
-		test('returns true for valid bidwon event', () => {
-			const events = [{ ev: 'bidwon' }];
-			expect(isPayloadValid(events)).toBe(true);
-		});
-
-		test('returns false for empty events', () => {
-			const events: EventData[] = [];
-
-			expect(isPayloadValid(events)).toBe(false);
-		});
-
-		test('returns false for invalid event type', () => {
-			const events = [{ ev: 'unknown' }];
-			expect(isPayloadValid(events)).toBe(false);
 		});
 	});
 

--- a/src/lib/header-bidding/prebid/modules/analyticsAdapter.ts
+++ b/src/lib/header-bidding/prebid/modules/analyticsAdapter.ts
@@ -191,31 +191,12 @@ type AnalyticsPayload = {
 	hb_ev: EventData[];
 };
 
-// Check if the payload is valid
-function isPayloadValid(events: EventData[]): boolean {
-	return (
-		(events[0] && (events[0].ev === 'init' || events[0].ev === 'bidwon')) ??
-		false
-	);
-}
-
 const createPayload = (events: EventData[], pv: string): AnalyticsPayload => {
-	const payload = {
+	return {
 		v: VERSION,
 		pv,
 		hb_ev: events,
 	};
-	if (!isPayloadValid(events)) {
-		reportError(
-			new Error('Invalid analytics payload'),
-			'commercial',
-			{},
-			{
-				invalidEventsList: JSON.stringify(events),
-			},
-		);
-	}
-	return payload;
 };
 
 const analyticsAdapter = Object.assign(adapter({ analyticsType: 'endpoint' }), {
@@ -323,6 +304,5 @@ export default analyticsAdapter;
 export const _ = {
 	getBidderCode,
 	createEvent,
-	isPayloadValid,
 	handlers,
 };


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This removes the `isPayloadValid` check which checked if the first event in the Prebid events array was 'init' or 'bidwon' and reported an error if this was not the case.

## Why?

This check did nothing besides sending an error to Sentry- the events array would be sent into the data lake regardless. It doesn't appear that anything changed about this behaviour from the recent migration of this file to Typescript or migration away from our old Prebid fork, or that sending this 'malformed' data is actually causing any problems. Removing the error simply reduces noise in Sentry with no effect on actual code execution.