### PR TITLE
Reword step which handles reporting of failure for starting the DCR container

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -50,7 +50,7 @@ jobs:
             ghcr.io/guardian/dotcom-rendering:main
           echo "exitcode=$?" >> $GITHUB_OUTPUT
 
-      - name: Start DCR in a container step failed
+      - name: Report if "start DCR in a container" step failed
         if: ${{ failure() && steps.start-dcr-container.conclusion == 'failure' && steps.start-dcr-container.outputs.exitcode == 125 }}
         run: echo "Unable to fetch a DCR container image from the registry. Run the DCR main build in order to create a new container image." && exit 1
 


### PR DESCRIPTION
## What does this change?

Rewords the name of the step which handles the failure scenario in the previous step, "Start DCR in a container"

## Why?

It looked a bit like an actual failure due to the wording of the step, rather than a job that was skipped due to a lack of failure

<img width="326" height="80" alt="Screenshot 2025-09-08 at 11 53 12" src="https://github.com/user-attachments/assets/d1938451-3a19-49be-aa4b-be9e06272de1" />


