### PR TITLE
Remove specific `pnpm` version from the `corepack prepare` step in setup-node-env action

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -7,9 +7,6 @@ runs:
     - run: corepack enable
       shell: bash
 
-    - run: corepack prepare pnpm@9.15.2 --activate
-      shell: bash
-
     - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version-file: '.nvmrc'

--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -7,6 +7,9 @@ runs:
     - run: corepack enable
       shell: bash
 
+    - run: corepack prepare
+      shell: bash
+
     - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version-file: '.nvmrc'


### PR DESCRIPTION
## What does this change?

Removes the `pnpm` version from the `corepack prepare` step in `setup-node-env` Github action

## Why?

We don't need it, and it forces the CI process to use a pinned version of `pnpm` which is different to the one specified in the `package-manager` field in `package.json`
