### PR TITLE
Add 2% for PrebidAdUnit test

### DIFF
--- a/bundle/src/experiments/tests/prebid-ad-unit.ts
+++ b/bundle/src/experiments/tests/prebid-ad-unit.ts
@@ -3,9 +3,9 @@ import type { ABTest } from '@guardian/ab-core';
 export const prebidAdUnit: ABTest = {
 	id: 'PrebidAdUnit',
 	author: '@commercial-dev',
-	start: '2025-07-03',
-	expiry: '2025-07-23',
-	audience: 0 / 100,
+	start: '2025-07-22',
+	expiry: '2025-08-12',
+	audience: 2 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',
 	successMeasure: '',


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR increases 0% to 2% in total (variant 1% and control 1%) for `PrebidAdUnit` test for 7 days which should allow use to check if grouping slots returns revenue with bid caching. 

## Why?

We want to test if the grouping slots for Prebid bid caching is going to increase revenue as we will be able to use the same bid cache for subsequent slots.  
