### PR TITLE
Revert "Add `tagid` and new placements to TripleLift bidder"

### DIFF
--- a/bundle/src/lib/header-bidding/prebid-types.ts
+++ b/bundle/src/lib/header-bidding/prebid-types.ts
@@ -55,7 +55,6 @@ type PrebidTrustXParams = {
 
 type PrebidTripleLiftParams = {
 	inventoryCode: string;
-	tagid: string;
 };
 
 type PrebidXaxisParams = {

--- a/bundle/src/lib/header-bidding/prebid/bid-config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bid-config.spec.ts
@@ -482,11 +482,10 @@ describe('triplelift adapter', () => {
 	});
 
 	test('should return correct triplelift adapter params for leaderboard, with requests from US or Canada', () => {
-		containsLeaderboard.mockReturnValue(true);
-		containsBillboard.mockReturnValueOnce(false);
+		containsLeaderboard.mockReturnValueOnce(true);
 		containsMpu.mockReturnValueOnce(false);
 		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValueOnce(false);
+		containsMobileSticky.mockReturnValue(false);
 		isInUsOrCa.mockReturnValue(true);
 
 		const tripleLiftBids = bids(
@@ -498,16 +497,14 @@ describe('triplelift adapter', () => {
 		).find((bid) => bid.bidder === 'triplelift');
 		expect(tripleLiftBids?.params).toEqual({
 			inventoryCode: 'theguardian_topbanner_728x90_prebid',
-			tagid: 'theguardian_topbanner_728x90_prebid',
 		});
 	});
 
 	test('should return correct triplelift adapter params for leaderboard, with requests from Aus or NZ', () => {
-		containsLeaderboard.mockReturnValue(true);
-		containsBillboard.mockReturnValueOnce(false);
+		containsLeaderboard.mockReturnValueOnce(true);
 		containsMpu.mockReturnValueOnce(false);
 		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValueOnce(false);
+		containsMobileSticky.mockReturnValue(false);
 		isInAuOrNz.mockReturnValue(true);
 
 		const tripleLiftBids = bids(
@@ -519,16 +516,14 @@ describe('triplelift adapter', () => {
 		).find((bid) => bid.bidder === 'triplelift');
 		expect(tripleLiftBids?.params).toEqual({
 			inventoryCode: 'theguardian_topbanner_728x90_prebid_AU',
-			tagid: 'theguardian_topbanner_728x90_prebid_AU',
 		});
 	});
 
 	test('should return correct triplelift adapter params for MPU, with requests from US or Canada', () => {
 		containsLeaderboard.mockReturnValueOnce(false);
-		containsBillboard.mockReturnValueOnce(false);
-		containsMpu.mockReturnValue(true);
+		containsMpu.mockReturnValueOnce(true);
 		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValueOnce(false);
+		containsMobileSticky.mockReturnValue(false);
 		isInUsOrCa.mockReturnValue(true);
 
 		const tripleLiftBids = bids(
@@ -540,16 +535,14 @@ describe('triplelift adapter', () => {
 		).find((bid) => bid.bidder === 'triplelift');
 		expect(tripleLiftBids?.params).toEqual({
 			inventoryCode: 'theguardian_sectionfront_300x250_prebid',
-			tagid: 'theguardian_sectionfront_300x250_prebid',
 		});
 	});
 
 	test('should return correct triplelift adapter params for MPU, with requests from Aus or NZ', () => {
 		containsLeaderboard.mockReturnValueOnce(false);
-		containsBillboard.mockReturnValueOnce(false);
-		containsMpu.mockReturnValue(true);
+		containsMpu.mockReturnValueOnce(true);
 		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValueOnce(false);
+		containsMobileSticky.mockReturnValue(false);
 		isInAuOrNz.mockReturnValue(true);
 
 		const tripleLiftBids = bids(
@@ -561,13 +554,11 @@ describe('triplelift adapter', () => {
 		).find((bid) => bid.bidder === 'triplelift');
 		expect(tripleLiftBids?.params).toEqual({
 			inventoryCode: 'theguardian_sectionfront_300x250_prebid_AU',
-			tagid: 'theguardian_sectionfront_300x250_prebid_AU',
 		});
 	});
 
 	test('should return correct triplelift adapter params for mobile sticky, with requests from US or Canada', () => {
 		containsLeaderboard.mockReturnValueOnce(false);
-		containsBillboard.mockReturnValueOnce(false);
 		containsMpu.mockReturnValueOnce(false);
 		containsDmpu.mockReturnValueOnce(false);
 		containsMobileSticky.mockReturnValue(true);
@@ -582,13 +573,11 @@ describe('triplelift adapter', () => {
 		).find((bid) => bid.bidder === 'triplelift');
 		expect(tripleLiftBids?.params).toEqual({
 			inventoryCode: 'theguardian_320x50_HDX',
-			tagid: 'theguardian_320x50_HDX',
 		});
 	});
 
 	test('should return correct triplelift adapter params for mobile sticky, with requests from Aus or NZ', () => {
 		containsLeaderboard.mockReturnValueOnce(false);
-		containsBillboard.mockReturnValueOnce(false);
 		containsMpu.mockReturnValueOnce(false);
 		containsDmpu.mockReturnValueOnce(false);
 		containsMobileSticky.mockReturnValue(true);
@@ -603,49 +592,6 @@ describe('triplelift adapter', () => {
 		).find((bid) => bid.bidder === 'triplelift');
 		expect(tripleLiftBids?.params).toEqual({
 			inventoryCode: 'theguardian_320x50_HDX_AU',
-			tagid: 'theguardian_320x50_HDX_AU',
-		});
-	});
-
-	test('should return correct triplelift adapter params for billboard, with requests from US or Canada', () => {
-		containsLeaderboard.mockReturnValueOnce(false);
-		containsBillboard.mockReturnValue(true);
-		containsMpu.mockReturnValueOnce(false);
-		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValueOnce(false);
-		isInUsOrCa.mockReturnValue(true);
-
-		const tripleLiftBids = bids(
-			'dfp-ad--merchandising-high',
-			[createAdSize(970, 250)],
-			mockPageTargeting,
-			'gpid',
-			mockConsentState,
-		).find((bid) => bid.bidder === 'triplelift');
-		expect(tripleLiftBids?.params).toEqual({
-			inventoryCode: 'theguardian_article_970x250_prebid',
-			tagid: 'theguardian_article_970x250_prebid',
-		});
-	});
-
-	test('should return correct triplelift adapter params for billboard, with requests from Aus or NZ', () => {
-		containsLeaderboard.mockReturnValueOnce(false);
-		containsBillboard.mockReturnValue(true);
-		containsMpu.mockReturnValueOnce(false);
-		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValueOnce(false);
-		isInAuOrNz.mockReturnValue(true);
-
-		const tripleLiftBids = bids(
-			'dfp-ad--merchandising-high',
-			[createAdSize(970, 250)],
-			mockPageTargeting,
-			'gpid',
-			mockConsentState,
-		).find((bid) => bid.bidder === 'triplelift');
-		expect(tripleLiftBids?.params).toEqual({
-			inventoryCode: 'theguardian_article_970x250_prebid_AU',
-			tagid: 'theguardian_article_970x250_prebid_AU',
 		});
 	});
 });

--- a/bundle/src/lib/header-bidding/prebid/bid-config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bid-config.ts
@@ -186,14 +186,6 @@ const getTripleLiftInventoryCode = (
 		}
 	}
 
-	if (containsBillboard(sizes)) {
-		if (isInUsOrCa()) {
-			return 'theguardian_article_970x250_prebid';
-		} else if (isInAuOrNz()) {
-			return 'theguardian_article_970x250_prebid_AU';
-		}
-	}
-
 	if (containsMobileSticky(sizes)) {
 		if (isInUsOrCa()) {
 			return 'theguardian_320x50_HDX';
@@ -416,7 +408,6 @@ const tripleLiftBidder: PrebidBidder = {
 		sizes: HeaderBiddingSize[],
 	): PrebidTripleLiftParams => ({
 		inventoryCode: getTripleLiftInventoryCode(slotId, sizes),
-		tagid: getTripleLiftInventoryCode(slotId, sizes),
 	}),
 };
 


### PR DESCRIPTION
Reverts guardian/commercial#2168