### PR TITLE
Spacefinder: prevent ads appearing directly after interactive block elements

### DIFF
--- a/bundle/src/insert/spacefinder/rules.ts
+++ b/bundle/src/insert/spacefinder/rules.ts
@@ -60,6 +60,8 @@ const inlineOpponentSelector = ['inline', 'supporting', 'showcase', 'halfWidth']
 
 const headingSelector = `:scope > h2, [data-spacefinder-role="nested"] > h2, :scope > h3, [data-spacefinder-role="nested"] > h3`;
 
+const interactiveElementSelector = `.element-interactive[data-spacefinder-role="inline"]`;
+
 const desktopInline1: SpacefinderRules = {
 	bodySelector,
 	candidateSelector,
@@ -90,6 +92,11 @@ const desktopInline1: SpacefinderRules = {
 		['[data-spacefinder-role="supporting"]']: {
 			marginBottom: 0,
 			marginTop: 100,
+		},
+		// Ensure sufficient space is left after inline interactive elements
+		[interactiveElementSelector]: {
+			marginBottom: 50,
+			marginTop: 0,
 		},
 	},
 };


### PR DESCRIPTION
## What does this change?

Add new rule for inline interactive elements to prevent ad insertion directly after interactive block elements (50px margin bottom)

## Why?

There was a bug reported where an advert was being inserted directly after an interactive block element, disrupting the flow for a given article.


## Screenshots

| Before | After |
| ----- | ----- |
| ![before][] | ![after][] |

[before]:https://github.com/user-attachments/assets/2d0f98cd-8bc1-4bde-9b0c-eeae7eb8699e
[after]:https://github.com/user-attachments/assets/9fdbaf1d-9e3e-4abe-9578-7bd7223fa4fa
