### PR TITLE
Extend `PrebidAdUnit` test 

### DIFF
--- a/bundle/src/experiments/tests/prebid-ad-unit.ts
+++ b/bundle/src/experiments/tests/prebid-ad-unit.ts
@@ -4,7 +4,7 @@ export const prebidAdUnit: ABTest = {
 	id: 'PrebidAdUnit',
 	author: '@commercial-dev',
 	start: '2025-07-22',
-	expiry: '2025-08-12',
+	expiry: '2025-08-21',
 	audience: 2 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR extends the expiry date for the `PrebidAdUnit` test. The switch is off until we get back the results from D&I and then we will decide if we want to increase the test or remove it based on the outcome. 

## Why?

Extend the expiry date to 1 week more as it might take longer than a week for the analysis.  
