### PR TITLE
Fix fabric/fluid centring issues

### DIFF
--- a/bundle/src/events/render-advert.ts
+++ b/bundle/src/events/render-advert.ts
@@ -152,31 +152,34 @@ const addContentClass = (adSlotNode: HTMLElement) => {
 };
 
 /* Centre certain slots in their containers, this class is added dynamically to avoid rendering quirks with the ad label and variable width ads. */
-const addContainerClass = (adSlotNode: HTMLElement, isRendered: boolean) => {
+const addContainerClass = async (
+	adSlotNode: HTMLElement,
+	isRendered: boolean,
+) => {
 	const centreAdSlots = [
 		'dfp-ad--top-above-nav',
 		'dfp-ad--merchandising-high',
 		'dfp-ad--merchandising',
 	];
-	return fastdom
-		.measure(
-			() =>
-				isRendered &&
-				!adSlotNode.classList.contains('ad-slot--fluid') &&
-				adSlotNode.parentElement?.classList.contains(
-					'ad-slot-container',
-				) &&
-				centreAdSlots.includes(adSlotNode.id),
-		)
-		.then((shouldCentre) => {
-			if (shouldCentre) {
-				return fastdom.mutate(() => {
-					adSlotNode.parentElement?.classList.add(
-						'ad-slot-container--centre-slot',
-					);
-				});
-			}
-		});
+	const shouldCentre = await fastdom.measure(
+		() =>
+			isRendered &&
+			!adSlotNode.classList.contains('ad-slot--fluid') &&
+			adSlotNode.parentElement?.classList.contains('ad-slot-container') &&
+			centreAdSlots.includes(adSlotNode.id),
+	);
+
+	return fastdom.mutate(() => {
+		if (shouldCentre) {
+			adSlotNode.parentElement?.classList.add(
+				'ad-slot-container--centre-slot',
+			);
+		} else {
+			adSlotNode.parentElement?.classList.remove(
+				'ad-slot-container--centre-slot',
+			);
+		}
+	});
 };
 
 /**


### PR DESCRIPTION
## What does this change?
Remove the `ad-slot-container--centre-slot` if it's no longer needed, converted the function to an async function.

## Why?
If this class remains after an ad has refreshed, and a fluid ad comes in it will render weirdly:
<img width="1915" height="937" alt="image" src="https://github.com/user-attachments/assets/62c6fb10-dd03-43e7-961a-3e6cdba79b78" />

I created `fabric_on_refresh` ad test and monitored the merchandising slot to reproduce and ensure the bug went away.

