### PR TITLE
adds new placementId for crossword pages with mobilesticky

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/bid-config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bid-config.ts
@@ -265,9 +265,8 @@ const openxBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
 	},
 });
 
-const isCrosswordPage = (slotId?: string, pageTargeting: PageTargeting = {}) =>
-	(slotId?.includes('crossword') ?? pageTargeting.ct === 'crossword') ||
-	pageTargeting.s === 'crossword';
+const isCrosswordPage = (pageTargeting: PageTargeting = {}) =>
+	pageTargeting.s === 'crosswords';
 
 const getOzonePlacementId = (
 	sizes: HeaderBiddingSize[],
@@ -285,15 +284,13 @@ const getOzonePlacementId = (
 			}
 		}
 		if (getBreakpointKey() === 'M') {
-			if (
-				isCrosswordPage(slotId, pageTargeting) &&
-				containsMobileSticky(sizes)
-			) {
-				return '1500001036';
-			}
 			if (containsMobileSticky(sizes)) {
+				if (isCrosswordPage(pageTargeting)) {
+					return '1500001035';
+				}
 				return '3500014217';
 			}
+
 			if (containsMpu(sizes)) {
 				return '1500001036';
 			}


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
This PR adds an addition Placement ID for a Crossword page in the US, with the mobile breakpoint with size 320, 50 (containsMobileSticky)
This should successfully return an id of: `1500001035`


A new function to detect if we are indeed in a crossword page:
- checks for content and section in `pageTargeting`
- checks for presence of crossword in slotId


## Why?
This is an extension to the work done in PR: https://github.com/guardian/commercial/pull/2252 


### Professor Prebid:

| Slot                                           | Placement ID   |
|--------------------------------------------------------|---------------|
| <img width="580" height="122" alt="Screenshot 2025-10-29 at 12 28 19" src="https://github.com/user-attachments/assets/1dcfbeb8-6cd2-4dbd-80cd-48a02910af5a" /> | <img width="432" height="602" alt="Screenshot 2025-10-30 at 19 53 30" src="https://github.com/user-attachments/assets/4bceb05a-c926-4cd1-bbdc-7146a9c121b3" />|


