### PR TITLE
Group major `@guardian/*` dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
         patterns:
           - '@guardian/*'
         update-types:
+          - 'major'
           - 'minor'
           - 'patch'
       prebid:


### PR DESCRIPTION
## What does this change?
Include major updates in the `guardian/*` group

## Why?
These packages mostly live together in guardian/csnx, often have peerDependencies on each other and are released together so having them in their own PR's is not useful.

I think grouping them will be helpful and reduce the number of dependabot PRs we have.