### PR TITLE
Fix changeset package name

### DIFF
--- a/.changeset/curvy-apes-lick.md
+++ b/.changeset/curvy-apes-lick.md
@@ -1,5 +1,5 @@
 ---
-'@guardian/commercial': minor
+'@guardian/commercial-core': minor
 ---
 
 adding a module to handle a/b tests under the new framework


### PR DESCRIPTION
## What does this change?

Updates the name of the package in the changeset file to `@guardian/commercial-core`

## Why?

A PR that was merged to main got slightly out of sync and has the wrong package name in the changeset