### PR TITLE
Remove Prebid server adapter

### DIFF
--- a/src/lib/header-bidding/prebid/pbjs-v9.46.0.ts
+++ b/src/lib/header-bidding/prebid/pbjs-v9.46.0.ts
@@ -11,7 +11,6 @@ import 'prebid-v9.46.0.js/modules/criteoBidAdapter';
 import 'prebid-v9.46.0.js/modules/gridBidAdapter';
 import 'prebid-v9.46.0.js/modules/ixBidAdapter';
 import 'prebid-v9.46.0.js/modules/ozoneBidAdapter';
-import 'prebid-v9.46.0.js/modules/prebidServerBidAdapter';
 import 'prebid-v9.46.0.js/modules/pubmaticBidAdapter';
 import 'prebid-v9.46.0.js/modules/tripleliftBidAdapter';
 import 'prebid-v9.46.0.js/modules/kargoBidAdapter';

--- a/src/lib/header-bidding/prebid/pbjs.ts
+++ b/src/lib/header-bidding/prebid/pbjs.ts
@@ -11,7 +11,6 @@ import 'prebid.js/modules/criteoBidAdapter';
 import 'prebid.js/modules/gridBidAdapter';
 import 'prebid.js/modules/ixBidAdapter';
 import 'prebid.js/modules/ozoneBidAdapter';
-import 'prebid.js/modules/prebidServerBidAdapter';
 import 'prebid.js/modules/pubmaticBidAdapter';
 import 'prebid.js/modules/tripleliftBidAdapter';
 import 'prebid.js/modules/kargoBidAdapter';

--- a/src/lib/header-bidding/prebid/prebid.spec.ts
+++ b/src/lib/header-bidding/prebid/prebid.spec.ts
@@ -127,24 +127,6 @@ describe('initialise', () => {
 				},
 			},
 			priceGranularity: 'custom',
-			s2sConfig: {
-				adapter: 'prebidServer',
-				adapterOptions: {},
-				allowUnknownBidderCodes: false,
-				bidders: [],
-				maxBids: 1,
-				maxTimeout: 1500,
-				ortbNative: {
-					eventtrackers: [
-						{
-							event: 1,
-							methods: [1, 2],
-						},
-					],
-				},
-				syncTimeout: 1000,
-				syncUrlModifier: {},
-			},
 			timeoutBuffer: 400,
 			useBidCache: true,
 			userSync: {


### PR DESCRIPTION
## What does this change?

- Removes the Prebid server adapter (https://docs.prebid.org/dev-docs/modules/prebidServer.html)

## Why?

We don't use Prebid server and we don't set config (`s2sConfig`) for it

It looks like it was implemented in 2018 as a test but never removed (https://github.com/guardian/Prebid.js/pull/32) 

