### PR TITLE
Add Magnite (rubicon) to acBidders

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/prebid.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid.spec.ts
@@ -169,6 +169,7 @@ describe('initialise', () => {
 								'ozone',
 								'pubmatic',
 								'trustx',
+								'rubicon',
 							],
 							overwrites: {
 								pubmatic,

--- a/bundle/src/lib/header-bidding/prebid/prebid.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid.ts
@@ -463,7 +463,14 @@ const initialise = (window: Window, consentState: ConsentState): void => {
 
 	if (shouldIncludePermutive(consentState)) {
 		const includedAcBidders = (
-			['and', 'ix', 'ozone', 'pubmatic', 'trustx'] satisfies BidderCode[]
+			[
+				'and',
+				'ix',
+				'ozone',
+				'pubmatic',
+				'trustx',
+				'rubicon',
+			] satisfies BidderCode[]
 		)
 			.filter(shouldInclude)
 			// "and" is the alias for the custom Guardian "appnexus" direct bidder


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR adds Magnite, formely known as "rubicon", to the `acBidders` list. 

Tested locally and now we have data with permutive that we don't have in PROD before the change. Check [ticket](https://trello.com/c/QGX2QRE3/3693-add-magnite-rubicon-to-acbidders) for similar screenshot for pubmatic which is part of the acBidders in PROD.

<img width="760" height="450" alt="image" src="https://github.com/user-attachments/assets/53ead420-9a50-41c9-b1a3-b6e6728c0b32" />


## Why?

Drive programmatic revenue. 