### PR TITLE
Add guard against window.module.abTests being `{}`

### DIFF
--- a/bundle/src/ab-testing/index.ts
+++ b/bundle/src/ab-testing/index.ts
@@ -7,34 +7,36 @@ const reportNoAbModule = () => {
 
 export const getParticipations = () => {
 	// This variable is deliberately not extracted to the top level to give further insurance against the possible race condition
-	const abModule = window.guardian.modules.abTests;
+	const abGetParticipations =
+		window.guardian.modules.abTests?.getParticipations;
 
-	if (!abModule) {
+	if (!abGetParticipations) {
 		reportNoAbModule();
 		return {};
 	}
 
-	return abModule.getParticipations();
+	return abGetParticipations();
 };
 
 export const isUserInTest = (testId: string) => {
-	const abModule = window.guardian.modules.abTests;
+	const abIsUserInTest = window.guardian.modules.abTests?.isUserInTest;
 
-	if (!abModule) {
+	if (!abIsUserInTest) {
 		reportNoAbModule();
 		return false;
 	}
 
-	return abModule.isUserInTest(testId);
+	return abIsUserInTest(testId);
 };
 
 export const isUserInTestGroup = (testId: string, variantId: string) => {
-	const abModule = window.guardian.modules.abTests;
+	const abIsUserInTestGroup =
+		window.guardian.modules.abTests?.isUserInTestGroup;
 
-	if (!abModule) {
+	if (!abIsUserInTestGroup) {
 		reportNoAbModule();
 		return false;
 	}
 
-	return abModule.isUserInTestGroup(testId, variantId);
+	return abIsUserInTestGroup(testId, variantId);
 };

--- a/bundle/src/ab-testing/index.ts
+++ b/bundle/src/ab-testing/index.ts
@@ -1,42 +1,31 @@
 import { reportError } from '../lib/error/report-error';
 
-const reportNoAbModule = (path: string) => {
-	const error = Error(`Unable to access 'window.guardian.modules.${path}'`);
+const reportNoAbModule = () => {
+	const error = Error(`'window.guardian.modules.abTests' is not set up`);
 	reportError(error, 'commercial');
 };
 
-export const getParticipations = () => {
-	// This variable is deliberately not extracted to the top level to give further insurance against the possible race condition
-	const abGetParticipations =
-		window.guardian.modules.abTests?.getParticipations;
-
-	if (!abGetParticipations) {
-		reportNoAbModule('abTests.getParticipations');
-		return {};
+const getAbModule = () => {
+	// Check if the AB testing module is available before trying to access it
+	// it could be missing or not fully initialized, and we want to avoid throwing errors in those cases
+	if (
+		!window.guardian.modules.abTests ||
+		!('getParticipations' in window.guardian.modules.abTests)
+	) {
+		reportNoAbModule();
+		return null;
 	}
+	return window.guardian.modules.abTests;
+};
 
-	return abGetParticipations();
+export const getParticipations = () => {
+	return getAbModule()?.getParticipations() ?? {};
 };
 
 export const isUserInTest = (testId: string) => {
-	const abIsUserInTest = window.guardian.modules.abTests?.isUserInTest;
-
-	if (!abIsUserInTest) {
-		reportNoAbModule('abTests.isUserInTest');
-		return false;
-	}
-
-	return abIsUserInTest(testId);
+	return getAbModule()?.isUserInTest(testId) ?? false;
 };
 
 export const isUserInTestGroup = (testId: string, variantId: string) => {
-	const abIsUserInTestGroup =
-		window.guardian.modules.abTests?.isUserInTestGroup;
-
-	if (!abIsUserInTestGroup) {
-		reportNoAbModule('abTests.isUserInTestGroup');
-		return false;
-	}
-
-	return abIsUserInTestGroup(testId, variantId);
+	return getAbModule()?.isUserInTestGroup(testId, variantId) ?? false;
 };

--- a/bundle/src/ab-testing/index.ts
+++ b/bundle/src/ab-testing/index.ts
@@ -1,7 +1,7 @@
 import { reportError } from '../lib/error/report-error';
 
-const reportNoAbModule = () => {
-	const error = Error('Unable to access abTests module on window.guardian');
+const reportNoAbModule = (path: string) => {
+	const error = Error(`Unable to access 'window.guardian.modules.${path}'`);
 	reportError(error, 'commercial');
 };
 
@@ -11,7 +11,7 @@ export const getParticipations = () => {
 		window.guardian.modules.abTests?.getParticipations;
 
 	if (!abGetParticipations) {
-		reportNoAbModule();
+		reportNoAbModule('abTests.getParticipations');
 		return {};
 	}
 
@@ -22,7 +22,7 @@ export const isUserInTest = (testId: string) => {
 	const abIsUserInTest = window.guardian.modules.abTests?.isUserInTest;
 
 	if (!abIsUserInTest) {
-		reportNoAbModule();
+		reportNoAbModule('abTests.isUserInTest');
 		return false;
 	}
 
@@ -34,7 +34,7 @@ export const isUserInTestGroup = (testId: string, variantId: string) => {
 		window.guardian.modules.abTests?.isUserInTestGroup;
 
 	if (!abIsUserInTestGroup) {
-		reportNoAbModule();
+		reportNoAbModule('abTests.isUserInTestGroup');
 		return false;
 	}
 


### PR DESCRIPTION
## What does this change?
We're witnessing `window.module.abTests` being set to an empty object `{}` without the methods we expect.

We can't trace the location of abTests being set to this, so this is sort of a quick fix to stop this error potentially preventing other commercial code form running.

## Why?
<img width="1285" height="92" alt="image (1)" src="https://github.com/user-attachments/assets/b17849a6-23a5-4899-90f7-477919baf764" />
