### PR TITLE
Move `articleBodyAdverts`  out of `commercialFeatures`

### DIFF
--- a/bundle/src/init/consentless/dynamic/article-body-adverts.ts
+++ b/bundle/src/init/consentless/dynamic/article-body-adverts.ts
@@ -1,6 +1,6 @@
 import { addInlineAds } from '../../../insert/spacefinder/article';
 import type { FillAdSlot } from '../../../insert/spacefinder/article';
-import { commercialFeatures } from '../../../lib/commercial-features';
+import { allowArticleBodyAdverts } from '../../../lib/article-body-adverts';
 import { getCurrentBreakpoint } from '../../../lib/detect/detect-breakpoint';
 import { defineSlot } from '../define-slot';
 
@@ -16,7 +16,7 @@ const fillConsentlessAdSlot: FillAdSlot = (name, slot) => {
 
 const initArticleBodyAdverts = async (): Promise<void> => {
 	// do we need to rerun for the sign-in gate?
-	if (!commercialFeatures.articleBodyAdverts) {
+	if (!allowArticleBodyAdverts()) {
 		return;
 	}
 

--- a/bundle/src/insert/spacefinder/article.spec.ts
+++ b/bundle/src/insert/spacefinder/article.spec.ts
@@ -20,9 +20,7 @@ jest.mock('insert/spacefinder/space-filler', () => ({
 	},
 }));
 
-const spaceFillerStub = spaceFiller.fillSpace as jest.MockedFunction<
-	typeof spaceFiller.fillSpace
->;
+const fillSpace = jest.mocked(spaceFiller.fillSpace);
 
 const mockViewport = (width: number, height: number): void => {
 	Object.defineProperties(window, {
@@ -38,7 +36,7 @@ const mockViewport = (width: number, height: number): void => {
 describe('Article Body Adverts', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
-		spaceFillerStub.mockImplementation(() => Promise.resolve(2));
+		fillSpace.mockImplementation(() => Promise.resolve(true));
 		mockViewport(0, 1300);
 		expect.hasAssertions();
 	});
@@ -51,7 +49,7 @@ describe('Article Body Adverts', () => {
 		const fillAdSlot = jest.fn();
 		jest.mocked(allowArticleBodyAdverts).mockReturnValue(false);
 		return init(fillAdSlot).then(() => {
-			expect(spaceFillerStub).not.toHaveBeenCalled();
+			expect(fillSpace).not.toHaveBeenCalled();
 		});
 	});
 
@@ -60,10 +58,10 @@ describe('Article Body Adverts', () => {
 		jest.mocked(allowArticleBodyAdverts).mockReturnValue(true);
 		mockViewport(1300, 1300);
 		return init(fillAdSlot).then(() => {
-			expect(spaceFillerStub).toHaveBeenCalledTimes(2);
-			console.log(spaceFillerStub.mock.calls[0]?.[0]);
-			expect(spaceFillerStub.mock.calls[0]?.[2]?.pass).toEqual('inline1');
-			expect(spaceFillerStub.mock.calls[1]?.[2]?.pass).toEqual(
+			expect(fillSpace).toHaveBeenCalledTimes(2);
+			console.log(fillSpace.mock.calls[0]?.[0]);
+			expect(fillSpace.mock.calls[0]?.[2]?.pass).toEqual('inline1');
+			expect(fillSpace.mock.calls[1]?.[2]?.pass).toEqual(
 				'subsequent-inlines',
 			);
 		});
@@ -74,8 +72,8 @@ describe('Article Body Adverts', () => {
 		jest.mocked(allowArticleBodyAdverts).mockReturnValue(true);
 		mockViewport(500, 1300);
 		return init(fillAdSlot).then(() => {
-			expect(spaceFillerStub).toHaveBeenCalledTimes(1);
-			expect(spaceFillerStub.mock.calls[0]?.[2]?.pass).toEqual(
+			expect(fillSpace).toHaveBeenCalledTimes(1);
+			expect(fillSpace.mock.calls[0]?.[2]?.pass).toEqual(
 				'mobile-inlines',
 			);
 		});

--- a/bundle/src/insert/spacefinder/article.spec.ts
+++ b/bundle/src/insert/spacefinder/article.spec.ts
@@ -1,4 +1,4 @@
-import { commercialFeatures } from '../../lib/commercial-features';
+import { allowArticleBodyAdverts } from '../../lib/article-body-adverts';
 import { init } from './article';
 import { spaceFiller } from './space-filler';
 
@@ -10,8 +10,8 @@ jest.mock('insert/fill-dynamic-advert-slot', () => ({
 	fillDynamicAdSlot: jest.fn(),
 }));
 
-jest.mock('lib/commercial-features', () => ({
-	commercialFeatures: {},
+jest.mock('lib/article-body-adverts', () => ({
+	allowArticleBodyAdverts: jest.fn().mockReturnValue(true),
 }));
 
 jest.mock('insert/spacefinder/space-filler', () => ({
@@ -38,8 +38,6 @@ const mockViewport = (width: number, height: number): void => {
 describe('Article Body Adverts', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
-		commercialFeatures.articleBodyAdverts = true;
-		// @ts-expect-error -- we need to TS space-filler’s queue
 		spaceFillerStub.mockImplementation(() => Promise.resolve(2));
 		mockViewport(0, 1300);
 		expect.hasAssertions();
@@ -49,9 +47,9 @@ describe('Article Body Adverts', () => {
 		expect(init).toBeDefined();
 	});
 
-	it('should exit if commercial feature disabled', () => {
+	it('should exit if ads in article body are disabled', () => {
 		const fillAdSlot = jest.fn();
-		commercialFeatures.articleBodyAdverts = false;
+		jest.mocked(allowArticleBodyAdverts).mockReturnValue(false);
 		return init(fillAdSlot).then(() => {
 			expect(spaceFillerStub).not.toHaveBeenCalled();
 		});
@@ -59,6 +57,7 @@ describe('Article Body Adverts', () => {
 
 	it('should call relevant functions to fill space on desktop', () => {
 		const fillAdSlot = jest.fn();
+		jest.mocked(allowArticleBodyAdverts).mockReturnValue(true);
 		mockViewport(1300, 1300);
 		return init(fillAdSlot).then(() => {
 			expect(spaceFillerStub).toHaveBeenCalledTimes(2);
@@ -72,6 +71,7 @@ describe('Article Body Adverts', () => {
 
 	it('should call relevant functions to fill space on mobile and tablet', () => {
 		const fillAdSlot = jest.fn();
+		jest.mocked(allowArticleBodyAdverts).mockReturnValue(true);
 		mockViewport(500, 1300);
 		return init(fillAdSlot).then(() => {
 			expect(spaceFillerStub).toHaveBeenCalledTimes(1);

--- a/bundle/src/insert/spacefinder/article.ts
+++ b/bundle/src/insert/spacefinder/article.ts
@@ -1,7 +1,7 @@
 import type { AdSize, SizeMapping } from '@guardian/commercial-core/ad-sizes';
 import { adSizes } from '@guardian/commercial-core/ad-sizes';
 import { isUserInTestGroup } from '../../ab-testing';
-import { commercialFeatures } from '../../lib/commercial-features';
+import { allowArticleBodyAdverts } from '../../lib/article-body-adverts';
 import type { ContainerOptions } from '../../lib/create-ad-slot';
 import {
 	adSlotContainerClass,
@@ -310,7 +310,7 @@ const addInlineAds = async (
  * @param fillAdSlot a function to fill the ad slots
  */
 const init = async (fillAdSlot: FillAdSlot): Promise<void> => {
-	if (!commercialFeatures.articleBodyAdverts) {
+	if (!allowArticleBodyAdverts()) {
 		return Promise.resolve();
 	}
 

--- a/bundle/src/lib/article-body-adverts.spec.ts
+++ b/bundle/src/lib/article-body-adverts.spec.ts
@@ -1,0 +1,80 @@
+import { isAdFree } from './ad-free';
+import { allowArticleBodyAdverts } from './article-body-adverts';
+import { shouldLoadAds } from './should-load-ads';
+
+jest.mock('lib/should-load-ads', () => ({
+	shouldLoadAds: jest.fn(),
+}));
+
+jest.mock('lib/ad-free', () => ({
+	isAdFree: jest.fn(),
+}));
+
+describe('Article Body Adverts', () => {
+	beforeEach(() => {
+		jest.restoreAllMocks();
+		jest.mocked(shouldLoadAds).mockReturnValue(true);
+		jest.mocked(isAdFree).mockReturnValue(false);
+		// True conditions
+		window.guardian.config.page.contentType = 'Article';
+		// False conditions
+		window.guardian.config.page.isMinuteArticle = false;
+		window.guardian.config.page.isLiveBlog = false;
+		window.guardian.config.page.isHosted = false;
+		window.guardian.config.page.showNewRecipeDesign = false;
+	});
+
+	it('Runs for articles by default', () => {
+		const articleBodyAdverts = allowArticleBodyAdverts();
+		expect(articleBodyAdverts).toBe(true);
+	});
+
+	it('Doesn`t run for ad free', () => {
+		jest.mocked(isAdFree).mockReturnValue(true);
+
+		const articleBodyAdverts = allowArticleBodyAdverts();
+		expect(articleBodyAdverts).toBe(false);
+	});
+
+	it('Doesn`t run if shouldLoadAds is false', () => {
+		jest.mocked(shouldLoadAds).mockReturnValue(false);
+
+		const articleBodyAdverts = allowArticleBodyAdverts();
+		expect(articleBodyAdverts).toBe(false);
+	});
+
+	it('Doesn`t run in minute articles', () => {
+		window.guardian.config.page.isMinuteArticle = true;
+
+		const articleBodyAdverts = allowArticleBodyAdverts();
+		expect(articleBodyAdverts).toBe(false);
+	});
+
+	it('Doesn`t run in non-article pages', () => {
+		window.guardian.config.page.contentType = 'Network Front';
+
+		const articleBodyAdverts = allowArticleBodyAdverts();
+		expect(articleBodyAdverts).toBe(false);
+	});
+
+	it('Doesn`t run in live blogs', () => {
+		window.guardian.config.page.isLiveBlog = true;
+
+		const articleBodyAdverts = allowArticleBodyAdverts();
+		expect(articleBodyAdverts).toBe(false);
+	});
+
+	it('Doesn`t run in hosted content pages', () => {
+		window.guardian.config.page.isHosted = true;
+
+		const articleBodyAdverts = allowArticleBodyAdverts();
+		expect(articleBodyAdverts).toBe(false);
+	});
+
+	it('Doesn`t run in new recipe design pages', () => {
+		window.guardian.config.page.isHosted = true;
+
+		const articleBodyAdverts = allowArticleBodyAdverts();
+		expect(articleBodyAdverts).toBe(false);
+	});
+});

--- a/bundle/src/lib/article-body-adverts.ts
+++ b/bundle/src/lib/article-body-adverts.ts
@@ -1,0 +1,75 @@
+import { log } from '@guardian/libs';
+import { isUserInTestGroup } from '../ab-testing';
+import { isAdFree } from './ad-free';
+import { shouldLoadAds } from './should-load-ads';
+
+/**
+ * Log the reason why adverts are disabled
+ *
+ * @param trueConditions - normally true conditions, log if false
+ * @param falseConditions - normally false conditions, log if true
+ */
+function adsDisabledLogger(
+	trueConditions: Record<string, boolean>,
+	falseConditions: Record<string, boolean>,
+): void {
+	const noAdsLog = (condition: string, value: boolean): void =>
+		log(
+			'commercial',
+			`Adverts are not shown because ${condition} = ${String(value)}`,
+		);
+
+	for (const [condition, value] of Object.entries(trueConditions)) {
+		if (!value) noAdsLog(condition, value);
+	}
+
+	for (const [condition, value] of Object.entries(falseConditions)) {
+		if (value) noAdsLog(condition, value);
+	}
+}
+
+const allowArticleBodyAdverts = (): boolean => {
+	const isMinuteArticle = window.guardian.config.page.isMinuteArticle;
+	const isArticle = window.guardian.config.page.contentType === 'Article';
+	const isInteractive =
+		window.guardian.config.page.contentType === 'Interactive';
+	const isLiveBlog = window.guardian.config.page.isLiveBlog ?? false;
+	const isHosted = window.guardian.config.page.isHosted;
+	const newRecipeDesign =
+		window.guardian.config.page.showNewRecipeDesign ?? false;
+
+	const isInSpacefinderOnInteractivesTest =
+		!isUserInTestGroup(
+			'commercial-holdback-spacefinder-on-interactives',
+			'holdback',
+		) && isInteractive;
+
+	const enableArticleBodyAdverts =
+		isArticle || isInSpacefinderOnInteractivesTest;
+
+	const disableArticleBodyAdverts =
+		isMinuteArticle || isLiveBlog || isHosted || newRecipeDesign;
+
+	const articleBodyAdverts = () =>
+		shouldLoadAds() &&
+		!isAdFree() &&
+		enableArticleBodyAdverts &&
+		!disableArticleBodyAdverts;
+
+	if (isArticle && !articleBodyAdverts()) {
+		// Log why article adverts are disabled
+		adsDisabledLogger(
+			{ isArticle },
+			{
+				isMinuteArticle,
+				isLiveBlog,
+				isHosted,
+				newRecipeDesign,
+			},
+		);
+	}
+
+	return !!articleBodyAdverts();
+};
+
+export { allowArticleBodyAdverts };

--- a/bundle/src/lib/commercial-features.spec.ts
+++ b/bundle/src/lib/commercial-features.spec.ts
@@ -68,39 +68,6 @@ describe('Commercial features', () => {
 		(shouldLoadAds as jest.Mock).mockReturnValue(true);
 	});
 
-	describe('Article body adverts', () => {
-		it('Runs by default', () => {
-			const features = new CommercialFeatures();
-			expect(features.articleBodyAdverts).toBe(true);
-		});
-
-		it('Doesn`t run in minute articles', () => {
-			window.guardian.config.page.isMinuteArticle = true;
-			const features = new CommercialFeatures();
-			expect(features.articleBodyAdverts).toBe(false);
-		});
-
-		it('Doesn`t run in non-article pages', () => {
-			window.guardian.config.page.contentType = 'Network Front';
-			const features = new CommercialFeatures();
-			expect(features.articleBodyAdverts).toBe(false);
-		});
-
-		it('Doesn`t run in live blogs', () => {
-			window.guardian.config.page.isLiveBlog = true;
-			const features = new CommercialFeatures();
-			expect(features.articleBodyAdverts).toBe(false);
-		});
-	});
-
-	describe('Article body adverts under ad-free', () => {
-		it('are disabled', () => {
-			setCookie({ name: 'GU_AF1', value: '10' });
-			const features = new CommercialFeatures();
-			expect(features.articleBodyAdverts).toBe(false);
-		});
-	});
-
 	describe('comscore ', () => {
 		beforeEach(() => {
 			window.guardian.config.switches.comscore = true;

--- a/bundle/src/lib/commercial-features.ts
+++ b/bundle/src/lib/commercial-features.ts
@@ -1,53 +1,16 @@
-import { log } from '@guardian/libs';
-import { isUserInTestGroup } from '../ab-testing';
 import { isAdFree } from './ad-free';
 import { isSecureContactPage } from './is-secure-contact';
-import { shouldLoadAds } from './should-load-ads';
-
-/**
- * Log the reason why adverts are disabled
- *
- * @param trueConditions - normally true conditions, log if false
- * @param falseConditions - normally false conditions, log if true
- */
-function adsDisabledLogger(
-	trueConditions: Record<string, boolean>,
-	falseConditions: Record<string, boolean>,
-): void {
-	const noAdsLog = (condition: string, value: boolean): void =>
-		log(
-			'commercial',
-			`Adverts are not shown because ${condition} = ${String(value)}`,
-		);
-
-	for (const [condition, value] of Object.entries(trueConditions)) {
-		if (!value) noAdsLog(condition, value);
-	}
-
-	for (const [condition, value] of Object.entries(falseConditions)) {
-		if (value) noAdsLog(condition, value);
-	}
-}
 
 // Having a constructor means we can easily re-instantiate the object in a test
 class CommercialFeatures {
-	articleBodyAdverts: boolean;
 	adFree: boolean;
 	comscore: boolean;
 	footballFixturesAdverts: boolean;
 
 	constructor() {
-		const isMinuteArticle = window.guardian.config.page.isMinuteArticle;
-		const isArticle = window.guardian.config.page.contentType === 'Article';
-		const isInteractive =
-			window.guardian.config.page.contentType === 'Interactive';
-		const isLiveBlog = window.guardian.config.page.isLiveBlog ?? false;
-		const isHosted = window.guardian.config.page.isHosted;
 		const isIdentityPage =
 			window.guardian.config.page.contentType === 'Identity' ||
 			window.guardian.config.page.section === 'identity'; // needed for pages under profile.* subdomain
-		const newRecipeDesign =
-			window.guardian.config.page.showNewRecipeDesign ?? false;
 
 		// Detect presence of space for football-right ad slot
 		const { pageId } = window.guardian.config.page;
@@ -62,39 +25,6 @@ class CommercialFeatures {
 		this.footballFixturesAdverts = isFootballPage && isPageWithRightAdSpace;
 
 		this.adFree = isAdFree();
-
-		const isInSpacefinderOnInteractivesTest =
-			!isUserInTestGroup(
-				'commercial-holdback-spacefinder-on-interactives',
-				'holdback',
-			) && isInteractive;
-
-		const enableArticleBodyAdverts =
-			isArticle || isInSpacefinderOnInteractivesTest;
-
-		const disableArticleBodyAdverts =
-			isMinuteArticle || isLiveBlog || isHosted || newRecipeDesign;
-
-		const adsEnabled = shouldLoadAds();
-
-		this.articleBodyAdverts =
-			adsEnabled &&
-			!this.adFree &&
-			enableArticleBodyAdverts &&
-			!disableArticleBodyAdverts;
-
-		if (isArticle && !this.articleBodyAdverts) {
-			// Log why article adverts are disabled
-			adsDisabledLogger(
-				{ isArticle },
-				{
-					isMinuteArticle,
-					isLiveBlog,
-					isHosted,
-					newRecipeDesign,
-				},
-			);
-		}
 
 		this.comscore =
 			!!window.guardian.config.switches.comscore &&


### PR DESCRIPTION
## What does this change?

- Takes the `articleBodyAdverts` code out of `commercialFeatures`, moving relevant tests over to the new location and updating any usages of this property in other places of the code base

## Why?

As part of some refactoring work to simplify the commercial bundle code, we're moving features away from `commercialFeatures` one by one, until we can remove it entirely.