### PR TITLE
Listen and report video progress messenger events

### DIFF
--- a/src/init/consented/messenger.ts
+++ b/src/init/consented/messenger.ts
@@ -11,6 +11,7 @@ import { init as passbackRefresh } from '../../lib/messenger/passback-refresh';
 import { init as resize } from '../../lib/messenger/resize';
 import { init as scroll } from '../../lib/messenger/scroll';
 import { init as type } from '../../lib/messenger/type';
+import { initMessengerVideoProgressReporting } from '../../lib/messenger/video';
 import { init as viewport } from '../../lib/messenger/viewport';
 
 /**
@@ -29,6 +30,7 @@ initMessenger(
 		background,
 		disableRefresh,
 		passback,
+		initMessengerVideoProgressReporting,
 	],
 	[scroll, viewport],
 );

--- a/src/lib/messenger.ts
+++ b/src/lib/messenger.ts
@@ -19,7 +19,8 @@ type MessageType =
 	| 'scroll'
 	| 'type'
 	| 'viewport'
-	| 'passback-refresh';
+	| 'passback-refresh'
+	| 'video-progress';
 
 /**
  * A message that is sent from an iframe following a standard format

--- a/src/lib/messenger/video.ts
+++ b/src/lib/messenger/video.ts
@@ -1,0 +1,26 @@
+import { isObject } from '@guardian/libs';
+import type { RegisterListener } from '../messenger';
+import {
+	sendProgressOnUnloadOnce,
+	updateVideoProgress,
+} from '../video-progress-reporting';
+
+const initMessengerVideoProgressReporting = (
+	register: RegisterListener,
+): void => {
+	register('video-progress', async (specs, ret, iframe): Promise<void> => {
+		const adSlot = iframe?.closest<HTMLElement>('.js-ad-slot');
+		if (
+			adSlot &&
+			isObject(specs) &&
+			'progress' in specs &&
+			typeof specs.progress === 'number'
+		) {
+			void sendProgressOnUnloadOnce();
+			updateVideoProgress(adSlot.id, specs.progress);
+		}
+		return Promise.resolve();
+	});
+};
+
+export { initMessengerVideoProgressReporting };


### PR DESCRIPTION
## What does this change?
Add messenger handler for video progress reports, log them with the video progress reporting lib. These events will be sent from `fabric-video` and `fabric-video-xl` native templates.

I did try using a `video-init` event to setup the progress reporting, however it was firing before messenger has set up!

As the `sendProgressOnUnloadOnce` is wrapped in a `once` it can be added to the progress report event to setup the reporting the first time one is recieved.

## Why?
So we can report video progress from fabric-video(-xl)