### PR TITLE
Prevent unhandled AB testing framework error breaking commercial in frontend

### DIFF
--- a/bundle/src/ab-testing/index.ts
+++ b/bundle/src/ab-testing/index.ts
@@ -6,6 +6,10 @@ const reportNoAbModule = () => {
 };
 
 const getAbModule = () => {
+	// We don't currently support frontend AB tests for commercial
+	if (!window.guardian.config.isDotcomRendering) {
+		return null;
+	}
 	// Check if the AB testing module is available before trying to access it
 	// it could be missing or not fully initialized, and we want to avoid throwing errors in those cases
 	if (

--- a/bundle/src/ab-testing/index.ts
+++ b/bundle/src/ab-testing/index.ts
@@ -6,7 +6,7 @@ const reportNoAbModule = () => {
 };
 
 const getAbModule = () => {
-	// We don't currently support frontend AB tests for commercial
+	// We only support running commercial AB tests in dotcom rendering
 	if (!window.guardian.config.isDotcomRendering) {
 		return null;
 	}


### PR DESCRIPTION
## What does this change?

Adds guard to prevent `getAbModule` breaking the commercial bundle in frontend due to `modules` not being available on the window

## Why?

Commercial is currently not working on frontend at all, causing server-side rendered ad slots to remain blank without collapsing them

<details>
<summary>This is because of an unhandled error due to the new AB testing module not being available on the `window.guardian` object</summary>

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'abTests')
getAbModule @ index.ts:9
(anonymous) @ index.ts:23
constructor @ commercial-features.ts:61
(anonymous) @ commercial-features.ts:98
__webpack_require__ @ bootstrap:19
686 @ graun.consented-advertising.commercial.js:1
__webpack_require__ @ bootstrap:19
8855 @ graun.consented-advertising.commercial.js:1
__webpack_require__ @ bootstrap:19
Promise.then
(anonymous) @ commercial.ts:30
c @ graun.standalone.commercial.js:1
r @ graun.standalone.commercial.js:1
Promise.then
c @ graun.standalone.commercial.js:1
r @ graun.standalone.commercial.js:1
(anonymous) @ graun.standalone.commercial.js:1
(anonymous) @ graun.standalone.commercial.js:1
(anonymous) @ graun.standalone.commercial.js:1
(anonymous) @ graun.standalone.commercial.js:1
PendingScript
(anonymous) @ loadScript.js:27
(anonymous) @ loadScript.js:1
(anonymous) @ boot.js:115
(anonymous) @ boot.js:134
(anonymous) @ regeneratorRuntime.js:52
(anonymous) @ regenerator.js:52
(anonymous) @ regeneratorDefine.js:11
asyncGeneratorStep @ asyncToGenerator.js:3
_next @ asyncToGenerator.js:17
Promise.then
asyncGeneratorStep @ asyncToGenerator.js:8
_next @ asyncToGenerator.js:17
Promise.then
asyncGeneratorStep @ asyncToGenerator.js:8
_next @ asyncToGenerator.js:17
Promise.then
asyncGeneratorStep @ asyncToGenerator.js:8
_next @ asyncToGenerator.js:17
(anonymous) @ asyncToGenerator.js:22
(anonymous) @ asyncToGenerator.js:14
wrapped @ raven.js:376
setTimeout
(anonymous) @ raven.js:1133
(anonymous) @ ready.js:27
(anonymous) @ boot.js:28
(anonymous) @ boot.js:176
(anonymous) @ graun.standard.js:2
(anonymous) @ graun.standard.js:2
PendingScript
(anonymous) @ theguardian:433
(anonymous) @ theguardian:433
```
</details>
<img width="781" height="149" alt="image" src="https://github.com/user-attachments/assets/7a588241-8789-4bb2-9e46-3cdd56b3188a" />

