### PR TITLE
Add Admiral candidate events to commercial logger

### DIFF
--- a/bundle/src/init/consented/prepare-admiral.ts
+++ b/bundle/src/init/consented/prepare-admiral.ts
@@ -1,3 +1,4 @@
+import type { Admiral } from '@guardian/commercial-core/types';
 import { log } from '@guardian/libs';
 
 type AdmiralEvent = Record<string, unknown>;
@@ -93,16 +94,16 @@ const handleCandidateDismissedEvent = (event: AdmiralEvent): void => {
 	}
 };
 
-const setUpAdmiralEventLogger = (): void => {
-	window.admiral?.('after', 'measure.detected', function (event) {
+const setUpAdmiralEventLogger = (admiral: Admiral): void => {
+	admiral('after', 'measure.detected', function (event) {
 		handleMeasureDetectedEvent(event);
 	});
 
-	window.admiral?.('after', 'candidate.shown', function (event) {
+	admiral('after', 'candidate.shown', function (event) {
 		handleCandidateShownEvent(event);
 	});
 
-	window.admiral?.('after', 'candidate.dismissed', function (event) {
+	admiral('after', 'candidate.dismissed', function (event) {
 		handleCandidateDismissedEvent(event);
 	});
 };
@@ -127,7 +128,7 @@ const initAdmiralAdblockRecovery = (): Promise<void> => {
 		};
 	/* eslint-enable */
 
-	void setUpAdmiralEventLogger();
+	void setUpAdmiralEventLogger(window.admiral);
 	return Promise.resolve();
 };
 


### PR DESCRIPTION
## What does this change?

- Adds event handlers for `candidate.shown` and `candidate.dismissed` events from Admiral
- Logs to the commercial logger when these events are detected

### Next

A follow-up from this PR will add Ophan tracking to these events so that we can analyse the results from the Admiral test when launched (https://github.com/guardian/commercial/pull/2141)

### How to test

- Deploy this branch to the `CODE` environment
- Use a VPN to make a request to code.dev-theguardian.com from the US, ensuring you are opted into the client side test by having `#ab-AdmiralAdblockRecovery=variant` at the end of the URL
- Subscribe to the commercial logger (`window.guardian.logger.subscribeTo('commercial')`)
- Do this with and without an ad blocker browser extension to demonstrate the various states and how we can recognise whether an ad blocker has been detected, whether a modal has been shown and whether the modal has been dismissed

## Why?

We're working on an AB test which uses Admiral's ad block recovery solution.
We want to add our own tracking of when ad block recovery screens are shown and dismissed for analysis
