### PR TITLE
Fix playwright reject all now that consent or pay has been rolled out in Europe

### DIFF
--- a/bundle/playwright/lib/allow-reject-all.ts
+++ b/bundle/playwright/lib/allow-reject-all.ts
@@ -1,0 +1,20 @@
+import { BrowserContext } from '@playwright/test';
+
+/**
+ * Adds a cookie to the browser context to allow the CMP reject all option to be tested in Playwright.
+ * This is necessary because normally only ad-lite or subscribers see the reject all option.
+ * @param context The Playwright browser context
+ */
+const allowRejectAll = async (context: BrowserContext) => {
+	await context.addCookies([
+		{
+			name: 'gu_allow_reject_all',
+			value: 'true',
+			domain: 'localhost',
+			path: '/',
+			httpOnly: false,
+		},
+	]);
+};
+
+export { allowRejectAll };

--- a/bundle/playwright/lib/allow-reject-all.ts
+++ b/bundle/playwright/lib/allow-reject-all.ts
@@ -9,7 +9,7 @@ const allowRejectAll = async (context: BrowserContext) => {
 	await context.addCookies([
 		{
 			name: 'gu_allow_reject_all',
-			value: 'true',
+			value: `${Date.now() + 1000 * 60 * 60}`, // 1 hour
 			domain: 'localhost',
 			path: '/',
 			httpOnly: false,

--- a/bundle/playwright/lib/load-page.ts
+++ b/bundle/playwright/lib/load-page.ts
@@ -216,7 +216,10 @@ const loadPage = async ({
 
 	const dcrUrl = getDcrUrl({
 		path,
-		queryParams,
+		queryParams: {
+			...queryParams,
+			_sp_geo_override: `${region}-XX`, // pass the region to sourcepoint, "XX" is the state which isn't used
+		},
 	});
 
 	// Override any request matching dcrUrl to use a POST method

--- a/bundle/playwright/tests/consent.spec.ts
+++ b/bundle/playwright/tests/consent.spec.ts
@@ -5,6 +5,7 @@ import type { GuPage } from '../fixtures/pages/Page';
 import { cmpAcceptAll, cmpReconsent, cmpRejectAll } from '../lib/cmp';
 import { loadPage } from '../lib/load-page';
 import { waitForSlot } from '../lib/util';
+import { allowRejectAll } from '../lib/allow-reject-all';
 
 const { path } = articles[0] as unknown as GuPage;
 
@@ -42,10 +43,13 @@ test.describe('tcfv2 consent', () => {
 		await adSlotsAreFulfilled(page);
 	});
 
-	test(`Reject all, load Opt Out, ad slots are present`, async ({ page }) => {
-		// if we pretend to be in Ireland, we can reject all and see opt out ads
-		// without needing to fake logging into an ad-lite account
-		await loadPage({ page, path, region: 'IE' });
+	test(`Reject all, load Opt Out, ad slots are present`, async ({
+		page,
+		context,
+	}) => {
+		await allowRejectAll(context);
+
+		await loadPage({ page, path });
 
 		const optOutPromise = waitForOptOut(page);
 
@@ -88,10 +92,11 @@ test.describe('tcfv2 consent', () => {
 
 	test(`Reject all, ad slots are fulfilled, then accept all, ad slots are fulfilled`, async ({
 		page,
+		context,
 	}) => {
-		// if we pretend to be in Ireland, we can reject all and see opt out ads
-		// without needing to fake logging into an ad-lite account
-		await loadPage({ page, path, region: 'IE' });
+		await allowRejectAll(context);
+
+		await loadPage({ page, path });
 
 		const optOutPromise = waitForOptOut(page);
 
@@ -155,14 +160,15 @@ test.describe('tcfv2 consent', () => {
 
 	test(`Reject all, ad slots are present, accept all, page refreshes, ad slots are fulfilled`, async ({
 		page,
+		context,
 	}) => {
-		// if we pretend to be in Ireland, we can reject all and see opt out ads
-		// without needing to fake logging into an ad-lite account
-		await loadPage({ page, path, region: 'IE' });
+		await allowRejectAll(context);
+
+		await loadPage({ page, path });
 
 		await cmpRejectAll(page);
 
-		await loadPage({ page, path, region: 'IE' });
+		await loadPage({ page, path });
 
 		await adSlotsArePresent(page);
 


### PR DESCRIPTION
## What does this change?
Use cookie to enable reject all instead of relying on region.

## Why?
Consent or pay has rolled out in Europe, so we can no longer rely on the test simulating it's in Ireland for testing reject-all.
