### PR TITLE
Bypass prebid metrics sampling for new ab test framework tests

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/prebid.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid.ts
@@ -313,6 +313,10 @@ const shouldEnableAnalytics = (): boolean => {
 		Object.keys(window.guardian.config.tests ?? {}).length > 0;
 	const isInClientSideTest = Object.keys(getParticipations()).length > 0;
 
+	/**
+	 * @todo drop old client/server side checks and use just window.guardian.modules.abTests once
+	 * all tests have been migrated to the new AB testing platform
+	 */
 	const isInNewABTest =
 		Object.keys(window.guardian.modules.abTests?.getParticipations() ?? {})
 			.length > 0;


### PR DESCRIPTION
## Why?
We do this to ensure we have prebid data for any running test

This could be improved in the future to respect the new `forceMetricsCollection`, but that needs to be available on the window first.