### PR TITLE
chore: silence error reporting for slot not returned

### DIFF
--- a/bundle/src/define/define-slot.ts
+++ b/bundle/src/define/define-slot.ts
@@ -192,7 +192,7 @@ const defineSlot = (
 		throw new DefineSlotError(
 			`googletag.defineSlot did not return a slot`,
 			sizeMapping,
-			false
+			false,
 		);
 	}
 


### PR DESCRIPTION
## What does this change?
This PR stops reporting errors to sentry when a slot is not returned by Google Tag

## Why?
We currently throw an error when Google Tag is unable to find an ad for any given ad slot. The reasons for this failure could be numerous and potentially based on the supply side, however Google does not return the reasons why a slot cannot be returned in its `defineSlot` method (it only returns null). We'll log the error in our datalake for further investigation but not in sentry.

**Notes**
- Google Publisher Console can be used for debugging: https://developers.google.com/publisher-tag/guides/publisher-console
- Some reasons for ads not being displayed are outlined here: https://wpadvancedads.com/manual/google-ad-manager-integration-manual/#Issues_related_to_Google_Ad_Manager
- Define Slot API: https://developers.google.com/publisher-tag/reference#googletag.defineSlot
- Attempt to narrow down defineSlot functionality in minified code
<img width="1050" height="959" alt="Screenshot 2025-11-17 at 16 33 48" src="https://github.com/user-attachments/assets/5023df98-83f3-427d-9e1f-650c97e0a256" />