### PR TITLE
Fix logic `disableChildDirected` test 

### DIFF
--- a/bundle/src/init/consented/prepare-googletag.ts
+++ b/bundle/src/init/consented/prepare-googletag.ts
@@ -86,7 +86,7 @@ const handleLocalePermissions = (consentState: ConsentState) => {
  */
 const disableChildDirectedTreatment = () =>
 	isSwitchedOn('disableChildDirected') &&
-	isUserInVariant(disableChildDirected, 'variant')
+	!isUserInVariant(disableChildDirected, 'control')
 		? window.googletag.pubads().setPrivacySettings({
 				childDirectedTreatment: false,
 			})


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR fixes the logic for the AB test `disableChildDirected` so everyone can see the change except users in control. We want to set live 95% (97.5% with variant) and keep back 2.5%. 

## Why?

This was suppose to be done in the previous PR https://github.com/guardian/commercial/pull/2185
