### PR TITLE
fix placement id for ozone

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/bid-config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bid-config.ts
@@ -266,11 +266,6 @@ const openxBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
 });
 
 const getOzonePlacementId = (sizes: HeaderBiddingSize[], slotId?: string) => {
-	if (getBreakpointKey() === 'M') {
-		if (slotId === 'dfp-ad--inline2' && containsMpu(sizes)) {
-			return '1500001025';
-		}
-	}
 	if (isInUsa()) {
 		if (getBreakpointKey() === 'D') {
 			if (containsBillboard(sizes)) {
@@ -296,6 +291,12 @@ const getOzonePlacementId = (sizes: HeaderBiddingSize[], slotId?: string) => {
 	if (isInRow()) {
 		if (containsMobileSticky(sizes)) {
 			return '1500000260';
+		}
+	}
+
+	if (getBreakpointKey() === 'M') {
+		if (slotId === 'dfp-ad--inline2' && containsMpu(sizes)) {
+			return '1500001025';
 		}
 	}
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
This is a quick fix to amend the logic for New Backup (All) | Mobile | 300x250, the `hangtime` will serve in all regions, for one slot; If slot is inline2, otherwise it will fallback to the original `1420436308` placementID


## Why?
Commercial team requested changes to Ozone ad unit mappings to support a new "hangtime" format for better mobile performance on inline2 slots specifically.