### PR TITLE
fix: enabling UID2 to generate a user ID

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/pbjs.ts
+++ b/bundle/src/lib/header-bidding/prebid/pbjs.ts
@@ -18,6 +18,7 @@ import 'prebid.js/modules/ttdBidAdapter';
 
 // User IDs
 import 'prebid.js/modules/id5IdSystem';
+import 'prebid.js/modules/uid2IdSystem';
 import 'prebid.js/modules/sharedIdSystem';
 import 'prebid.js/modules/userId';
 

--- a/bundle/src/lib/header-bidding/prebid/prebid.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid.ts
@@ -417,7 +417,7 @@ const initialise = async (
 		const email = await getEmail();
 		if (
 			email &&
-			isUserInTestGroup('commercial-user-module-uid2', 'variant')
+			!isUserInTestGroup('commercial-user-module-uid2', 'variant')
 		) {
 			const hashedUid2Email = await hashEmailForClient(email, 'uid2');
 
@@ -427,7 +427,7 @@ const initialise = async (
 					serverPublicKey:
 						'UID2-X-P-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7MS+2jntlSNTDP65WBYaCLR/Wla8r3h9NkYtN73lNtbo7WT5LFIKSGnD0kERa8VG8bNJvZrQs2bCU0P8ZH4uaA==',
 					subscriptionId: 'HhGv3vmQcS',
-					email: hashedUid2Email,
+					emailHash: hashedUid2Email,
 				},
 			});
 		}


### PR DESCRIPTION
## What does this change?
Imports the UID2 user ID module in pbjs.ts to enable UID2 token generation for US users with consent, and corrects the parameter name from email to emailHash to properly pass the pre-hashed email value.

Removes the `storage` configuration from the UID2 UserId module in Prebid.js.

## Why?
We're experiencing an issue where `pbjs.getUserIds().uid2` returns `undefined` in the browser console, despite Prebid Professor showing the correct UID2 parameters are being passed to the module.

We need to test this in the production environment to ensure Prebid can correctly recognise the Guardian's domain and respond with an appropriate UID2 token. 

According to [Trade Desk documentation](https://docs.prebid.org/dev-docs/modules/userid-submodules/uid2.html#uid2-configuration):
> "To check that the UID2 module has successfully generated a UID2 token, call `pbjs.getUserIds().uid2`. If a value is returned, a valid UID2 token exists in the UID2 module."

**Hypothesis:** The `storage` configuration may be interfering with token generation or retrieval and import UID2 toke to pbjs.

**Testing approach:**
1. Remove `storage` property to test if it's causing the issue
2. Monitor `pbjs.getUserIds().uid2` to confirm token generation
3. Check loaded modules `pbjs.installedModules`

## Testing
- [ ] Verify `pbjs.getUserIds().uid2` returns a valid token (not `undefined`)
- [ ] Confirm Prebid Professor still shows correct UID2 parameters
- [ ] Validate token is being passed to bid requests
- [ ] Check browser console for any new errors/warnings

<img width="692" height="344" alt="Screenshot 2025-12-10 at 10 14 14" src="https://github.com/user-attachments/assets/2246b987-b342-4416-812d-ad0eb63549e5" />

<img width="731" height="138" alt="Screenshot 2025-12-10 at 10 14 58" src="https://github.com/user-attachments/assets/d436480e-005e-4fc5-bd63-0ab1ea5c267e" />
