### PR TITLE
Add 1% variant for 8 days to PrebidMultibid test

### DIFF
--- a/src/experiments/tests/prebid-multibid.ts
+++ b/src/experiments/tests/prebid-multibid.ts
@@ -3,9 +3,9 @@ import type { ABTest } from '@guardian/ab-core';
 export const prebidMultibid: ABTest = {
 	id: 'PrebidMultibid',
 	author: '@commercial-dev',
-	start: '2025-05-29',
-	expiry: '2025-07-15',
-	audience: 0 / 100,
+	start: '2025-06-18',
+	expiry: '2025-07-01',
+	audience: 2 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',
 	successMeasure: '',

--- a/src/experiments/tests/prebid-multibid.ts
+++ b/src/experiments/tests/prebid-multibid.ts
@@ -4,7 +4,7 @@ export const prebidMultibid: ABTest = {
 	id: 'PrebidMultibid',
 	author: '@commercial-dev',
 	start: '2025-06-18',
-	expiry: '2025-07-01',
+	expiry: '2025-07-08',
 	audience: 2 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR increases the `PrebidMultibid` test from 0% to 1% variant so in total 2% and it should take around 8 days to collect data. 

## Why?

We want to retest multibid after the changes that has been done in the setup https://github.com/guardian/commercial/pull/2008 to be confident we don't have any negative impact before we make further changes to group slots and test it separately. 
