### PR TITLE
Add commercial.queue for external code initialisation

### DIFF
--- a/bundle/src/commercial.ts
+++ b/bundle/src/commercial.ts
@@ -1,6 +1,10 @@
 import type { ConsentState } from '@guardian/libs';
 import { getConsentFor, onConsent } from '@guardian/libs';
 import { commercialFeatures } from './lib/commercial-features';
+import { createCommercialQueue } from './lib/guardian-commercial-queue';
+
+window.guardian.commercial ??= {};
+window.guardian.commercial.queue = createCommercialQueue();
 
 const shouldBootConsentless = (consentState: ConsentState) => {
 	return (

--- a/bundle/src/lib/commercial-boot-utils.ts
+++ b/bundle/src/lib/commercial-boot-utils.ts
@@ -48,7 +48,10 @@ const bootCommercial = async (
 
 	try {
 		return Promise.allSettled(modules.map((module) => module())).then(
-			recordCommercialMetrics,
+			() => {
+				recordCommercialMetrics();
+				window.guardian.commercial?.queue?.flush();
+			},
 		);
 	} catch (error) {
 		// report async errors in bootCommercial to Sentry with the commercial feature tag

--- a/bundle/src/lib/guardian-commercial-queue.ts
+++ b/bundle/src/lib/guardian-commercial-queue.ts
@@ -15,7 +15,6 @@ export const createCommercialQueue = (): QueueArray => {
 
 	const queue = new Proxy(targetArray, {
 		get(target, property) {
-			// console.log(`Someone accessed property: ${property}`);
 			if (property === 'push') {
 				return (...items: QueueFunction[]) => {
 					if (isInitialised) {
@@ -53,7 +52,6 @@ export const createCommercialQueue = (): QueueArray => {
 			}
 
 			return Reflect.get(target, property);
-			// return target[property]
 		},
 	});
 	return queue as unknown as QueueArray;

--- a/core/src/global.ts
+++ b/core/src/global.ts
@@ -45,8 +45,10 @@ declare global {
 			commercial?: {
 				dfpEnv?: DfpEnv;
 				a9WinningBids?: FetchBidResponse[];
-				queue?: {push: (...items: Array<() => void>) => number; flush: () => void};
-
+				queue?: {
+					push: (...items: Array<() => void>) => number;
+					flush: () => void;
+				};
 			};
 			notificationEventHistory?: HeaderNotification[][];
 			commercialTimer?: EventTimer;


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Adds `window.guardian.commercial.queue` - a global queue that external code can use to run functions after commercial initialisation.

**How it works (3 phases):**
1. **Setup**: Queue created early in commercial.ts before async modules load
2. **Buffering**: Functions pushed pre-init are buffered (not executed)
3. **Flush & immediate execution**: After all modules load, buffer executes in order. Post-flush, new functions execute immediately.

## Why?
External code sometimes needs to run after commercial initialises (e.g., code that depends on ads being defined). Currently no clean way to do this without polling or timing hacks.

This pattern mirrors `googletag.cmd` and provides a reliable "run when ready" mechanism.
