### PR TITLE
Add `consentManagementGpp` module

### DIFF
--- a/src/lib/header-bidding/prebid/pbjs-v9.46.0.ts
+++ b/src/lib/header-bidding/prebid/pbjs-v9.46.0.ts
@@ -2,7 +2,7 @@ import pbjs from 'prebid-v9.46.0.js';
 
 import 'prebid-v9.46.0.js/modules/adyoulikeBidAdapter';
 import 'prebid-v9.46.0.js/modules/consentManagementTcf';
-import 'prebid-v9.46.0.js/modules/consentManagementUsp';
+import 'prebid-v9.46.0.js/modules/consentManagementGpp';
 import 'prebid-v9.46.0.js/modules/criteoBidAdapter';
 import 'prebid-v9.46.0.js/modules/gridBidAdapter';
 import 'prebid-v9.46.0.js/modules/ixBidAdapter';

--- a/src/lib/header-bidding/prebid/pbjs-v9.46.0.ts
+++ b/src/lib/header-bidding/prebid/pbjs-v9.46.0.ts
@@ -2,6 +2,7 @@ import pbjs from 'prebid-v9.46.0.js';
 
 import 'prebid-v9.46.0.js/modules/adyoulikeBidAdapter';
 import 'prebid-v9.46.0.js/modules/consentManagementTcf';
+import 'prebid-v9.46.0.js/modules/consentManagementUsp';
 import 'prebid-v9.46.0.js/modules/consentManagementGpp';
 import 'prebid-v9.46.0.js/modules/criteoBidAdapter';
 import 'prebid-v9.46.0.js/modules/gridBidAdapter';

--- a/src/lib/header-bidding/prebid/pbjs.ts
+++ b/src/lib/header-bidding/prebid/pbjs.ts
@@ -2,6 +2,7 @@ import pbjs from 'prebid.js';
 
 import 'prebid.js/modules/adyoulikeBidAdapter';
 import 'prebid.js/modules/consentManagementTcf';
+import 'prebid.js/modules/consentManagementUsp';
 import 'prebid.js/modules/consentManagementGpp';
 import 'prebid.js/modules/criteoBidAdapter';
 import 'prebid.js/modules/gridBidAdapter';

--- a/src/lib/header-bidding/prebid/pbjs.ts
+++ b/src/lib/header-bidding/prebid/pbjs.ts
@@ -2,7 +2,7 @@ import pbjs from 'prebid.js';
 
 import 'prebid.js/modules/adyoulikeBidAdapter';
 import 'prebid.js/modules/consentManagementTcf';
-import 'prebid.js/modules/consentManagementUsp';
+import 'prebid.js/modules/consentManagementGpp';
 import 'prebid.js/modules/criteoBidAdapter';
 import 'prebid.js/modules/gridBidAdapter';
 import 'prebid.js/modules/ixBidAdapter';

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -55,6 +55,7 @@ type USPConfig = {
 type GPPConfig = {
 	cmpApi: CmpApi;
 	timeout: number;
+	actionTimeout?: number;
 	consentData?: Record<string, unknown>;
 };
 

--- a/src/lib/header-bidding/prebid/prebid.ts
+++ b/src/lib/header-bidding/prebid/prebid.ts
@@ -51,6 +51,13 @@ type USPConfig = {
 	consentData?: Record<string, unknown>;
 };
 
+/** @see https://docs.prebid.org/dev-docs/modules/consentManagementGpp.html */
+type GPPConfig = {
+	cmpApi: CmpApi;
+	timeout: number;
+	consentData?: Record<string, unknown>;
+};
+
 type ConsentManagement =
 	| {
 			gdpr: GDPRConfig;
@@ -59,7 +66,7 @@ type ConsentManagement =
 			usp: USPConfig;
 	  }
 	| {
-			gpp: USPConfig;
+			gpp: GPPConfig;
 	  };
 
 type UserId = {


### PR DESCRIPTION
## Why?
Since we switched to GPP in the US we haven't been passing consent to our prebid vendors for users there.

This wasn't a risk to us as we don't launch prebid without the requisite consent, but likely means our ad-tech partners may believe we’re not adequately collecting and/or passing consent on to them

Before:
<img width="367" alt="Screenshot 2025-07-08 at 14 24 31" src="https://github.com/user-attachments/assets/94acac3f-f532-4862-a3f5-ec2db45f5878" />

After:
<img width="354" alt="Screenshot 2025-07-08 at 14 23 59" src="https://github.com/user-attachments/assets/9756c1fd-6438-4119-ba41-e1e85c4e273d" />