### PR TITLE
add halfPage (300×600) to mobile inline1 with AB gate

### DIFF
--- a/bundle/src/insert/spacefinder/article.ts
+++ b/bundle/src/insert/spacefinder/article.ts
@@ -1,5 +1,6 @@
 import type { AdSize, SizeMapping } from '@guardian/commercial-core/ad-sizes';
 import { adSizes } from '@guardian/commercial-core/ad-sizes';
+import { isUserInTestGroup } from '../../experiments/beta-ab';
 import { commercialFeatures } from '../../lib/commercial-features';
 import type { ContainerOptions } from '../../lib/create-ad-slot';
 import {
@@ -192,9 +193,9 @@ const addDesktopRightRailAds = (
 
 const additionalMobileAndTabletInlineSizes = (index: number) => {
 	if (index === 1) {
-		return {
-			mobile: [adSizes.portraitInterstitial],
-		};
+		return isUserInTestGroup('mobile-inline1-halfpage', 'variant')
+			? { mobile: [adSizes.portraitInterstitial, adSizes.halfPage] }
+			: { mobile: [adSizes.portraitInterstitial] };
 	} else if (index === 2) {
 		return {
 			mobile: [


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Adds 300×600 (halfPage) ad size to mobile inline1 slot as part of the `MobileInline1Halfpage` A/B test to improve mobile web monetisation.

There are 2 independent size systems:

- defineSlot (spacefinder) → controls what GAM can serve
- getSlots (slot-config) → controls what Prebid competitors bid on
For this test, only GAM needs the new size. Both systems normally need updating, but skipping Prebid for now per requirements.

## Why?
As part of the ongoing improvement to monetisation on Mobile Web, we are adding an addition size of 300x600 (halfPage).

Currently, mobile inline1 only accepts 300×250 (mpu) and 300×1050 (portraitInterstitial). Adding the 300×600 halfPage size gives AdX more flexibility to serve higher-value ads, potentially increasing RPM.


- A/B test configuration: `MobileInline1Halfpage`
  - Audience: 20% (10% control, 10% variant)
  - Start: 2026-01-29
  - Expiry: 2026-02-28

**AdX only** - No Prebid integration (as per ticket requirements). The new size is only added to the GPT/AdX path via `defineSlot()`, not the header bidding configuration.

**Mobile/Tablet only** - Change only affects `addMobileAndTabletInlineAds()` flow. Desktop inline1 unchanged.

## Testing


Tested locally on mobile viewport (width < 740px):
```js
// Verify variant includes 300×600
googletag.pubads().getSlots()
  .find(s => s.getSlotElementId().includes('inline1'))
  ?.getSizes()
  .map(s => s === 'fluid' ? 'fluid' : `${s.getWidth()}×${s.getHeight()}`)
```


| in variant (`?ab-mobile-inline1-halfpage=variant`) | in control (`?ab-mobile-inline1-halfpage=control`) |
|----------|----------|
| <img width="517" height="186" alt="Screenshot 2026-01-29 at 15 08 39" src="https://github.com/user-attachments/assets/62620cba-8dcf-4209-b67d-fe5a2f3b5009" /> | <img width="478" height="186" alt="Screenshot 2026-01-29 at 15 11 55" src="https://github.com/user-attachments/assets/a141fd86-6de6-45e3-8b29-0f27598508ca" /> |

