### PR TITLE
Fix changesets publish command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1.5.3
         with:
-          publish: pnpm --filter @guardian/commercial-core changeset publish
+          publish: pnpm changeset publish
           title: '🦋 Release package updates'
           commit: 'Bump package versions'
           setupGitUser: false


### PR DESCRIPTION
## Why?
It should run in the root of the monorepo