### PR TITLE
Extend the Admiral AB test expiry to Jan 2026

### DIFF
--- a/bundle/src/experiments/tests/admiral-adblocker-recovery.ts
+++ b/bundle/src/experiments/tests/admiral-adblocker-recovery.ts
@@ -4,7 +4,7 @@ export const admiralAdblockRecovery: ABTest = {
 	id: 'AdmiralAdblockRecovery',
 	author: '@commercial-dev',
 	start: '2025-08-13',
-	expiry: '2025-11-26',
+	expiry: '2026-01-21',
 	audience: 100 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',


### PR DESCRIPTION
## What does this change?

Extends the life of the Admiral Adblock Recovery AB test

## Why?

We are transferring ownership outside of CommDev and need more time to do this before the test expires