### PR TITLE
fix: report ad overflows on inline2+

### DIFF
--- a/bundle/src/events/on-slot-render.ts
+++ b/bundle/src/events/on-slot-render.ts
@@ -82,7 +82,9 @@ export const onSlotRender = (
 				const parentHeight = parentElement.offsetHeight;
 				const parentWidth = parentElement.offsetWidth;
 
-				const isInline = advert.node.id.includes('dfp-ad--inline');
+				const isInlineTwoPlus =
+					advert.node.id.includes('dfp-ad--inline') &&
+					advert.node.id !== 'dfp-ad--inline1';
 
 				if (
 					adElementWidth > parentWidth ||
@@ -90,7 +92,7 @@ export const onSlotRender = (
 					// Note: this is an experiment to determine which element is
 					// causing issues with the right ad slot (as well as other ads).
 					// We can remove this check once we have enough data.
-					(isInline && adElementWidth > 300)
+					(isInlineTwoPlus && adElementWidth > 300)
 				) {
 					reportError(
 						new Error('Ad is overflowing its container'),


### PR DESCRIPTION
## What does this change?

Excludes reporting ad overflow errors on inline1 container.

## Why?

Follows on from #2314 