### PR TITLE
Update detection method for applying offset class to right rail ads on interactives

### DIFF
--- a/bundle/src/insert/spacefinder/interactive.ts
+++ b/bundle/src/insert/spacefinder/interactive.ts
@@ -20,6 +20,8 @@ const getInteractiveGridWidths = () =>
 
 /**
  * Determine whether the grid body is the standard desktop width, if it is then right rail ads don't need the offset right class, if it's not then we need to add the offset right class to move the ad over to the right.
+ *
+ * The 620px comes from the `ArticleContainer` component in DCR https://github.com/guardian/dotcom-rendering/blob/a321a1e296f54c73580151f3b4c7170ce373eb1f/dotcom-rendering/src/components/ArticleContainer.tsx
  */
 const isBodyStandardDesktopWidth = (bodyWidth: number): boolean => {
 	return bodyWidth === 620;


### PR DESCRIPTION
## What does this change?
Just check if the width is `620px`, this is a better indicator if we need to apply the class that applies the negative margins to right rail ads.

## Why?
The current detection method doesn't work in some circumstances where the contentGrid is larger than the body. e.g. this article https://www.theguardian.com/politics/ng-interactive/2026/feb/25/how-rightwing-rhetoric-has-risen-sharply-in-the-uk-parliament-an-exclusive-visual-analysis