### PR TITLE
Remove upload and download of `core` build files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 on:
   push:
     branches:
-      - "main"
+      - main
   pull_request:
     branches-ignore:
-      - "gh-pages"
+      - gh-pages
 
 permissions: write-all
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,14 +59,14 @@ jobs:
         uses: changesets/action@v1.5.3
         with:
           publish: pnpm changeset publish
-          title: "🦋 Release package updates"
-          commit: "Bump package versions"
+          title: 🦋 Release package updates
+          commit: Bump package versions
           setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   publish-beta:
-    name: "@guardian/commercial-core"
+    name: '@guardian/commercial-core'
     runs-on: ubuntu-latest
     # Only run the `publish-beta` job if the correct label has been added to the PR
     if: github.event.label.name == '[beta] @guardian/commercial-core'


### PR DESCRIPTION
## What does this change?

As a follow up from https://github.com/guardian/commercial/pull/2283, this removes parts of the Github workflow which upload and download the core build files.

## Why?

We don't seem to actually use these files anywhere and the upload/download is currently [failing](https://github.com/guardian/commercial/actions/runs/18970034959/job/54175401090) between the `CI` and `Publish NPM package` workflows
