### PR TITLE
Include Multibid targeting

### DIFF
--- a/src/lib/header-bidding/prebid/prebid.spec.ts
+++ b/src/lib/header-bidding/prebid/prebid.spec.ts
@@ -3,6 +3,7 @@ import { getConsentFor } from '@guardian/libs';
 import { isUserInVariant } from '../../../experiments/ab';
 import { pubmatic } from '../../__vendor/pubmatic';
 import { getAdvertById as getAdvertById_ } from '../../dfp/get-advert-by-id';
+import type { BidderCode } from '../prebid-types';
 import { shouldIncludeBidder, shouldIncludePermutive } from '../utils';
 import { prebid } from './prebid';
 
@@ -335,16 +336,13 @@ describe('initialise', () => {
 
 	describe('permutive realTimeData', () => {
 		test('should filter out non included bidders from permutive acBidders array', () => {
+			const mockShouldInclude = jest
+				.fn()
+				.mockImplementation((bidder: BidderCode) =>
+					Boolean(['and', 'ozone', 'pubmatic'].includes(bidder)),
+				);
+			jest.mocked(shouldIncludeBidder).mockReturnValue(mockShouldInclude);
 			jest.mocked(shouldIncludePermutive).mockReturnValue(true);
-			jest.mocked(shouldIncludeBidder).mockReturnValue(
-				jest
-					.fn()
-					.mockReturnValueOnce(true) // and (appnexus)
-					.mockReturnValueOnce(false) // ix
-					.mockReturnValueOnce(true) // ozone
-					.mockReturnValueOnce(true) // pubmatic
-					.mockReturnValueOnce(false), // trustx
-			);
 
 			prebid.initialise(window, mockConsentState);
 			expect(window.pbjs?.getConfig()).toMatchObject({
@@ -365,16 +363,13 @@ describe('initialise', () => {
 		});
 
 		test('should filter out pubmatic from the overwrites field and the acBidders array if shouldInclude is false', () => {
+			const mockShouldInclude = jest
+				.fn()
+				.mockImplementation((bidder: BidderCode) =>
+					Boolean(['and', 'ix', 'ozone', 'trustx'].includes(bidder)),
+				);
+			jest.mocked(shouldIncludeBidder).mockReturnValue(mockShouldInclude);
 			jest.mocked(shouldIncludePermutive).mockReturnValue(true);
-			jest.mocked(shouldIncludeBidder).mockReturnValue(
-				jest
-					.fn()
-					.mockReturnValueOnce(true) // and (appnexus)
-					.mockReturnValueOnce(true) // ix
-					.mockReturnValueOnce(true) // ozone
-					.mockReturnValueOnce(false) // pubmatic
-					.mockReturnValueOnce(true), // trustx
-			);
 
 			prebid.initialise(window, mockConsentState);
 			expect(window.pbjs?.getConfig()).toMatchObject({


### PR DESCRIPTION
## What does this change?

Expands upon the Prebid Multibid config set up to add 9 variations (one for each additional bid for a bidder using multibid, see #2008) per bidder per targeting value to the Prebid config

This results in 600+ additional targeting values (roughly 9 variations x 10 bidders x 7 targeting values)

## Why?

We noticed that some targeting values were being removed before being sent to GAM:

Prebid debug logging:
```
Prebid INFO: allowTargetingKeys - removed keys [ hb_source, hb_adomain, hb_crid, hb_source_ttd, hb_adomain_ttd, hb_crid_ttd, hb_source_ttd_m2, hb_adomain_ttd_m2, hb_crid_ttd_m2, hb_source_ttd_m3, hb_adomain_ttd_m3, hb_crid_ttd_m3, hb_source_ix, hb_adomain_ix, hb_crid_ix, hb_dsp_ix, hb_source_ix_m2, hb_adomain_ix_m2, hb_crid_ix_m2, hb_dsp_ix_m2, hb_source_ix_m3, hb_adomain_ix_m3, hb_crid_ix_m3, hb_dsp_ix_m3, hb_source_criteo, hb_adomain_criteo, hb_crid_criteo, hb_dsp_criteo, hb_source_criteo_m2, hb_adomain_criteo_m2, hb_acat_criteo_m2, hb_crid_criteo_m2, hb_dsp_criteo_m2, hb_source_criteo_m3, hb_adomain_criteo_m3, hb_acat_criteo_m3, hb_crid_criteo_m3, hb_dsp_criteo_m3, hb_source_ozone, hb_adomain_ozone, hb_crid_ozone, hb_source_ozone_m2, hb_adomain_ozone_m2, hb_crid_ozone_m2, hb_source_ozone_m3, hb_adomain_ozone_m3, hb_crid_ozone_m3, hb_source_ozone_m4, hb_adomain_ozone_m4, hb_crid_ozone_m4, hb_source_ozone_m5, hb_adomain_ozone_m5, hb_crid_ozone_m5, hb_source_ozone_m6, hb_adomain_ozone_m6, hb_crid_ozone_m6, hb_source_ozone_m7, hb_adomain_ozone_m7, hb_crid_ozone_m7, hb_source_ozone_m8, hb_adomain_ozone_m8, hb_crid_ozone_m8 ]
```

The highlighted code for this was coming from the [`bidsBackHandler`](https://github.com/guardian/commercial/blob/2a3255030d0b9448bb0693c519def8c66d483492/src/lib/header-bidding/prebid/prebid.ts#L669-L685) where there is a line of code that calls [`setTargetingForGPTAsync`](https://docs.prebid.org/dev-docs/publisher-api-reference/setTargetingForGPTAsync.html)

So after checking the docs for `setTargetingForGPTAsync` we considered that we might need to explicitly allow sending these additional targeting values through to the ad server
