### PR TITLE
Convert Liveramp run condition from AB test to a switch

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/id-handlers/liveramp.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/liveramp.spec.ts
@@ -1,24 +1,17 @@
 import * as core from '@guardian/commercial-core';
 import { loadScript } from '@guardian/libs';
-import { isUserInTestGroup } from '../../../../experiments/beta-ab';
 import { getUserIdForLiveRamp } from './liveramp';
 
 jest.mock('@guardian/libs');
 jest.mock('../../../../experiments/beta-ab');
 
 const mockLoadScript = loadScript as jest.MockedFunction<typeof loadScript>;
-const mockIsUserInTestGroup = isUserInTestGroup as jest.MockedFunction<
-	typeof isUserInTestGroup
->;
 
 describe('getUserIdForLiveRamp', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
 		jest.restoreAllMocks();
-
-		// ensure user is always in test group for these tests
-		// TODO: remove once the experiment is over
-		mockIsUserInTestGroup.mockReturnValue(true);
+		window.guardian.config.switches['prebid-liveramp'] = true;
 	});
 
 	afterEach(() => {

--- a/bundle/src/lib/header-bidding/prebid/id-handlers/liveramp.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/liveramp.ts
@@ -1,6 +1,6 @@
 import { hashEmailForClient } from '@guardian/commercial-core';
 import { loadScript, log } from '@guardian/libs';
-import { isUserInTestGroup } from '../../../../experiments/beta-ab';
+import { isSwitchedOn } from '../../utils';
 import type { UserId } from '../types';
 
 const ATS_PLACEMENT_ID = 14522;
@@ -93,12 +93,9 @@ const getLiveRampParams = async (email: string): Promise<UserId[]> => {
 export const getUserIdForLiveRamp = async (
 	email: string | null,
 ): Promise<UserId[] | undefined> => {
-	const isInTest = isUserInTestGroup(
-		'commercial-user-module-liveramp',
-		'variant',
-	);
+	const isLiverampEnabled = isSwitchedOn('prebid-liveramp');
 
-	if (email && isInTest) {
+	if (email && isLiverampEnabled) {
 		const params = await getLiveRampParams(email);
 		return params;
 	}


### PR DESCRIPTION
## What does this change?

Updates the logic for Liveramp so that it now relies on the switch configured in frontend rather than the AB test

## Why?

The Liveramp user ID module was previously only enabled if the user was in the `variant` group of the corresponding AB test. 
The AB test has now ended and moving forward, this feature will be controlled by a switch instead (https://github.com/guardian/frontend/pull/28651)