### PR TITLE
Remove `youtubeAdvertising` from commercial features

### DIFF
--- a/bundle/src/lib/commercial-features.ts
+++ b/bundle/src/lib/commercial-features.ts
@@ -35,13 +35,9 @@ class CommercialFeatures {
 	liveblogAdverts: boolean;
 	adFree: boolean;
 	comscore: boolean;
-	youtubeAdvertising: boolean;
 	footballFixturesAdverts: boolean;
 
 	constructor() {
-		const sensitiveContent =
-			window.guardian.config.page.shouldHideAdverts ||
-			window.guardian.config.page.section === 'childrens-books-site';
 		const isMinuteArticle = window.guardian.config.page.isMinuteArticle;
 		const isArticle = window.guardian.config.page.contentType === 'Article';
 		const isInteractive =
@@ -67,8 +63,6 @@ class CommercialFeatures {
 		this.footballFixturesAdverts = isFootballPage && isPageWithRightAdSpace;
 
 		this.adFree = isAdFree();
-
-		this.youtubeAdvertising = !this.adFree && !sensitiveContent;
 
 		const isInSpacefinderOnInteractivesTest =
 			!isUserInTestGroup(


### PR DESCRIPTION
## What does this change?

Removes the `youtubeAdvertising` property from `CommercialFeatures`

## Why?

Tidying up and improving the readability of commercial code.

Turns out `commercialFeatures.youtubeAdvertising` isn't actually used anywhere 🤔 🔍
It seems to have been [inherited from frontend](https://github.com/guardian/frontend/blob/1d965e8c9b92a2d69374d94c69e16d0de253b32b/static/src/javascripts/projects/common/modules/commercial/commercial-features.ts#L25) but isn't actually used in `commercial`
