### PR TITLE
Update Opinary event

### DIFF
--- a/src/init/consented/opinary.ts
+++ b/src/init/consented/opinary.ts
@@ -66,6 +66,12 @@ const opinaryPollListener = (event: MessageEvent) => {
 
 	const { poll, vote } = event.data;
 
+	/**
+	 * IMPORTANT: Do not change the shape of this data before checking with Permutive!
+	 * This is a Permutive custom event and is documented and specified manually in a schema
+	 * @see https://support.permutive.com/hc/en-us/articles/10211335253660-Schema-Updates-for-the-Pageview-Event-Custom-Events
+	 * for more information
+	 */
 	const surveyResponse: SurveyResponse = {
 		survey: {
 			id: poll.pollId,


### PR DESCRIPTION
## What does this change?

- Updates type for Opinary response data and specifies expected result shape to send to Permutive
- Only inits the poll event listener if `window.permutive` is available on the page
- Adds documentation warning to discourage casual changes to the response type due to it needing to match the Permutive schema

## Why?

We are adding this custom event to the Permutive schema so need to be specific about the data types we expect to send