### PR TITLE
Remove Sentry error for fillDynamicAdvertSlot

### DIFF
--- a/bundle/src/insert/fill-dynamic-advert-slot.ts
+++ b/bundle/src/insert/fill-dynamic-advert-slot.ts
@@ -6,7 +6,6 @@ import { enableLazyLoad } from '../display/lazy-load';
 import { loadAdvert } from '../display/load-advert';
 import { dfpEnv } from '../lib/dfp/dfp-env';
 import { queueAdvert } from '../lib/dfp/queue-advert';
-import { reportError } from '../lib/error/report-error';
 
 const displayAd = (advert: Advert, forceDisplay: boolean) => {
 	if (dfpEnv.shouldLazyLoad() && !forceDisplay) {
@@ -29,10 +28,6 @@ const fillDynamicAdSlot = (
 			if (dfpEnv.adverts.has(adSlot.id)) {
 				const errorMessage = `Attempting to add slot with exisiting id ${adSlot.id}`;
 				log('commercial', errorMessage);
-				reportError(Error(errorMessage), 'commercial', {
-					slotId: adSlot.id,
-				});
-
 				return;
 			}
 


### PR DESCRIPTION
## What does this change?

Removes the Sentry error log for `fillDynamicAdvertSlot` as we haven't resolved this issue since it was added more than 2 years ago!

We feel that this logic is doing the right thing by not attempting to insert an advert into a slot with an advert already in it. 
This perhaps isn't an error worth logging, though we may want to investigate why this is happening at some point

## Why?

Tidying up Sentry

---------

_Co-authored-by: @on-ye_
