### PR TITLE
Add useSafeFrames to a9 config

### DIFF
--- a/bundle/src/lib/header-bidding/a9/a9.ts
+++ b/bundle/src/lib/header-bidding/a9/a9.ts
@@ -1,5 +1,6 @@
 import { flatten } from 'lodash-es';
 import type { Advert } from '../../../define/Advert';
+import { isUserInTestGroup } from '../../../experiments/beta-ab';
 import type {
 	A9AdUnitInterface,
 	FetchBidResponse,
@@ -42,6 +43,10 @@ const initialise = (): void => {
 			pubID: window.guardian.config.page.a9PublisherId,
 			adServer: 'googletag',
 			bidTimeout: bidderTimeout,
+			useSafeFrames: isUserInTestGroup(
+				'commercial-a9-safe-frames',
+				'variant',
+			),
 			blockedBidders,
 		});
 	}

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -384,6 +384,7 @@ type ApstagInitConfig = {
 	adServer?: string;
 	bidTimeout?: number;
 	blockedBidders?: string[];
+	useSafeFrames?: boolean;
 };
 
 // https://ams.amazon.com/webpublisher/uam/docs/web-integration-documentation/integration-guide/javascript-guide/api-reference.html#apstaginit


### PR DESCRIPTION
## What does this change?
Add the `useSafeFrames` option to A9 init config, behind a 0% test.

## Why?
We need to fix a issue with mobile-sticky, but we don't want to affect other slots, this will let us share an opt in link with amazon so they can check for us.