### PR TITLE
Handle undefined `section` in `imr-worldwide` script

### DIFF
--- a/bundle/src/lib/third-party-tags/imr-worldwide.ts
+++ b/bundle/src/lib/third-party-tags/imr-worldwide.ts
@@ -58,10 +58,11 @@ const guMetadata: Record<string, string> = {
 };
 
 const onLoad = (): void => {
-	const sectionFromMeta =
-		window.guardian.config.page.section.toLowerCase() || '';
-	const subBrandApId = (guMetadata[sectionFromMeta] ??
-		guMetadata['brand-only']) as string;
+	const sectionFromMeta = window.guardian.config.page.section;
+	const lookupKey = sectionFromMeta
+		? sectionFromMeta.toLowerCase()
+		: 'brand-only';
+	const subBrandApId = guMetadata[lookupKey] as string;
 
 	const sectionRef =
 		sectionFromMeta in guMetadata


### PR DESCRIPTION
## What does this change?

Adds a default value of empty string if `section` is not defined for `window.guardian.config.page` 

## Why?

We wouldn't expect `section` to not be defined but if for some reason it ends up being undefined, we should handle this to avoid unhandled errors resulting from trying to call `toLowerCase` on an undefined value