### PR TITLE
Add permissions to e2e Github workflow

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -1,4 +1,6 @@
 name: E2E
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/guardian/commercial/security/code-scanning/6](https://github.com/guardian/commercial/security/code-scanning/6)

To fix this issue, you should add a `permissions:` block near the top of your workflow file (`.github/workflows/e2e-playwright.yml`). As a general rule, place it immediately after the workflow name and before the job definitions, unless specific jobs need additional permissions. The recommended minimal configuration is `permissions: contents: read`, which allows jobs to read repository contents but not write to them. This block covers the needs of most test and artifact upload workflows, unless you require write access for actions like merging PRs or pushing changes. You only need to add:
```yaml
permissions:
  contents: read
```
right below the workflow name (after line 1). No other changes or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
