### PR TITLE
Simplify Admiral code

### DIFF
--- a/bundle/src/init/consented/admiral.ts
+++ b/bundle/src/init/consented/admiral.ts
@@ -1,15 +1,5 @@
-import { log } from '@guardian/libs';
 import { isUserInVariant } from '../../experiments/ab';
 import { admiralAdblockRecovery } from '../../experiments/tests/admiral-adblocker-recovery';
-
-/**
- * Logs a message to the commercial logger available on the window object
- * with an Admiral prefix
- *
- * @param message log message
- */
-const admiralLog = (message: string): void =>
-	log('commercial', `🛡️ Admiral - ${message}`);
 
 /**
  * Fetches AB test variant name for Admiral, as there are two variants
@@ -36,4 +26,4 @@ const getAdmiralAbTestVariant = (): string | undefined => {
 const setAdmiralTargeting = (key: string, value: string): void =>
 	window.admiral?.('targeting', 'set', key, value);
 
-export { admiralLog, getAdmiralAbTestVariant, setAdmiralTargeting };
+export { getAdmiralAbTestVariant, setAdmiralTargeting };

--- a/bundle/src/init/consented/prepare-admiral.ts
+++ b/bundle/src/init/consented/prepare-admiral.ts
@@ -1,5 +1,5 @@
 import type { Admiral, AdmiralEvent } from '@guardian/commercial-core/types';
-import { admiralLog } from './admiral';
+import { log } from '@guardian/libs';
 
 type MeasureDetectedEvent = {
 	adblocking: boolean;
@@ -27,19 +27,27 @@ const handleMeasureDetectedEvent = (event: AdmiralEvent): void => {
 
 	if (isMeasureDetectedEvent(event)) {
 		if (event.adblocking) {
-			admiralLog('user has an adblocker and it is enabled');
+			log(
+				'commercial',
+				'🛡️ Admiral - user has an adblocker and it is enabled',
+			);
 		}
 		if (event.whitelisted) {
-			admiralLog(
-				'user has seen Engage and subsequently disabled their adblocker',
+			log(
+				'commercial',
+				'🛡️ Admiral - user has seen Engage and subsequently disabled their adblocker',
 			);
 		}
 		if (event.subscribed) {
-			admiralLog('user has an active subscription to a transact plan');
+			log(
+				'commercial',
+				'🛡️ Admiral - user has an active subscription to a transact plan',
+			);
 		}
 	} else {
-		admiralLog(
-			'Event is not of expected format of measure.detected ${JSON.stringify(event)}',
+		log(
+			'commercial',
+			`🛡️ Admiral - Event is not of expected format of measure.detected ${JSON.stringify(event)}`,
 		);
 	}
 };
@@ -52,12 +60,14 @@ const handleCandidateShownEvent = (event: AdmiralEvent): void => {
 		'candidateGroups' in e;
 
 	if (isCandidateShownEvent(event)) {
-		admiralLog(
-			'Launching candidate ${event.candidateID} with variant ${event.variantID}',
+		log(
+			'commercial',
+			`🛡️ Admiral - Launching candidate ${event.candidateID}`,
 		);
 	} else {
-		admiralLog(
-			'Event is not of expected format of candidate.shown ${JSON.stringify(event)}',
+		log(
+			'commercial',
+			`🛡️ Admiral - Event is not of expected format of candidate.shown ${JSON.stringify(event)}`,
 		);
 	}
 };
@@ -69,10 +79,14 @@ const handleCandidateDismissedEvent = (event: AdmiralEvent): void => {
 		typeof e === 'object' && 'candidateID' in e && 'candidateGroups' in e;
 
 	if (isCandidateDismissedEvent(event)) {
-		admiralLog('Candidate ${event.candidateID} was dismissed');
+		log(
+			'commercial',
+			`🛡️ Admiral - Candidate ${event.candidateID} was dismissed`,
+		);
 	} else {
-		admiralLog(
-			'Event is not of expected format of candidate.dismissed ${JSON.stringify(event)}',
+		log(
+			'commercial',
+			`🛡️ Admiral - Event is not of expected format of candidate.dismissed ${JSON.stringify(event)}`,
 		);
 	}
 };

--- a/bundle/src/init/consented/third-party-tags.ts
+++ b/bundle/src/init/consented/third-party-tags.ts
@@ -3,7 +3,7 @@
 import { getConsentFor, onConsent } from '@guardian/libs';
 import { commercialFeatures } from '../../lib/commercial-features';
 import fastdom from '../../lib/fastdom-promise';
-import { admiralTag as admiral } from '../../lib/third-party-tags/admiral-adblocker';
+import { admiralTag as admiral } from '../../lib/third-party-tags/admiral';
 import { ias } from '../../lib/third-party-tags/ias';
 import { imrWorldwide } from '../../lib/third-party-tags/imr-worldwide';
 import { imrWorldwideLegacy } from '../../lib/third-party-tags/imr-worldwide-legacy';

--- a/bundle/src/lib/third-party-tags/admiral.ts
+++ b/bundle/src/lib/third-party-tags/admiral.ts
@@ -1,7 +1,6 @@
 import { isInUsa } from '@guardian/commercial-core/geo/geo-utils';
-import { cmp } from '@guardian/libs';
+import { cmp, log } from '@guardian/libs';
 import {
-	admiralLog,
 	getAdmiralAbTestVariant,
 	setAdmiralTargeting,
 } from '../../init/consented/admiral';
@@ -54,12 +53,15 @@ const admiralTag: ReturnType<GetThirdPartyTag> = {
 	async: true,
 	url: `${BASE_AJAX_URL}/commercial/admiral-bootstrap.js`,
 	beforeLoad: () => {
-		admiralLog('loading script on the page');
+		log('commercial', '🛡️ Admiral - loading script on the page');
 
 		/** Send targeting to Admiral for AB test variants */
 		if (isInVariant && abTestVariant) {
 			setAdmiralTargeting('guAbTest', abTestVariant);
-			admiralLog(`setting targeting: guAbTest = ${abTestVariant}`);
+			log(
+				'commercial',
+				`🛡️ Admiral - setting targeting: guAbTest = ${abTestVariant}`,
+			);
 		}
 	},
 };


### PR DESCRIPTION
## What does this change?

Refactors Admiral code to make it simpler to add Ophan component event tracking

Does this by adding a library/helper file with common functionality used in the third party tag code as well as the init script

## Why?

The `prepare-admiral` file is getting larger and harder to read

Splitting this out into sections and extracting repetitive code could make it slightly easier to understand
