### PR TITLE
Fix liveramp switch name

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/id-handlers/liveramp.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/liveramp.spec.ts
@@ -11,7 +11,7 @@ describe('getUserIdForLiveRamp', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
 		jest.restoreAllMocks();
-		window.guardian.config.switches['prebid-liveramp'] = true;
+		window.guardian.config.switches['prebidLiveramp'] = true;
 	});
 
 	afterEach(() => {

--- a/bundle/src/lib/header-bidding/prebid/id-handlers/liveramp.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/liveramp.ts
@@ -93,7 +93,7 @@ const getLiveRampParams = async (email: string): Promise<UserId[]> => {
 export const getUserIdForLiveRamp = async (
 	email: string | null,
 ): Promise<UserId[] | undefined> => {
-	const isLiverampEnabled = isSwitchedOn('prebid-liveramp');
+	const isLiverampEnabled = isSwitchedOn('prebidLiveramp');
 
 	if (email && isLiverampEnabled) {
 		const params = await getLiveRampParams(email);


### PR DESCRIPTION
## What does this change?

Updates the switch name for Liveramp. Should have been camelCase rather than kebab-case

## Why?

I got it wrong in https://github.com/guardian/commercial/pull/2439
