### PR TITLE
Rollout a9 safeframe option

### DIFF
--- a/bundle/src/lib/header-bidding/a9/a9.ts
+++ b/bundle/src/lib/header-bidding/a9/a9.ts
@@ -1,6 +1,5 @@
 import { flatten } from 'lodash-es';
 import type { Advert } from '../../../define/Advert';
-import { isUserInTestGroup } from '../../../experiments/beta-ab';
 import type {
 	A9AdUnitInterface,
 	FetchBidResponse,
@@ -43,10 +42,7 @@ const initialise = (): void => {
 			pubID: window.guardian.config.page.a9PublisherId,
 			adServer: 'googletag',
 			bidTimeout: bidderTimeout,
-			useSafeFrames: isUserInTestGroup(
-				'commercial-a9-safe-frames',
-				'variant',
-			),
+			useSafeFrames: true, // Enable safeframe support for A9 ads, this doesn't mean all ads will be in safeframes
 			blockedBidders,
 		});
 	}


### PR DESCRIPTION
## What does this change?
Set `enableSafeFrames` to `true`

## Why?
We need safeframe support for `mobile-sticky`, this option doesn't force safeframes, just allows them to be used.

Very briefly tested and shared with amazon for testing in #2311 