### PR TITLE
Remove multibid adapter from v9.46.0 Prebid.js import

### DIFF
--- a/src/lib/header-bidding/prebid/pbjs-v9.46.0.ts
+++ b/src/lib/header-bidding/prebid/pbjs-v9.46.0.ts
@@ -16,7 +16,6 @@ import 'prebid-v9.46.0.js/modules/tripleliftBidAdapter';
 import 'prebid-v9.46.0.js/modules/kargoBidAdapter';
 import 'prebid-v9.46.0.js/modules/rubiconBidAdapter';
 import 'prebid-v9.46.0.js/modules/ttdBidAdapter';
-import 'prebid-v9.46.0.js/modules/multibid';
 import 'prebid-v9.46.0.js/modules/id5IdSystem';
 import 'prebid-v9.46.0.js/modules/userId';
 


### PR DESCRIPTION
## What does this change?

Removes the multibid adapter import from the beta version of Prebid we are currently testing (v9.46.0)

## Why?

We removed multibid in https://github.com/guardian/commercial/pull/2066 but must have copied the pbjs file at an earlier point in https://github.com/guardian/commercial/pull/2057

We want the current version of Prebid.js and the newer version we are testing to be as close as possible in terms of configuration