### PR TITLE
Remove Permutive track condition from Opinary event listener init function

### DIFF
--- a/src/init/consented/opinary.ts
+++ b/src/init/consented/opinary.ts
@@ -101,14 +101,8 @@ const opinaryPollListener = (event: MessageEvent) => {
 	log('commercial', surveyResponse);
 };
 
-const initOpinaryPollListener = (): Promise<void> => {
-	if (window.permutive?.track) {
-		return Promise.resolve(
-			window.addEventListener('message', opinaryPollListener),
-		);
-	}
-	return Promise.resolve();
-};
+const initOpinaryPollListener = (): Promise<void> =>
+	Promise.resolve(window.addEventListener('message', opinaryPollListener));
 
 // Exports for testing only
 export const _ = {


### PR DESCRIPTION
## What does this change?

Removes extra condition from `initOpinaryPollListener` to allow it to listen for Opinary events regardless of whether Permutive has fully loaded on the page yet.

## Why?

There was a mismatch identified between votes recorded in Opinary directly versus those sent to Permutive.

By adding the event listener regardless of whether Permutive has fully loaded yet, we may catch those final edge cases.

We already filter out events in the listener itself if the Permutive `track` function is not available.