### PR TITLE
remove liveblogAdverts from commercialFeatures

### DIFF
--- a/bundle/src/insert/spacefinder/liveblog-adverts.ts
+++ b/bundle/src/insert/spacefinder/liveblog-adverts.ts
@@ -1,9 +1,10 @@
 import { adSizes } from '@guardian/commercial-core/ad-sizes';
 import { log } from '@guardian/libs';
-import { commercialFeatures } from '../../lib/commercial-features';
+import { isAdFree } from '../../lib/ad-free';
 import { createAdSlot } from '../../lib/create-ad-slot';
 import { getCurrentBreakpoint } from '../../lib/detect/detect-breakpoint';
 import fastdom from '../../lib/fastdom-promise';
+import { shouldLoadAds } from '../../lib/should-load-ads';
 import { fillDynamicAdSlot } from '../fill-dynamic-advert-slot';
 import { spaceFiller } from './space-filler';
 import type {
@@ -241,8 +242,13 @@ const onUpdate = (): void => {
  * Inserts inline ad slots between new content
  * blocks when they are pushed to the page.
  */
+
+const isLiveBlog = window.guardian.config.page.isLiveBlog ?? false;
+const adsEnabled = shouldLoadAds();
+const adFree = isAdFree();
+
 export const init = (): Promise<void> => {
-	if (commercialFeatures.liveblogAdverts) {
+	if (!!isLiveBlog && adsEnabled && !adFree) {
 		void startListening();
 	}
 

--- a/bundle/src/lib/commercial-features.ts
+++ b/bundle/src/lib/commercial-features.ts
@@ -38,7 +38,6 @@ class CommercialFeatures {
 	articleBodyAdverts: boolean;
 	thirdPartyTags: boolean;
 	commentAdverts: boolean;
-	liveblogAdverts: boolean;
 	adFree: boolean;
 	comscore: boolean;
 	youtubeAdvertising: boolean;
@@ -126,8 +125,6 @@ class CommercialFeatures {
 			!!window.guardian.config.switches.enableDiscussionSwitch &&
 			window.guardian.config.page.commentable &&
 			(!isLiveBlog || isWidePage);
-
-		this.liveblogAdverts = !!isLiveBlog && adsEnabled && !this.adFree;
 
 		this.comscore =
 			!!window.guardian.config.switches.comscore &&


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Removes the `liveblogAdverts` property from the commercialFeatures class, and ports the logic over to be done inline within the `liveblog-adverts` module.
Logic such as the isLiveBlog,  adsEnabled and isAdFree() has been copied over for now as they are still being used by other properties and methods in the commercialFeatures class

## Why?
This is part of a larger body of work to Deprecate commercialFeatures.
We want to simplify the codebase, commercialFeatures is difficult to understand and we don't need a Singleton.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213593434587899