### PR TITLE
Increase `disableChildDirected` test

### DIFF
--- a/bundle/src/experiments/tests/disable-child-directed.ts
+++ b/bundle/src/experiments/tests/disable-child-directed.ts
@@ -5,7 +5,7 @@ export const disableChildDirected: ABTest = {
 	author: '@commercial-dev',
 	start: '2025-08-28',
 	expiry: '2025-09-19',
-	audience: 2.5 / 100,
+	audience: 5 / 100,
 	audienceOffset: 5 / 100,
 	audienceCriteria: '',
 	successMeasure: '',


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR increases the test size for `disableChildDirected` from 0% to 2.5% variant so in total 5% (variant and control). Related PR https://github.com/guardian/frontend/pull/28193

We add the overall size in client-side tests unlike the server-side tests where you add just the variant for audience size.

## Why?

We want to check if disabling child-directed will uplift revenue.  
