### PR TITLE
Extend Admiral test by one day

### DIFF
--- a/bundle/src/experiments/tests/admiral-adblocker-recovery.ts
+++ b/bundle/src/experiments/tests/admiral-adblocker-recovery.ts
@@ -4,7 +4,7 @@ export const admiralAdblockRecovery: ABTest = {
 	id: 'AdmiralAdblockRecovery',
 	author: '@commercial-dev',
 	start: '2025-08-13',
-	expiry: '2025-09-24',
+	expiry: '2025-09-25',
 	audience: 100 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',


### PR DESCRIPTION
## What does this change?

Extends Admiral AB test by one day to avoid it expiring before a decision is made on how to proceed
