### PR TITLE
Admiral banner should not run if the gu_hide_support_messaging cookie is set

### DIFF
--- a/bundle/src/lib/third-party-tags/admiral.ts
+++ b/bundle/src/lib/third-party-tags/admiral.ts
@@ -1,5 +1,5 @@
 import { isInUsa } from '@guardian/commercial-core/geo/geo-utils';
-import { cmp, log } from '@guardian/libs';
+import { cmp, getCookie, log } from '@guardian/libs';
 import {
 	getAdmiralAbTestVariant,
 	recordAdmiralOphanEvent,
@@ -15,12 +15,18 @@ const BASE_AJAX_URL =
 const abTestVariant = getAdmiralAbTestVariant();
 const isInVariant = abTestVariant?.startsWith('variant') ?? false;
 
+console.log('***', !getCookie({
+	name: 'gu_hide_support_messaging',
+	shouldMemoize: true,
+}));
+
 /**
  * The Admiral bootstrap script should only run under the following conditions:
  *
  * - Should not run if the CMP is due to show
  * - Should only run in the US
  * - Should only run if in the variant of the AB test
+ * - Should not run if the gu_hide_support_messaging cookie is set
  * - Should not run for content marked as: shouldHideAdverts, shouldHideReaderRevenue, isSensitive
  * - Should not run for paid-content sponsorship type (includes Hosted Content)
  * - Should not run for certain sections
@@ -30,6 +36,10 @@ const shouldRun =
 	!cmp.willShowPrivacyMessageSync() &&
 	isInUsa() &&
 	isInVariant &&
+	!getCookie({
+		name: 'gu_hide_support_messaging',
+		shouldMemoize: true,
+	}) &&
 	!window.guardian.config.page.shouldHideAdverts &&
 	!window.guardian.config.page.shouldHideReaderRevenue &&
 	!window.guardian.config.page.isSensitive &&


### PR DESCRIPTION
## What does this change?

Updates the Admiral Banner to not run when `gu_hide_support_messaging` cookie is set

## Why?

We don't want to show paying supporters the Admiral banner.

The `gu_hide_support_messaging` cookie is set for paying supporters on checkout completion, for all products other than Ad Lite, and on retrieval of user benefits from the User Benefits API (https://user-benefits.guardianapis.com/benefits/me). If this cookie has expired, or is not set we call this endpoint on page load, for signed-in users on www.theguardian.com.
