### PR TITLE
Import `google-publisher-tag` in `global.ts` types file

### DIFF
--- a/bundle/src/types/global.ts
+++ b/bundle/src/types/global.ts
@@ -1,3 +1,4 @@
+import 'google-publisher-tag';
 import type { PageTargeting } from '@guardian/commercial-core/targeting/build-page-targeting';
 import type {
 	AdBlockers,
@@ -346,6 +347,8 @@ declare global {
 
 	interface Window {
 		guardian: Guardian;
+
+		googletag: typeof googletag;
 
 		ootag: {
 			queue: Array<() => void>;


### PR DESCRIPTION
## What does this change?

Adds `google-publisher-tag` import to global.ts to allow IDEs to interpret global `googletag` types from the `window` object

## Why?

Reduces the type errors coming from my IDE