### PR TITLE
refactor `articleBodyAdverts` flag

### DIFF
--- a/bundle/src/lib/commercial-features.ts
+++ b/bundle/src/lib/commercial-features.ts
@@ -77,14 +77,15 @@ class CommercialFeatures {
 		const isArticle = window.guardian.config.page.contentType === 'Article';
 		const isInteractive =
 			window.guardian.config.page.contentType === 'Interactive';
-		const isLiveBlog = window.guardian.config.page.isLiveBlog;
+		const isLiveBlog = window.guardian.config.page.isLiveBlog ?? false;
 		const isHosted = window.guardian.config.page.isHosted;
 		const isIdentityPage =
 			window.guardian.config.page.contentType === 'Identity' ||
 			window.guardian.config.page.section === 'identity'; // needed for pages under profile.* subdomain
 		const switches = window.guardian.config.switches;
 		const isWidePage = getCurrentBreakpoint() === 'wide';
-		const newRecipeDesign = window.guardian.config.page.showNewRecipeDesign;
+		const newRecipeDesign =
+			window.guardian.config.page.showNewRecipeDesign ?? false;
 
 		const isUnsupportedBrowser: boolean = isInternetExplorer();
 
@@ -136,28 +137,27 @@ class CommercialFeatures {
 			);
 		}
 
-		const articleBodyAdvertsTrueConditions = {
-			isArticle,
-		};
+		const enableArticleBodyAdverts = isArticle;
 
-		const articleBodyAdvertsFalseConditions = {
-			isMinuteArticle,
-			isLiveBlog: !!isLiveBlog,
-			isHosted,
-			newRecipeDesign: !!newRecipeDesign,
-		};
+		const disableArticleBodyAdverts =
+			isMinuteArticle || isLiveBlog || isHosted || newRecipeDesign;
 
 		this.articleBodyAdverts =
 			this.shouldLoadGoogletag &&
 			!this.adFree &&
-			Object.values(articleBodyAdvertsTrueConditions).every(Boolean) &&
-			!Object.values(articleBodyAdvertsFalseConditions).some(Boolean);
+			enableArticleBodyAdverts &&
+			!disableArticleBodyAdverts;
 
 		if (isArticle && !this.articleBodyAdverts) {
 			// Log why article adverts are disabled
 			adsDisabledLogger(
-				articleBodyAdvertsTrueConditions,
-				articleBodyAdvertsFalseConditions,
+				{ isArticle },
+				{
+					isMinuteArticle,
+					isLiveBlog,
+					isHosted,
+					newRecipeDesign,
+				},
 			);
 		}
 


### PR DESCRIPTION
## What does this change?
Refactor `articleBodyAdverts` flag

## Why?
I was trying to add my test for [running spacefinder on interactives on mobile](https://github.com/guardian/dotcom-rendering/pull/15215) in here and it was rather confusing.

I think this clarifies it and make it easier to add my test :)