### PR TITLE
spacefinder - default standard article grid

### DIFF
--- a/bundle/src/insert/spacefinder/article.ts
+++ b/bundle/src/insert/spacefinder/article.ts
@@ -137,8 +137,8 @@ const addDesktopInline1 = (fillSlot: FillAdSlot): Promise<boolean> => {
 const addDesktopRightRailAds = ({
 	fillSlot,
 	isConsentless,
-	standardArticleGrid,
-	isInteractive,
+	standardArticleGrid = true,
+	isInteractive = false,
 }: {
 	fillSlot: FillAdSlot;
 	isConsentless: boolean;


### PR DESCRIPTION
## What does this change?
Default to `standardArticleGrid = true` and `isInteractive = false`

## Why?
When https://github.com/guardian/dotcom-rendering/pull/15387 is merged this is neccessary to ensure that right column ads have the correct margins applied. It should have been part of #2408.
