### PR TITLE
Update start date and audience for Admiral client-side AB test

### DIFF
--- a/bundle/src/experiments/tests/admiral-adblocker-recovery.ts
+++ b/bundle/src/experiments/tests/admiral-adblocker-recovery.ts
@@ -4,7 +4,7 @@ export const admiralAdblockRecovery: ABTest = {
 	id: 'AdmiralAdblockRecovery',
 	author: '@commercial-dev',
 	start: '2025-08-13',
-	expiry: '2025-08-29',
+	expiry: '2025-09-17',
 	audience: 100 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',


### PR DESCRIPTION
> [!IMPORTANT]
> Wait until Wednesday 13th to merge this

## What does this change?

Updates the start date and audience for the Admiral client-side AB test

Also updates the expiry date to last until 17th September, so that we can allow the test to run for long enough to gather sufficient data for analysis. Guessing that four weeks should give us enough but we can always extend further if needed

## Why?

We're launching the test with 100% of the audience and 1/3rd of the audience in each of the three variants

[Technical summary](https://docs.google.com/document/d/1N_rYnN700khvRGHkdAMbndHXWB9dvWjCQtuTeclh0RI/edit?usp=sharing)
[Setup documentation](https://docs.google.com/document/d/1QiaEJtv9LkDo-YEeoEBd6Tg9DlvzgSNs8tBePLtNxhw/edit?usp=sharing)

## How to verify once live

Once this is in PROD, every user should be in one of the three groups: `control`, `variant-detect`, `variant-recover` with a roughly 33% split between each

You can subscribe to the commercial logger on the window.guardian object by running `window.guardian.logger.subscribeTo('commercial')`. 
If Admiral is running on the page, you should be able to see log messages starting with `🛡️ Admiral`. You can then find a log message where we set targeting for Admiral with the name of the AB test variant you're in: either `variant-detect` or `variant-recover`

If Admiral does not run on the page, you can assume you are in the `control` group 

You can double check this by inspecting the `gu.ab.participations` key in your local storage

You can force yourself into a particular variant by adding a hash to the end of your URL:
`#ab-AdmiralAdBlockRecovery=<variant>`


## How to switch off

Either revert this PR or turn off the appropriate switch in the frontend admin switchboard.
This will automatically expire on 17th September 2025