### PR TITLE
add EventTimer marks to measure timing of user ID retrieval

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/id-handlers/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/index.ts
@@ -1,3 +1,4 @@
+import { EventTimer } from '@guardian/commercial-core/event-timer';
 import { type ConsentState, getConsentFor } from '@guardian/libs';
 import { getEmail } from '../../../identity/api';
 import { isSwitchedOn } from '../../utils';
@@ -10,6 +11,8 @@ import { getUserIdForTradeDesk } from './tradedesk';
 export const getUserSyncSettings = async (
 	consentState: ConsentState,
 ): Promise<UserSync> => {
+	EventTimer.get().mark('getUserIdsStart');
+
 	const userEmail = await getEmail();
 	const fetchId5UserId =
 		getConsentFor('id5', consentState) && getUserIdForId5(userEmail);
@@ -37,6 +40,7 @@ export const getUserSyncSettings = async (
 			return Array.isArray(idModule) ? idModule : [idModule];
 		});
 	});
+	EventTimer.get().mark('getUserIdsEnd');
 
 	const userSync: UserSync = isSwitchedOn('prebidUserSync')
 		? {


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR adds EventTimer marks to monitor the lifecycle of fetching User IDs, from the start of the process to the successful resolution of all User IDs.

Events added:
- getUserIdsStart
- getUserIdsEnd

## Why?
As part of the work to allow User IDs to be declared asynchronously in the commercial bundle, we want to monitor the current timing of the User ID fetching process. 
This will help us better understand performance and identify potential bottlenecks.