### PR TITLE
Add 'data-ad-slot' to the ad slot container

### DIFF
--- a/bundle/src/lib/create-ad-slot.ts
+++ b/bundle/src/lib/create-ad-slot.ts
@@ -152,6 +152,7 @@ const wrapSlotInContainer = (
 ) => {
 	const container = document.createElement('div');
 	container.className = `${adSlotContainerClass} ${options.className ?? ''}`;
+	container.dataset.adSlot = 'true';
 	container.appendChild(adSlot);
 
 	return container;


### PR DESCRIPTION
## What does this change?

Adds `data-ad-slot='true'` to the ad slot container created by `wrapSlotInContainer`, for consistency with the attribute on other ad slots added on-platform in https://github.com/guardian/dotcom-rendering/pull/14126.

## Why?

Per https://github.com/guardian/dotcom-rendering/pull/14126, we want a unified approach to be able to identify ad slots in both web and apps articles that is not likely to have an effect on styling decisions (like the class `ad-slot-container`.)

This is especially useful for things like interactive articles, so that they can be designed and built in a platform-agnostic way.

## How do I test this?

- There aren't any tests that check the container markup that I can see — happy to add one!
- Deploy to CODE. You should see the new attribute on the ad slot container:

<img width="411" height="306" alt="Screenshot 2025-07-17 at 14 29 11" src="https://github.com/user-attachments/assets/f6d2354b-e537-492f-b072-e36e6b9deaa9" />

- [x] Tested in CODE.
