### PR TITLE
Fix core build path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/upload-artifact@v4.6.2
         with:
           name: core-dist
-          path: dist
+          path: core/dist
 
   changesets:
     name: Core Changesets


### PR DESCRIPTION
## What does this change?
Fix Build Core artifact path

## Why?
The build path was incorrect causing changesets release not to work
