### PR TITLE
Fix issue with the docker image pull for Playwright in E2E workflow

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -49,7 +49,7 @@ jobs:
             -p 3030:3030 \
             -e "PORT=3030" \
             -e "COMMERCIAL_BUNDLE_URL=http://localhost:3031/graun.standalone.commercial.js" \
-            ghcr.io/guardian/dotcom-rendering:fake-tag
+            ghcr.io/guardian/dotcom-rendering:main
 
       - name: Report if "start DCR in a container" step failed
         if: ${{ steps.start-dcr-container.outcome == 'failure' }}


### PR DESCRIPTION
## What does this change?

Picks up the error fetching the DCR container image earlier and reports back with helpful error message

### Before
<img width="1148" height="628" alt="Screenshot 2025-12-08 at 12 47 42" src="https://github.com/user-attachments/assets/93b5555a-bbcc-4dd3-b85b-927f3d51666d" /> | 

### After
<img width="1148" height="736" alt="Screenshot 2025-12-08 at 12 46 16" src="https://github.com/user-attachments/assets/1a0ccd5b-6616-4e00-b489-0527798aba8a" /> |

## Why?

This was implemented previously but doesn't seem to be working as intended

I think this is because the `outputs` weren't defined for the previous step which errored

We now use the `steps.<step-id>.outcomes` value to determine whether the previous step was successful or not. See https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#steps-context
