### PR TITLE
Add test coverage and fail tests when coverage drops below threshold

### DIFF
--- a/bundle/README.md
+++ b/bundle/README.md
@@ -24,6 +24,8 @@ To run the unit tests:
 
 `pnpm test`
 
+This might fail if the base test coverage hasn't been met. This is set in [jest.config.js](./jest.config.js). Ensure you add sufficient tests to meet the threshold if you can. If this is not possible for whatever reason, you can decrease the set thresholds but this should be considered a last resort
+
 To run the Playwright e2e tests:
 
 Follow the steps above to run DCR against the local bundle.

--- a/bundle/jest.config.js
+++ b/bundle/jest.config.js
@@ -1,3 +1,40 @@
-import jestConfig from '../jest.config.js';
+import repoJestConfig from '../jest.config.js';
+
+const jestConfig = {
+	...repoJestConfig,
+	/**
+	 * We want to continuously increase these thresholds as we add more test coverage
+	 * If you need to lower the thresholds you can, but this should be a last resort
+	 */
+	coverageThreshold: {
+		global: {
+			branches: 45,
+			functions: 41,
+			lines: 61,
+			statements: 61,
+		},
+		/**
+		 * Higher testing threshold for the src/lib directory
+		 * It's easy to dump files in lib without thinking about it
+		 * By having a higher threshold we ensure that testing is considered more
+		 */
+		'./src/lib': {
+			branches: 61,
+			functions: 66,
+			lines: 74,
+			statements: 75,
+		},
+		/**
+		 * Higher testing threshold for the src/init/consented directory
+		 * These files are particularly important for commercial logic
+		 */
+		'./src/init/consented': {
+			branches: 68,
+			functions: 76,
+			lines: 84,
+			statements: 84,
+		},
+	},
+};
 
 export default jestConfig;

--- a/bundle/package.json
+++ b/bundle/package.json
@@ -29,6 +29,7 @@
 		"prettier:fix": "prettier . --write --cache",
 		"serve": "OVERRIDE_BUNDLE=true pnpm webpack-dev-server -c ./webpack.config.dev.mjs",
 		"test": "jest",
+		"test-cov": "jest --coverage",
 		"tsc": "tsc --noEmit",
 		"validate": "npm-run-all tsc lint test build"
 	},

--- a/core/README.md
+++ b/core/README.md
@@ -22,6 +22,15 @@ pnpm build
 
 This will build the package into the `dist` directory, which is what is published to npm.
 
+### Testing
+
+To run the unit tests:
+
+`pnpm test`
+
+This might fail if the base test coverage hasn't been met. This is set in jest.config.js. Ensure you add sufficient tests to meet the threshold if you can. If this is not possible for whatever reason, you can decrease the set thresholds but this should be considered a last resort
+
+
 #### Beta Releases
 You can add the [beta] @guardian/commercial-core label to your pull request, this will release a beta version of the bundle to NPM, the exact version will be commented on your PR.
 

--- a/core/jest.config.js
+++ b/core/jest.config.js
@@ -1,3 +1,19 @@
-import jestConfig from '../jest.config.js';
+import repoJestConfig from '../jest.config.js';
+
+const jestConfig = {
+	...repoJestConfig,
+	/**
+	 * We want to continuously increase these thresholds as we add more test coverage
+	 * If you need to lower the thresholds you can, but this should be a last resort
+	 */
+	coverageThreshold: {
+		global: {
+			branches: 96,
+			functions: 97,
+			lines: 98,
+			statements: 98,
+		},
+	},
+};
 
 export default jestConfig;

--- a/core/package.json
+++ b/core/package.json
@@ -40,6 +40,7 @@
 		"prettier:check": "prettier . --check --cache",
 		"prettier:fix": "prettier . --write --cache",
 		"test": "jest",
+		"test-cov": "jest --coverage",
 		"tsc": "tsc --noEmit"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"prettier:fix": "prettier . --write --cache",
 		"serve": "pnpm --filter @guardian/commercial-bundle serve",
 		"test": "pnpm -r --parallel --aggregate-output test",
-		"test:ci": "pnpm -r --parallel --aggregate-output test -- --ci",
+		"test:ci": "pnpm -r --parallel --aggregate-output test -- --ci --coverage",
 		"tsc": "pnpm -r --parallel --aggregate-output tsc"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## What does this change?

- Adds test coverage using the [`--coverage`](https://jestjs.io/docs/cli#--coverageboolean) option via the Jest CLI
  - Commands in `bundle` and `core` are `test-cov`
  - `test:ci` at the top level (repo root) now automatically includes coverage reporting
- Sets [coverage thresholds](https://jestjs.io/docs/configuration#coveragethreshold-object) in the Jest config objects in both `bundle` and `core` based on the current level of test coverage available
  - This will cause test runs to fail if the coverage falls below the set thresholds
  - Documentation has been added in the README files in `core` and `bundle` to explain what to do if the coverage does not meet the thresholds set and how to check this

## Why?

We want to ensure our code is tested more thoroughly in commercial to:
1) ensure things work the way we think they do. This will be particularly helpful when it comes to understanding how things work now in case we do any refactoring in the future.
2) document how things work to make it easier for other developers to understand what various parts of the codebase are designed to do and how they are intended to work