### PR TITLE
Add CAPI Native creative template IDs to ad label skip list

### DIFF
--- a/bundle/src/events/render-advert-label.ts
+++ b/bundle/src/events/render-advert-label.ts
@@ -8,6 +8,11 @@ const templatesWithoutLabels = [
 	12317037, // EVENTS_MULTIPLE
 	10070487, // CAPI_SINGLE_PAIDFOR
 	10063287, // MANUAL_MULTIPLE
+	11750608, // cAPI multiple no logos
+	12478885, // CAPI Multiple Paid For
+	10070367, // cAPI Multiple Supported
+	12490730, // CAPI Single Paid For
+	10070607, // cAPI Single Supported
 ];
 
 const shouldRenderLabel = (


### PR DESCRIPTION

<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Adds CAPI native format creative template IDs to the array of templates that skip the advertisement label.


Template ID | Name
-- | --
11750608 | cAPI multiple no logos
12478885 | CAPI Multiple Paid For
10070367 | cAPI Multiple Supported
12490730 | CAPI Single Paid For
10070607 | cAPI Single Supported

## Why?
We are currently serving CAPI native formats with an advertisement label. Since Labs native formats are directed content owned by The Guardian, we do not want to render the advertisement label in these cases.

### Testing

Tested with: https://www.theguardian.com/us?adtest=7221512111

| Before | After |
|----------|----------|
| <img width="818" height="485" alt="Screenshot 2026-02-27 at 11 13 33" src="https://github.com/user-attachments/assets/bf19d928-cacd-45cd-9bdd-2d3d34d15aac" /> | <img width="811" height="480" alt="Screenshot 2026-02-27 at 11 47 36" src="https://github.com/user-attachments/assets/7d92d87f-fc30-4e71-ac36-10cf99f782de" /> |

