### PR TITLE
Force GAM to use use GB for location in playwright

### DIFF
--- a/bundle/playwright/lib/load-page.ts
+++ b/bundle/playwright/lib/load-page.ts
@@ -181,7 +181,7 @@ const loadPage = async ({
 
 			window.googletag.cmd.push(() => {
 				// @ts-expect-error this is valid, @types/googletag not updated, see https://developers.google.com/publisher-tag/reference#typescript_65
-				googletag.setConfig({ location: 'GB' });
+				googletag.setConfig({ location: args.region });
 			});
 		},
 		{


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Force googletag/GAM to run as if it's in the GB region.

## Why?
Playwright in CI runs in the US (as that's where the github action runners are), there's occasionally ad formats that break our tests, this is less common in the UK so this may help.

