### PR TITLE
Update exclusions for dependabot groupings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,8 @@ updates:
           - 'patch'
         exclude-patterns:
           - 'prebid.js'
+          - 'typescript'
+          - '@types/*'
       minor-devDependencies:
         dependency-type: 'development'
         update-types:


### PR DESCRIPTION
## What does this change?

Explicitly exclude `typescript` and `@types/*` patterns from the minor-dependencies group 

## Why?

Due to the presence of the "catalog" file , dependabot doesn't recognise these as dev-dependencies correctly
