### PR TITLE
feat: load prebid 9 in place of 10

### DIFF
--- a/bundle/src/init/consented/prepare-prebid.ts
+++ b/bundle/src/init/consented/prepare-prebid.ts
@@ -29,10 +29,16 @@ const loadPrebid = async (consentState: ConsentState): Promise<void> => {
 	);
 
 	if (isPrebidV10Enabled) {
+		// temporarily load prebid v9 to see if bidding works
+		// as expected or if the test setup is wrong
 		await import(
-			/* webpackChunkName: "Prebid@10.11.0.js" */
-			'../../lib/header-bidding/prebid/pbjs-v10.11.0'
+			/* webpackChunkName: "Prebid.js" */
+			'../../lib/header-bidding/prebid/pbjs'
 		);
+		// await import(
+		// 	/* webpackChunkName: "Prebid@10.11.0.js" */
+		// 	'../../lib/header-bidding/prebid/pbjs-v10.11.0'
+		// );
 	} else {
 		await import(
 			/* webpackChunkName: "Prebid.js" */


### PR DESCRIPTION
## What does this change?

Using prebid v9 configuration over prebid v10

## Why?

Testing why the `bidWon` event is significantly higher in v9 than in v10, by eliminating difference in the test setup as a factor