### PR TITLE
Test canary version of libs with australia ccpa migration

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 8.0.1
       version: 8.0.1
     '@guardian/libs':
-      specifier: 25.2.0
-      version: 25.2.0
+      specifier: 0.0.0-canary-20250812112542
+      version: 0.0.0-canary-20250812112542
     '@guardian/ophan-tracker-js':
       specifier: 2.4.0
       version: 2.4.0
@@ -96,16 +96,16 @@ importers:
         version: link:../core
       '@guardian/core-web-vitals':
         specifier: 14.0.0
-        version: 14.0.0(@guardian/libs@25.2.0(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)(web-vitals@4.2.4)
+        version: 14.0.0(@guardian/libs@0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)(web-vitals@4.2.4)
       '@guardian/identity-auth':
         specifier: ^10.0.0
-        version: 10.0.0(@guardian/libs@25.2.0(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)
+        version: 10.0.0(@guardian/libs@0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)
       '@guardian/identity-auth-frontend':
         specifier: 12.0.0
-        version: 12.0.0(@guardian/identity-auth@10.0.0(@guardian/libs@25.2.0(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3))(@guardian/libs@25.2.0(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)
+        version: 12.0.0(@guardian/identity-auth@10.0.0(@guardian/libs@0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3))(@guardian/libs@0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)
       '@guardian/libs':
         specifier: 'catalog:'
-        version: 25.2.0(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3)
+        version: 0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3)
       '@guardian/source':
         specifier: 11.1.0
         version: 11.1.0(tslib@2.8.1)(typescript@5.8.3)
@@ -250,7 +250,7 @@ importers:
         version: 8.0.1(tslib@2.8.1)(typescript@5.8.3)
       '@guardian/libs':
         specifier: 'catalog:'
-        version: 25.2.0(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3)
+        version: 0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3)
       '@types/googletag':
         specifier: 'catalog:'
         version: 3.3.0
@@ -1127,8 +1127,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/libs@25.2.0':
-    resolution: {integrity: sha512-1zwsHKRB/DjwnRyKZK6TY/r9GfZf/qK1VzUwb6EFe4CG0r94Qnz3zdEHIfF4nC8eMaua2RoCmF27b/tTEHbi5A==}
+  '@guardian/libs@0.0.0-canary-20250812112542':
+    resolution: {integrity: sha512-3waUYoreQDqac9SwCG6alXp3vb3/Tg0EXP287FySMexO/D7Y1U0wbwvuknm0+v4Y4+nlCs87z0HB6Q9xMNDcHQ==}
     peerDependencies:
       '@guardian/ophan-tracker-js': ^2.2.10
       tslib: ^2.6.2
@@ -6664,9 +6664,9 @@ snapshots:
       browserslist: 4.25.1
       tslib: 2.8.1
 
-  '@guardian/core-web-vitals@14.0.0(@guardian/libs@25.2.0(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)(web-vitals@4.2.4)':
+  '@guardian/core-web-vitals@14.0.0(@guardian/libs@0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)(web-vitals@4.2.4)':
     dependencies:
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3)
+      '@guardian/libs': 0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3)
       tslib: 2.8.1
       web-vitals: 4.2.4
     optionalDependencies:
@@ -6693,22 +6693,22 @@ snapshots:
       - supports-color
       - typescript
 
-  '@guardian/identity-auth-frontend@12.0.0(@guardian/identity-auth@10.0.0(@guardian/libs@25.2.0(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3))(@guardian/libs@25.2.0(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)':
+  '@guardian/identity-auth-frontend@12.0.0(@guardian/identity-auth@10.0.0(@guardian/libs@0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3))(@guardian/libs@0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)':
     dependencies:
-      '@guardian/identity-auth': 10.0.0(@guardian/libs@25.2.0(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3)
+      '@guardian/identity-auth': 10.0.0(@guardian/libs@0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)
+      '@guardian/libs': 0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3)
       tslib: 2.8.1
     optionalDependencies:
       typescript: 5.8.3
 
-  '@guardian/identity-auth@10.0.0(@guardian/libs@25.2.0(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)':
+  '@guardian/identity-auth@10.0.0(@guardian/libs@0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3))(tslib@2.8.1)(typescript@5.8.3)':
     dependencies:
-      '@guardian/libs': 25.2.0(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3)
+      '@guardian/libs': 0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3)
       tslib: 2.8.1
     optionalDependencies:
       typescript: 5.8.3
 
-  '@guardian/libs@25.2.0(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3)':
+  '@guardian/libs@0.0.0-canary-20250812112542(@guardian/ophan-tracker-js@2.4.0)(tslib@2.8.1)(typescript@5.8.3)':
     dependencies:
       '@guardian/ophan-tracker-js': 2.4.0
       tslib: 2.8.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
 
 catalog:
     '@guardian/ab-core': '8.0.1'
-    '@guardian/libs': '25.2.0'
+    '@guardian/libs': '0.0.0-canary-20250812112542'
     '@guardian/ophan-tracker-js': '2.4.0'
     '@types/node': '24.2.0'
     '@types/jest': '30.0.0'


### PR DESCRIPTION
## What does this change?

Installs the canary release of upcoming change to the CMP where Australia is being migrated from CCPA to global CMP

## Why?

Checking things work as expected with these changes