### PR TITLE
Update Opinary survey response event name

### DIFF
--- a/src/init/consented/opinary.ts
+++ b/src/init/consented/opinary.ts
@@ -46,7 +46,7 @@ const opinaryPollListener = (event: MessageEvent) => {
 
 	const { poll, vote } = event.data;
 
-	window.permutive.track('SurveyResponse', {
+	window.permutive.track('OpinarySurveyResponse', {
 		survey: {
 			id: poll.pollId,
 			type: poll.type,
@@ -72,8 +72,14 @@ const opinaryPollListener = (event: MessageEvent) => {
 	);
 };
 
-const initOpinaryPollListener = (): Promise<void> =>
-	Promise.resolve(window.addEventListener('message', opinaryPollListener));
+const initOpinaryPollListener = (): Promise<void> => {
+	if (window.permutive?.track) {
+		return Promise.resolve(
+			window.addEventListener('message', opinaryPollListener),
+		);
+	}
+	return Promise.resolve();
+};
 
 // Exports for testing only
 export const _ = {


### PR DESCRIPTION
## What does this change?

- Updates Opinary survey response event name to `OpinarySurveyReponse`
- Only adds an event listener when Permutive is available on the `window` object

## Why?

It will make more sense in Permutive if the event name is specific to Opinary rather than just using `SurveyResponse`