### PR TITLE
Extend the Admiral AB test by one month

### DIFF
--- a/bundle/src/experiments/tests/admiral-adblocker-recovery.ts
+++ b/bundle/src/experiments/tests/admiral-adblocker-recovery.ts
@@ -4,7 +4,7 @@ export const admiralAdblockRecovery: ABTest = {
 	id: 'AdmiralAdblockRecovery',
 	author: '@commercial-dev',
 	start: '2025-08-13',
-	expiry: '2025-10-23',
+	expiry: '2025-11-26',
 	audience: 100 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',


### PR DESCRIPTION
## What does this change?

Extends the Admiral Adblock recovery AB test by another month

## Why?

To enable a smoother handover between teams
