### PR TITLE
Extend expiry date for AdmiralAdblockRecovery test

### DIFF
--- a/bundle/src/experiments/tests/admiral-adblocker-recovery.ts
+++ b/bundle/src/experiments/tests/admiral-adblocker-recovery.ts
@@ -4,7 +4,7 @@ export const admiralAdblockRecovery: ABTest = {
 	id: 'AdmiralAdblockRecovery',
 	author: '@commercial-dev',
 	start: '2025-08-13',
-	expiry: '2026-01-21',
+	expiry: '2027-01-21',
 	audience: 100 / 100,
 	audienceOffset: 0 / 100,
 	audienceCriteria: '',


### PR DESCRIPTION
## What does this change?

Extends the expiry of the Admiral AB test to 2027 to match the frontend switch

See https://github.com/guardian/frontend/pull/28516

## Why?

It expired early
