### PR TITLE
Allow merchandising slots to use the 'full-width' message

### DIFF
--- a/bundle/src/lib/messenger/full-width.ts
+++ b/bundle/src/lib/messenger/full-width.ts
@@ -23,7 +23,11 @@ const init = (register: RegisterListener): void => {
 
 			// only allow for banner ads
 			const name = adSlot?.dataset.name;
-			if (!name?.startsWith('fronts-banner') || !adSlot) {
+			if (
+				(!name?.startsWith('fronts-banner') &&
+					!name?.startsWith('merchandising')) ||
+				!adSlot
+			) {
 				return;
 			}
 


### PR DESCRIPTION
## Why?
At the moment only fronts-banners can use this message.
DAP would like all slots on a front to be able to be full-width as they've sold a campaign with that specified.