### PR TITLE
Move third party tags logic out of commercial features

### DIFF
--- a/bundle/src/init/consented/prepare-a9.ts
+++ b/bundle/src/init/consented/prepare-a9.ts
@@ -11,7 +11,7 @@ import { shouldLoadAds } from '../../lib/should-load-ads';
 
 const shouldLoadA9 = () =>
 	// All of the following conditions must be met to load A9
-	(!isSecureContactPage(window.guardian.config.page.pageId) &&
+	(!isSecureContactPage() &&
 		!isGoogleProxy() &&
 		window.guardian.config.switches.a9HeaderBidding &&
 		shouldLoadAds() &&

--- a/bundle/src/init/consented/third-party-tags.spec.ts
+++ b/bundle/src/init/consented/third-party-tags.spec.ts
@@ -1,15 +1,17 @@
 import { getConsentFor, onConsent } from '@guardian/libs';
 import type { ConsentState, USNATConsentState } from '@guardian/libs';
-import { commercialFeatures } from '../../lib/commercial-features';
+import { isAdFree } from '../../lib/ad-free';
 import type { ThirdPartyTag } from '../../types/global';
 import { _, initThirdPartyTags } from './third-party-tags';
-
-const { insertScripts, loadOther } = _;
 
 jest.mock('@guardian/libs', () => ({
 	...jest.requireActual<typeof import('@guardian/libs')>('@guardian/libs'),
 	onConsent: jest.fn(),
 	getConsentFor: jest.fn(),
+}));
+
+jest.mock('../../lib/ad-free', () => ({
+	isAdFree: jest.fn(),
 }));
 
 const tcfv2AllConsent = {
@@ -99,12 +101,6 @@ afterEach(() => {
 	document.body.innerHTML = '';
 });
 
-jest.mock('lib/commercial-features', () => ({
-	commercialFeatures: {
-		thirdPartyTags: true,
-	},
-}));
-
 jest.mock('lib/third-party-tags/imr-worldwide', () => ({
 	imrWorldwide: {
 		shouldRun: true,
@@ -120,37 +116,64 @@ const mockGetConsentFor = (hasConsent: boolean) =>
 	(getConsentFor as jest.Mock).mockReturnValueOnce(hasConsent);
 
 describe('third party tags', () => {
-	it('should exist', () => {
-		expect(initThirdPartyTags).toBeDefined();
-		expect(loadOther).toBeDefined();
-		expect(insertScripts).toBeDefined();
+	describe('canRunThirdPartyTags', () => {
+		beforeEach(() => {
+			jest.mocked(isAdFree).mockReturnValue(false);
+			window.location.hash = '';
+			window.guardian.config.page.contentType = '';
+			window.guardian.config.page.section = '';
+			window.guardian.config.page.pageId = '';
+		});
+
+		it('Does not run for ad free', () => {
+			jest.mocked(isAdFree).mockReturnValue(true);
+			expect(_.canRunThirdPartyTags()).toBe(false);
+		});
+
+		it('Does not run on identity content type', () => {
+			window.guardian.config.page.contentType = 'Identity';
+			expect(_.canRunThirdPartyTags()).toBe(false);
+		});
+
+		it('Does not run on identity section', () => {
+			// This is needed for identity pages in the profile subdomain
+			window.guardian.config.page.section = 'identity';
+			expect(_.canRunThirdPartyTags()).toBe(false);
+		});
+
+		it('Does not run for #noads', () => {
+			window.location.hash = '#noads';
+			expect(_.canRunThirdPartyTags()).toBe(false);
+		});
+
+		it('Does not run on secure contact pages', () => {
+			window.guardian.config.page.pageId =
+				'help/ng-interactive/2017/mar/17/contact-the-guardian-securely';
+
+			expect(_.canRunThirdPartyTags()).toBe(false);
+		});
 	});
 
-	it('should not run if disabled in commercial features', (done) => {
-		mockOnConsent(tcfv2AllConsent);
-		commercialFeatures.thirdPartyTags = false;
-		initThirdPartyTags()
-			.then((enabled) => {
+	describe('initThirdPartyTags', () => {
+		it('should not run if third party tags criteria not met', async () => {
+			jest.mocked(isAdFree).mockReturnValue(true);
+
+			await initThirdPartyTags().then((enabled) => {
 				expect(enabled).toBe(false);
-				done();
-			})
-			.catch(() => {
-				done.fail('third-party tags failed');
 			});
-	});
+		});
 
-	it('should run if commercial enabled', (done) => {
-		mockOnConsent(tcfv2AllConsent);
-		commercialFeatures.thirdPartyTags = true;
-		commercialFeatures.adFree = false;
-		initThirdPartyTags()
-			.then((enabled) => {
+		it('should run if criteria met for running third party tags', async () => {
+			jest.mocked(isAdFree).mockReturnValue(false);
+			window.location.hash = '';
+			window.guardian.config.page.contentType = '';
+			window.guardian.config.page.section = '';
+			window.guardian.config.page.pageId = '';
+
+			await initThirdPartyTags().then((enabled) => {
 				expect(enabled).toBe(true);
-				done();
-			})
-			.catch(() => {
-				done.fail('init failed');
 			});
+		});
 	});
 
 	describe('insertScripts', () => {
@@ -182,7 +205,7 @@ describe('third party tags', () => {
 		it('should add scripts to the document when TCFv2 consent has been given', async () => {
 			mockOnConsent(tcfv2AllConsent);
 			mockGetConsentFor(true);
-			await insertScripts(
+			await _.insertScripts(
 				[fakeThirdPartyAdvertisingTag],
 				[fakeThirdPartyPerformanceTag],
 			);
@@ -192,7 +215,7 @@ describe('third party tags', () => {
 		it('should only add performance scripts to the document when TCFv2 consent has not been given', async () => {
 			mockOnConsent(tcfv2WithoutConsent);
 			mockGetConsentFor(false);
-			await insertScripts(
+			await _.insertScripts(
 				[fakeThirdPartyAdvertisingTag],
 				[fakeThirdPartyPerformanceTag],
 			);
@@ -205,7 +228,7 @@ describe('third party tags', () => {
 				framework: 'usnat',
 			});
 			mockGetConsentFor(true);
-			await insertScripts(
+			await _.insertScripts(
 				[fakeThirdPartyAdvertisingTag],
 				[fakeThirdPartyPerformanceTag],
 			);
@@ -217,7 +240,7 @@ describe('third party tags', () => {
 				framework: 'usnat',
 			});
 			mockGetConsentFor(false);
-			await insertScripts(
+			await _.insertScripts(
 				[fakeThirdPartyAdvertisingTag],
 				[fakeThirdPartyPerformanceTag],
 			);
@@ -228,7 +251,7 @@ describe('third party tags', () => {
 			mockOnConsent(tcfv2WithConsent);
 			mockGetConsentFor(true);
 			mockGetConsentFor(false);
-			await insertScripts(
+			await _.insertScripts(
 				[fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
 				[],
 			);
@@ -241,11 +264,11 @@ describe('third party tags', () => {
 			mockGetConsentFor(false);
 			mockOnConsent(tcfv2WithoutConsent);
 			mockGetConsentFor(false);
-			await insertScripts(
+			await _.insertScripts(
 				[fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
 				[],
 			);
-			await insertScripts(
+			await _.insertScripts(
 				[fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
 				[],
 			);
@@ -255,7 +278,7 @@ describe('third party tags', () => {
 		it('should not add scripts to the document when TCFv2 consent has not been given', async () => {
 			mockOnConsent(tcfv2WithoutConsent);
 			mockGetConsentFor(false);
-			await insertScripts(
+			await _.insertScripts(
 				[fakeThirdPartyAdvertisingTag, fakeThirdPartyAdvertisingTag2],
 				[],
 			);

--- a/bundle/src/init/consented/third-party-tags.ts
+++ b/bundle/src/init/consented/third-party-tags.ts
@@ -1,8 +1,9 @@
 /* A regionalised container for all the commercial tags. */
 
 import { getConsentFor, onConsent } from '@guardian/libs';
-import { commercialFeatures } from '../../lib/commercial-features';
+import { isAdFree } from '../../lib/ad-free';
 import fastdom from '../../lib/fastdom-promise';
+import { isSecureContactPage } from '../../lib/is-secure-contact';
 import { ias } from '../../lib/third-party-tags/ias';
 import { imrWorldwide } from '../../lib/third-party-tags/imr-worldwide';
 import { imrWorldwideLegacy } from '../../lib/third-party-tags/imr-worldwide-legacy';
@@ -10,6 +11,16 @@ import { inizio } from '../../lib/third-party-tags/inizio';
 import { permutive } from '../../lib/third-party-tags/permutive';
 import { remarketing } from '../../lib/third-party-tags/remarketing';
 import type { ThirdPartyTag } from '../../types/global';
+
+const isIdentityPage = () =>
+	window.guardian.config.page.contentType === 'Identity' ||
+	window.guardian.config.page.section === 'identity'; // needed for pages under profile.* subdomain
+
+// Used for speedcurve tests
+const noadsUrl = () => /[#&]noads(&.*)?$/.test(window.location.hash);
+
+const canRunThirdPartyTags = () =>
+	!isAdFree() && !noadsUrl() && !isIdentityPage() && !isSecureContactPage();
 
 const createTagScript = (tag: ThirdPartyTag) => {
 	const script = document.createElement('script');
@@ -104,7 +115,7 @@ const loadOther = (): Promise<void> => {
 };
 
 export const initThirdPartyTags = async (): Promise<boolean> => {
-	if (commercialFeatures.thirdPartyTags) {
+	if (canRunThirdPartyTags()) {
 		void loadOther();
 		return Promise.resolve(true);
 	}
@@ -113,4 +124,5 @@ export const initThirdPartyTags = async (): Promise<boolean> => {
 export const _ = {
 	insertScripts,
 	loadOther,
+	canRunThirdPartyTags,
 };

--- a/bundle/src/lib/commercial-features.spec.ts
+++ b/bundle/src/lib/commercial-features.spec.ts
@@ -1,4 +1,4 @@
-import { setCookie, storage } from '@guardian/libs';
+import { setCookie } from '@guardian/libs';
 import type { CommercialFeaturesConstructor } from './commercial-features';
 import { commercialFeatures } from './commercial-features';
 import { getCurrentBreakpoint as getCurrentBreakpoint_ } from './detect/detect-breakpoint';
@@ -59,8 +59,6 @@ describe('Commercial features', () => {
 
 		window.location.hash = '';
 
-		storage.local.remove(`gu.prefs.switch.adverts`);
-
 		setCookie({ name: 'GU_AF1', value: '' });
 
 		getCurrentBreakpoint.mockReturnValue('desktop');
@@ -100,73 +98,6 @@ describe('Commercial features', () => {
 			setCookie({ name: 'GU_AF1', value: '10' });
 			const features = new CommercialFeatures();
 			expect(features.articleBodyAdverts).toBe(false);
-		});
-	});
-
-	describe('Third party tags', () => {
-		it('Runs by default', () => {
-			const features = new CommercialFeatures();
-			expect(features.thirdPartyTags).toBe(true);
-		});
-
-		it('Does not run on identity pages', () => {
-			window.guardian.config.page.contentType = 'Identity';
-			const features = new CommercialFeatures();
-			expect(features.thirdPartyTags).toBe(false);
-		});
-
-		it('Does not run on identity section', () => {
-			// This is needed for identity pages in the profile subdomain
-			window.guardian.config.page.section = 'identity';
-			const features = new CommercialFeatures();
-			expect(features.thirdPartyTags).toBe(false);
-		});
-
-		it('Does not run on the secure contact interactive', () => {
-			window.guardian.config.page.pageId =
-				'help/ng-interactive/2017/mar/17/contact-the-guardian-securely';
-			const features = new CommercialFeatures();
-			expect(features.thirdPartyTags).toBe(false);
-		});
-
-		it('Does not run on secure contact help page', () => {
-			window.guardian.config.page.pageId =
-				'help/2016/sep/19/how-to-contact-the-guardian-securely';
-
-			const features = new CommercialFeatures();
-			expect(features.thirdPartyTags).toBe(false);
-		});
-	});
-
-	describe('Third party tags under ad-free', () => {
-		beforeEach(() => {
-			setCookie({ name: 'GU_AF1', value: '10' });
-		});
-
-		it('Does not run by default', () => {
-			const features = new CommercialFeatures();
-			expect(features.thirdPartyTags).toBe(false);
-		});
-
-		it('Does not run on identity pages', () => {
-			window.guardian.config.page.contentType = 'Identity';
-			const features = new CommercialFeatures();
-			expect(features.thirdPartyTags).toBe(false);
-		});
-
-		it('Does not run on identity section', () => {
-			// This is needed for identity pages in the profile subdomain
-			window.guardian.config.page.section = 'identity';
-			const features = new CommercialFeatures();
-			expect(features.thirdPartyTags).toBe(false);
-		});
-
-		it('Does not run on secure contact pages', () => {
-			window.guardian.config.page.contentType =
-				'help/ng-interactive/2017/mar/17/contact-the-guardian-securely';
-
-			const features = new CommercialFeatures();
-			expect(features.thirdPartyTags).toBe(false);
 		});
 	});
 

--- a/bundle/src/lib/commercial-features.ts
+++ b/bundle/src/lib/commercial-features.ts
@@ -1,4 +1,4 @@
-import { log, storage } from '@guardian/libs';
+import { log } from '@guardian/libs';
 import { isUserInTestGroup } from '../ab-testing';
 import { isAdFree } from './ad-free';
 import { isSecureContactPage } from './is-secure-contact';
@@ -29,13 +29,9 @@ function adsDisabledLogger(
 	}
 }
 
-const isUserPrefsAdsOff = (): boolean =>
-	storage.local.get(`gu.prefs.switch.adverts`) === false;
-
 // Having a constructor means we can easily re-instantiate the object in a test
 class CommercialFeatures {
 	articleBodyAdverts: boolean;
-	thirdPartyTags: boolean;
 	liveblogAdverts: boolean;
 	adFree: boolean;
 	comscore: boolean;
@@ -43,9 +39,6 @@ class CommercialFeatures {
 	footballFixturesAdverts: boolean;
 
 	constructor() {
-		// this is used for SpeedCurve tests
-		const noadsUrl = /[#&]noads(&.*)?$/.test(window.location.hash);
-		const externalAdvertising = !noadsUrl && !isUserPrefsAdsOff();
 		const sensitiveContent =
 			window.guardian.config.page.shouldHideAdverts ||
 			window.guardian.config.page.section === 'childrens-books-site';
@@ -110,18 +103,12 @@ class CommercialFeatures {
 			);
 		}
 
-		this.thirdPartyTags =
-			!this.adFree &&
-			externalAdvertising &&
-			!isIdentityPage &&
-			!isSecureContactPage(window.guardian.config.page.pageId);
-
 		this.liveblogAdverts = !!isLiveBlog && adsEnabled && !this.adFree;
 
 		this.comscore =
 			!!window.guardian.config.switches.comscore &&
 			!isIdentityPage &&
-			!isSecureContactPage(window.guardian.config.page.pageId);
+			!isSecureContactPage();
 	}
 }
 

--- a/bundle/src/lib/is-secure-contact.ts
+++ b/bundle/src/lib/is-secure-contact.ts
@@ -3,7 +3,7 @@ const SECURE_CONTACT_PAGES = [
 	'help/2016/sep/19/how-to-contact-the-guardian-securely',
 ];
 
-const isSecureContactPage = (pageId: string): boolean =>
-	SECURE_CONTACT_PAGES.includes(pageId);
+const isSecureContactPage = (): boolean =>
+	SECURE_CONTACT_PAGES.includes(window.guardian.config.page.pageId);
 
 export { isSecureContactPage };


### PR DESCRIPTION
## What does this change?

- Removes `thirdPartyTags` from `commercialFeatures`, moving it to the third-party-tags file instead
- Removes `isUserPrefsAdsOff` logic entirely. I can't find any reference to it in code or documentation so assume it is no longer relevant today
- Removes the argument from `isSecureContactPage` since the pageId is stable and will not change for the duration of commercial scripts

## Why?

Simplifying and tidying up the codebase, making it easier to understand for current and future developers.