### PR TITLE
Extend `prebid946` test

### DIFF
--- a/bundle/src/experiments/tests/prebid946.ts
+++ b/bundle/src/experiments/tests/prebid946.ts
@@ -4,7 +4,7 @@ export const prebid946: ABTest = {
 	id: 'Prebid946',
 	author: '@commercial-dev',
 	start: '2025-08-12',
-	expiry: '2025-09-12',
+	expiry: '2025-09-30',
 	audience: 5 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR extends `prebid946` for 2 more weeks and I extended a bit more than 2 weeks just in case. Related work https://github.com/guardian/frontend/pull/28223

## Why?

This test was paused and now we are rerunning it so it requires 2 weeks worth of data. 
