### PR TITLE
fix: optionally chain googletag functions

### DIFF
--- a/bundle/src/define/define-slot.ts
+++ b/bundle/src/define/define-slot.ts
@@ -121,7 +121,11 @@ const isEligibleForOutstream = (slotTarget: string) =>
 	(slotTarget === 'inline1' || slotTarget === 'top-above-nav');
 
 const allowSafeFrameToExpand = (slot: googletag.Slot) => {
-	slot.setConfig({
+	/*
+		eslint-disable-next-line @typescript-eslint/no-unnecessary-condition --
+		the slot.setConfig function may not exist if googletag has been shimmed by an adblocker
+	*/
+	slot.setConfig?.({
 		safeFrame: {
 			allowOverlayExpansion: false,
 			allowPushExpansion: true,
@@ -246,7 +250,11 @@ const defineSlot = (
 		});
 	});
 
-	slot.addService(window.googletag.pubads()).setConfig({
+	/*
+		eslint-disable-next-line @typescript-eslint/no-unnecessary-condition --
+		the slot.setConfig function may not exist if googletag has been shimmed by an adblocker
+	*/
+	slot.addService(window.googletag.pubads()).setConfig?.({
 		targeting: {
 			slot: slotTarget,
 			testgroup: String(Math.floor(100 * Math.random())),

--- a/core/src/targeting/teads-eligibility.ts
+++ b/core/src/targeting/teads-eligibility.ts
@@ -4,7 +4,9 @@ const isEligibleForTeads = (slotId: string) => {
 	const { contentType, isSensitive } = window.guardian.config.page;
 
 	// This IAS value is returned when a page is thought to contain content which is not brand safe
-	const iasKw = window.googletag.getConfig('targeting').targeting?.['ias-kw'];
+	const iasKw =
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- the googletag.getConfig function may not exist if googletag has been shimmed by an adblocker
+		window.googletag.getConfig?.('targeting').targeting?.['ias-kw'];
 	const iasKwArray = Array.isArray(iasKw) ? iasKw : iasKw ? [iasKw] : [];
 	const isBrandSafe = !iasKwArray.includes('IAS_16425_KW');
 


### PR DESCRIPTION
## What does this change?

Optionally chain `googletag.setConfig` / `googletag.getConfig` and the slot definitions

## Why?

We've noticed a number of FE errors being reported when working with googletag. The `googletag.getConfig` and `googletag.setConfig` functions may not exist if googletag has been shimmed by an adblocker, so to avoid causing page errors we'll optionally chain these instances.

## Notes
- This is a minimally invasive PR. More extensive attempt had been made to optionally chain _all_ instances of `googletag.[method]`, which was not clean, so we'll start with what is explicitly being reported in the error logs
- There is some difficulty in understanding the downstream effects of not failing these features explicitly, such as how ad metrics are impacted by silent failures considering ad slot functionality continues running. These metrics will need to be observed for some time after these changes are merged.
- There is a possibility to wrap all `googletag` features into a `withGoogleTag((googletag) => ...)` type callback to ensure we don't execute these functions until it exists, however this poses its own challenges that I won't go into detail here