### PR TITLE
Fix pre-push hook to prevent pushes to main branch

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,5 @@
-if [[ $currentBranch == "main" ]]
+CURRENT_BRANCH="$(git branch --show-current)"
+if [[ $CURRENT_BRANCH == "main" ]]
 then
 	echo "⚠️ You should not push to the \`main\` branch"
 	exit 1


### PR DESCRIPTION
## What does this change?

Fixes the pre-push husky hook to prevent accidental pushes to the main branch

## Why?

The hook wasn't working because `currentBranch` wasn't defined
