### PR TITLE
Allow background height to occupy 100vh for fixed scrollType

### DIFF
--- a/bundle/src/lib/messenger/background.ts
+++ b/bundle/src/lib/messenger/background.ts
@@ -88,7 +88,7 @@ const createParent = (
 		background.style.inset = '0';
 		background.style.transition = 'background 100ms ease';
 
-		if (scrollType === 'interscroller') {
+		if (scrollType === 'interscroller' || scrollType === 'fixed') {
 			background.style.height = '100vh';
 		}
 	}


### PR DESCRIPTION
## What does this change?

Sets the background height as `100vh` for "fixed" scrollType in the message handler for `background`

## Why?

To prevent the background changing height when scrolling on native templates like the _mobile revealer_ which use a "fixed" scrollType

Raised by @Onelittlewolfe in https://github.com/guardian/commercial-templates/pull/542#issuecomment-3724512582

## Screenshots

### Before
https://github.com/user-attachments/assets/440871a3-dc2b-4eb6-ac2c-fc19044e276e

### After
https://github.com/user-attachments/assets/ba59fadb-2523-4dca-abd8-f699dc672735
