### PR TITLE
Add externalUrl param to ID5 setup

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/prebid.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid.ts
@@ -361,7 +361,8 @@ const initialise = (window: Window, consentState: ConsentState): void => {
 				partner: 182,
 				// ID5 recommend specifying this to ensure use of the most recent module version
 				// https://wiki.id5.io/docs/id5-prebid-user-id-module
-				externalModuleUrl: 'https://cdn.id5-sync.com/api/1.0/id5PrebidModule.js',
+				externalModuleUrl:
+					'https://cdn.id5-sync.com/api/1.0/id5PrebidModule.js',
 			},
 			storage: {
 				type: 'html5',


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This adds the `externalUrl` parameter to our ID5 setup.

## Why?

[ID5 recommend using this parameter with any version of Prebid after 8.33.0](https://wiki.id5.io/docs/id5-prebid-user-id-module). It adds an additional request- around 30kb- on a fresh, unconsented page view to download this module, and appears to have no other effect on page load.
