### PR TITLE
Create copies of modules for prebid-v9.46.0

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/modules/analyticsAdapter-v9.46.0.ts
+++ b/bundle/src/lib/header-bidding/prebid/modules/analyticsAdapter-v9.46.0.ts
@@ -1,0 +1,308 @@
+// see http://docs.prebid.org/dev-docs/integrate-with-the-prebid-analytics-api.html
+import { log } from '@guardian/libs';
+import adapter from 'prebid-v9.46.0.js/libraries/analyticsAdapter/AnalyticsAdapter.js';
+import adapterManager from 'prebid-v9.46.0.js/src/adapterManager.js';
+import { fetch } from 'prebid-v9.46.0.js/src/ajax.js';
+import { EVENTS } from 'prebid-v9.46.0.js/src/constants.js';
+import { reportError } from '../../../../lib/error/report-error';
+import {
+	type BidArgs,
+	type EventData,
+	eventKeys,
+	type Handler,
+	type RawEventData,
+} from '../../prebid-types';
+
+/*
+ * Update whenever you want to make sure you're sending the right version of analytics.
+ * This is useful when some browsers are using old code and some new, for example.
+ */
+const VERSION = 9;
+
+let queue: EventData[] = [];
+
+function getBidderCode(args: BidArgs): string {
+	if (args.bidderCode !== 'ozone') return args.bidderCode ?? '';
+
+	// Ozone represents several different advertisers
+	if (args.adserverTargeting) {
+		/**
+		 * Each Ozone bid contains information about all the other bids.
+		 * To pinpoint which advertiser is reponsible for the bid,
+		 * we can match `adId` against the adserverTargeting key-values for each.
+		 *
+		 * For example, given `oz_appnexus_adId: "123abc456def789-0-0"`,
+		 * we want to capture `appnexus` if `adId` matches `123abc456def789-0-0`
+		 */
+		for (const key in args.adserverTargeting) {
+			const [, advertiser, info] = key.split('_');
+			const value = args.adserverTargeting[key];
+			if (info === 'adId' && value === args.adId) {
+				return `ozone-${advertiser}`;
+			}
+		}
+
+		// If none matched, use ozone's winner as fallback
+		if (
+			args.adserverTargeting.oz_winner &&
+			typeof args.adserverTargeting.oz_winner === 'string'
+		) {
+			return `ozone-${args.adserverTargeting.oz_winner}`;
+		}
+	}
+
+	return `ozone-unknown`;
+}
+
+function logEvents(events: EventData[]): void {
+	const isBid = events[0]?.ev === 'init';
+	const isBidWon = events[0]?.ev === 'bidwon';
+	let logMsg = '';
+	if (isBid) {
+		const slotId = events.find((e) => e.sid)?.sid;
+		logMsg = `bids for ${slotId ?? 'unknown slot'}`;
+	} else if (isBidWon) {
+		const bidId = events[0]?.bid;
+		logMsg = `bid won ${bidId ?? 'unknown bid'}`;
+	}
+	log('commercial', `Prebid.js events: ${logMsg}`, events);
+}
+
+function isEventKey(key: string): key is keyof EventData {
+	return eventKeys.includes(key as keyof EventData);
+}
+
+// Remove any properties that are undefined or null
+function createEvent(event: RawEventData): EventData {
+	if (!event.ev) {
+		throw new Error('Event must have an "ev" property');
+	}
+	const cleanedEvent: Partial<EventData> = {
+		ev: event.ev,
+	};
+	for (const key in event) {
+		if (
+			isEventKey(key) &&
+			event[key] !== undefined &&
+			event[key] !== null
+		) {
+			cleanedEvent[key] = event[key];
+		}
+	}
+
+	return cleanedEvent as EventData;
+}
+
+// Handlers for each event type, these create a loggable event from prebid event
+const handlers = {
+	[EVENTS.AUCTION_INIT]: (adapter, args) => {
+		queue = [];
+
+		if (adapter.context) {
+			adapter.context.auctionTimeStart = Date.now();
+		}
+		const event = createEvent({
+			ev: 'init',
+			aid: args.auctionId,
+			st: adapter.context?.auctionTimeStart,
+		});
+
+		return [event];
+	},
+	[EVENTS.BID_REQUESTED]: (_, args) => {
+		if (args.bids) {
+			return args.bids.map((bid) => {
+				const event = createEvent({
+					ev: 'request',
+					n: args.bidderCode,
+					sid: bid.adUnitCode,
+					bid: bid.bidId,
+					st: args.start,
+				});
+
+				return event;
+			});
+		}
+		return null;
+	},
+	[EVENTS.BID_RESPONSE]: (_, args) => {
+		if (args.statusMessage === 'Bid available') {
+			const event = createEvent({
+				ev: 'response',
+				n: getBidderCode(args),
+				bid: args.requestId,
+				sid: args.adUnitCode,
+				cpm: args.cpm,
+				pb: args.pbCg,
+				cry: args.currency,
+				net: args.netRevenue,
+				did: args.adId,
+				cid: args.creativeId,
+				sz: args.size,
+				ttr: args.timeToRespond,
+				lid: args.dealId,
+				dsp: args.meta?.networkId,
+				adv: args.meta?.buyerId,
+				bri: args.meta?.brandId,
+				brn: args.meta?.brandName,
+				add: args.meta?.clickUrl,
+			});
+
+			return [event];
+		}
+		return null;
+	},
+	[EVENTS.NO_BID]: (adapter, args) => {
+		const duration = Date.now() - (adapter.context?.auctionTimeStart ?? 0);
+		const event = createEvent({
+			ev: 'nobid',
+			n: args.bidder ?? args.bidderCode,
+			bid: args.bidId ?? args.requestId,
+			sid: args.adUnitCode,
+			aid: args.auctionId,
+			ttr: duration,
+		});
+
+		return [event];
+	},
+	[EVENTS.AUCTION_END]: (adapter, args) => {
+		const duration = Date.now() - (adapter.context?.auctionTimeStart ?? 0);
+		const event = createEvent({
+			ev: 'end',
+			aid: args.auctionId,
+			ttr: duration,
+		});
+
+		return [event];
+	},
+	[EVENTS.BID_WON]: (_, args: BidArgs) => {
+		const event = createEvent({
+			ev: 'bidwon',
+			aid: args.auctionId,
+			bid: args.requestId,
+		});
+		return [event];
+	},
+} as const satisfies Record<string, Handler>;
+
+type AnalyticsPayload = {
+	v: number;
+	pv: string;
+	hb_ev: EventData[];
+};
+
+const createPayload = (events: EventData[], pv: string): AnalyticsPayload => {
+	return {
+		v: VERSION,
+		pv,
+		hb_ev: events,
+	};
+};
+
+const analyticsAdapter = Object.assign(adapter({ analyticsType: 'endpoint' }), {
+	sendPayload: async (
+		url: string,
+		payload: AnalyticsPayload,
+	): Promise<void> => {
+		const events = [...queue];
+		queue = [];
+		try {
+			const response = await fetch(url, {
+				method: 'POST',
+				body: JSON.stringify(payload),
+				keepalive: true,
+				headers: {
+					'Content-Type': 'application/json',
+				},
+			});
+
+			if (!response.ok) {
+				throw new Error(
+					`Failed to send analytics payload: ${
+						response.statusText
+					} (${response.status})`,
+				);
+			}
+			logEvents(events);
+		} catch (error) {
+			if (error instanceof Error && error.name === 'AbortError') {
+				// Ignore abort errors, they are expected when the fetch times out
+				return;
+			}
+			reportError(
+				error,
+				'commercial',
+				{},
+				{
+					events,
+				},
+			);
+		}
+	},
+	track({ eventType, args }: { eventType: string; args: BidArgs }): void {
+		if (!analyticsAdapter.context) {
+			// this should never happen
+			reportError(
+				new Error(
+					'context is not defined, prebid event not being logged',
+				),
+				'commercial',
+				{},
+				{
+					eventType,
+					args,
+				},
+			);
+			log(
+				'commercial',
+				'context is not defined, prebid event not being logged',
+			);
+			return;
+		}
+
+		const handler = handlers[eventType];
+		if (handler) {
+			const events = handler(analyticsAdapter, args);
+			if (events) {
+				if (eventType === EVENTS.BID_WON) {
+					// clear queue to avoid sending late bids with bidWon event
+					queue = [];
+				}
+				queue.push(...events);
+			}
+			if ([EVENTS.AUCTION_END, EVENTS.BID_WON].includes(eventType)) {
+				const { pv, url } = analyticsAdapter.context;
+				const events = [...queue];
+				queue = [];
+				const payload = createPayload(events, pv);
+				void analyticsAdapter.sendPayload(url, payload);
+			}
+		}
+	},
+});
+
+analyticsAdapter.originEnableAnalytics = analyticsAdapter.enableAnalytics;
+
+analyticsAdapter.enableAnalytics = (config): void => {
+	analyticsAdapter.context = {
+		url: config.options.url,
+		pv: config.options.pv,
+	};
+
+	if (analyticsAdapter.originEnableAnalytics) {
+		analyticsAdapter.originEnableAnalytics(config);
+	}
+};
+
+adapterManager.registerAnalyticsAdapter({
+	adapter: analyticsAdapter,
+	code: 'gu',
+});
+
+export default analyticsAdapter;
+
+export const _ = {
+	getBidderCode,
+	createEvent,
+	handlers,
+};

--- a/bundle/src/lib/header-bidding/prebid/modules/appnexusBidAdapter-v9.46.0.ts
+++ b/bundle/src/lib/header-bidding/prebid/modules/appnexusBidAdapter-v9.46.0.ts
@@ -1,0 +1,9 @@
+import { registerBidder } from 'prebid-v9.46.0.js/adapters/bidderFactory';
+import { spec } from 'prebid-v9.46.0.js/modules/appnexusBidAdapter';
+
+const customSpec = {
+	...spec,
+	aliases: [...spec.aliases, { code: 'and' }, { code: 'xhb' }],
+};
+
+registerBidder(customSpec);

--- a/bundle/src/lib/header-bidding/prebid/modules/openxBidAdapter-v9.46.0.ts
+++ b/bundle/src/lib/header-bidding/prebid/modules/openxBidAdapter-v9.46.0.ts
@@ -1,0 +1,9 @@
+import { registerBidder } from 'prebid-v9.46.0.js/adapters/bidderFactory';
+import { spec } from 'prebid-v9.46.0.js/modules/openxBidAdapter';
+
+const customSpec = {
+	...spec,
+	aliases: ['oxd'],
+};
+
+registerBidder(customSpec);

--- a/bundle/src/lib/header-bidding/prebid/pbjs-v9.46.0.ts
+++ b/bundle/src/lib/header-bidding/prebid/pbjs-v9.46.0.ts
@@ -26,9 +26,9 @@ import 'prebid-v9.46.0.js/modules/rtdModule';
 import 'prebid-v9.46.0.js/modules/permutiveRtdProvider';
 
 // Guardian specific adapters that we have modified or created
-import './modules/appnexusBidAdapter';
-import './modules/openxBidAdapter';
-import './modules/analyticsAdapter';
+import './modules/appnexusBidAdapter-v9.46.0';
+import './modules/openxBidAdapter-v9.46.0';
+import './modules/analyticsAdapter-v9.46.0';
 
 pbjs.processQueue();
 


### PR DESCRIPTION
## What does this change?

This PR creates a v9.46.0 copy of every module that imports from [prebid.js/src](http://prebid.js/src), [prebid.js/libraries](http://prebid.js/libraries), [prebid.js/adapters](http://prebid.js/adapters). This creates copies of the following modules:

- /commercial/bundle/src/lib/header-bidding/prebid/modules/appnexusBidAdapter.ts
- /commercial/bundle/src/lib/header-bidding/prebid/modules/openxBidAdapter.ts
- /commercial/bundle/src/lib/header-bidding/prebid/modules/analyticsAdapter.ts

So we now have 

- /commercial/bundle/src/lib/header-bidding/prebid/modules/appnexusBidAdapter-v9.46.0.ts
- /commercial/bundle/src/lib/header-bidding/prebid/modules/openxBidAdapter-v9.46.0.ts
- /commercial/bundle/src/lib/header-bidding/prebid/modules/analyticsAdapter-v9.46.0.ts

In each copy any `prebid.js/*` import has been updated to use `prebid-v9.46.0.js/*`, this means the `'prebid-v9.46.0.js/*` aliases configured in our [webpack config](https://github.com/guardian/commercial/blob/main/bundle/webpack.config.mjs#L73) will work as intended and point to the v9.46.0 of the prebid library.

The module /commercialbundle/src/lib/header-bidding/prebid/pbjs-v9.46.0.ts has been updated to now imports these copies.

## Why?

The `prebid-v9.46.0.js/*` aliases in https://github.com/guardian/commercial/blob/main/bundle/webpack.config.mjs  do not pull in the code from node_modules/prebid-v9.46.0.js as intended. Even when we’re in the variant we’re still using the code from node_modules/prebid.js, this meant certain code such as the analyticsAdapter was not working in the variant. More info in [Trello](https://trello.com/c/yZUJWGcY/3562-investigate-why-prebid946-variant-page-views-arent-in-prebidanalytics-table).