### PR TITLE
Extend expiry date of Admiral AB test by one week

### DIFF
--- a/bundle/src/experiments/tests/admiral-adblocker-recovery.ts
+++ b/bundle/src/experiments/tests/admiral-adblocker-recovery.ts
@@ -4,7 +4,7 @@ export const admiralAdblockRecovery: ABTest = {
 	id: 'AdmiralAdblockRecovery',
 	author: '@commercial-dev',
 	start: '2025-08-13',
-	expiry: '2025-09-17',
+	expiry: '2025-09-24',
 	audience: 100 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',


### PR DESCRIPTION
## What does this change?

Extend expiry date of Admiral AB test by one week

## Why?

Allows the test to run for a bit longer to collect more data