### PR TITLE
Update commercial features logic for add free

### DIFF
--- a/bundle/src/lib/commercial-features.spec.ts
+++ b/bundle/src/lib/commercial-features.spec.ts
@@ -71,7 +71,7 @@ describe('Commercial features', () => {
 		expect.hasAssertions();
 	});
 
-	describe('DFP advertising', () => {
+	describe('GAM advertising', () => {
 		it('Runs by default', () => {
 			const features = new CommercialFeatures();
 			expect(features.shouldLoadGoogletag).toBe(true);

--- a/bundle/src/lib/commercial-features.ts
+++ b/bundle/src/lib/commercial-features.ts
@@ -47,14 +47,6 @@ const isInternetExplorer = () => {
 	return !!navigator.userAgent.match(/MSIE|Trident/g)?.length;
 };
 
-const DIGITAL_SUBSCRIBER_COOKIE = 'gu_digital_subscriber';
-
-const isDigitalSubscriber = (): boolean =>
-	getCookie({ name: DIGITAL_SUBSCRIBER_COOKIE }) === 'true';
-
-const isAdFreeUser = (): boolean =>
-	isDigitalSubscriber() || adFreeDataIsPresent();
-
 const isUserPrefsAdsOff = (): boolean =>
 	storage.local.get(`gu.prefs.switch.adverts`) === false;
 
@@ -115,7 +107,7 @@ class CommercialFeatures {
 		].includes(window.guardian.config.page.pageId);
 
 		// Feature switches
-		this.adFree = !!forceAdFree || isAdFreeUser();
+		this.adFree = !!forceAdFree || adFreeDataIsPresent();
 
 		this.youtubeAdvertising = !this.adFree && !sensitiveContent;
 


### PR DESCRIPTION
## What does this change?

Removes `isDigitalSubscriber` from logic to determine whether a user should have the ad free experience

## Why?

Matching logic with https://github.com/guardian/dotcom-rendering/pull/13277