### PR TITLE
Move more types to core

### DIFF
--- a/.changeset/grumpy-kids-clean.md
+++ b/.changeset/grumpy-kids-clean.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial-core': minor
+---
+
+Add AdsConfig types to core

--- a/bundle/src/lib/types.ts
+++ b/bundle/src/lib/types.ts
@@ -85,15 +85,6 @@ export type AdsConfigTCFV2 = AdsConfigBasic & {
 	nonPersonalizedAd: boolean;
 };
 
-export type AdsConfigEnabled =
-	| AdsConfigBasic
-	| AdsConfigUSNATorAus
-	| AdsConfigTCFV2;
-
-export type AdsConfig = AdsConfigEnabled | AdsConfigDisabled;
-
-export type AdTargetingBuilder = () => Promise<AdsConfig>;
-
 export type True = 't';
 
 export type False = 'f';

--- a/core/package.json
+++ b/core/package.json
@@ -46,11 +46,11 @@
 	},
 	"dependencies": {
 		"@guardian/ab-core": "catalog:",
-		"@guardian/libs": "catalog:"
+		"@guardian/libs": "catalog:",
+		"@types/googletag": "catalog:"
 	},
 	"devDependencies": {
 		"@types/node": "catalog:",
-		"@types/googletag": "catalog:",
 		"typescript": "catalog:",
 		"@types/jest": "catalog:",
 		"jest": "catalog:",

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -104,6 +104,12 @@ type AdsConfigTCFV2 = AdsConfigBasic & {
 	nonPersonalizedAd: boolean;
 };
 
+type AdsConfigEnabled = AdsConfigBasic | AdsConfigUSNATorAus | AdsConfigTCFV2;
+
+type AdsConfig = AdsConfigEnabled | AdsConfigDisabled;
+
+type AdTargetingBuilder = () => Promise<AdsConfig>;
+
 interface Ophan {
 	trackComponentAttention: (
 		name: string,
@@ -503,9 +509,12 @@ export type {
 	Indices,
 	Edition,
 	AdsConfigDisabled,
+	AdsConfigEnabled,
 	AdsConfigBasic,
 	AdsConfigUSNATorAus,
 	AdsConfigTCFV2,
+	AdsConfig,
+	AdTargetingBuilder,
 	Ophan,
 	Config,
 	AdBlockers,

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -1,5 +1,6 @@
 import type { AdSize, SizeMapping } from './ad-sizes';
 import type { PageTargeting } from './targeting/build-page-targeting';
+import 'googletag';
 
 type HeaderBiddingSize = AdSize;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,10 +240,10 @@ importers:
       '@guardian/libs':
         specifier: 'catalog:'
         version: 22.5.0(tslib@2.8.1)(typescript@5.5.4)
-    devDependencies:
       '@types/googletag':
         specifier: 'catalog:'
         version: 3.3.0
+    devDependencies:
       '@types/jest':
         specifier: 'catalog:'
         version: 30.0.0


### PR DESCRIPTION
## What does this change?
Move `AdsConfig` types to `core`, I didn't notice they were used by frontend.

Also need to import the `googletag` ambient types in `core` and have it as a dependency rather than devDependency as the `Slot` type is used and exported there as part of the `Advert` interface.

Unfortunately there isn't a way to import/export just the `Slot` type as it's not a module.

I'm quite puzzled how I'm only noticing these now 🤔

## Why?
To make frontend and DCR happy.