### PR TITLE
Enable hot module replacement (HMR) for dev server

### DIFF
--- a/bundle/webpack.config.dev.mjs
+++ b/bundle/webpack.config.dev.mjs
@@ -17,7 +17,7 @@ export default merge(config, {
 	devServer: {
 		port,
 		compress: true,
-		hot: false,
+		hot: true,
 		liveReload: true,
 	},
 });


### PR DESCRIPTION
## What does this change?

Sets `hot: true` in the webpack config for the dev server to enable hot module replacement (HMR)

## Why?

Enables the commercial bundle to update quickly without needing a full reload when in dev mode. This should give us faster feedback on changes we're testing locally

See https://webpack.js.org/concepts/hot-module-replacement

> Hot Module Replacement (HMR) exchanges, adds, or removes [modules](https://webpack.js.org/concepts/modules/) while an application is running, without a full reload. This can significantly speed up development in a few ways:
> 
> - Retain application state which is lost during a full reload.
> - Save valuable development time by only updating what's changed.
> - Instantly update the browser when modifications are made to CSS/JS in the source code, which is almost comparable to changing styles directly in the browser's dev tools.


