### PR TITLE
Set prebid price floor V1

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/index.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.spec.ts
@@ -604,7 +604,9 @@ describe('Prebid.js bidWon Events', () => {
 });
 describe('commercial-loading-userids-async experiment', () => {
 	test('when user is not in variant test group, pbjs.setConfig to be called with userIds', async () => {
-		jest.mocked(isUserInTestGroup).mockReturnValue(false);
+		jest.mocked(isUserInTestGroup)
+			.mockReturnValueOnce(false) // userids-async → not in test
+			.mockReturnValueOnce(false); // price-floor → not in test
 		mockGetConsentForID5(true);
 		(getEmail as jest.Mock).mockReturnValue('');
 		window.guardian.config.switches.prebidUserSync = true;
@@ -626,7 +628,9 @@ describe('commercial-loading-userids-async experiment', () => {
 		);
 	});
 	test('when user is in test group, mergeConfig is called with all resolved userIds after promises settle', async () => {
-		jest.mocked(isUserInTestGroup).mockReturnValue(true);
+		jest.mocked(isUserInTestGroup)
+			.mockReturnValueOnce(true) // userids-async → in test
+			.mockReturnValueOnce(false); // price-floor → not in test
 		mockGetConsentForID5(true);
 		(getEmail as jest.Mock).mockReturnValue('');
 		window.guardian.config.switches.prebidUserSync = true;
@@ -650,6 +654,48 @@ describe('commercial-loading-userids-async experiment', () => {
 
 		expect(setConfigSpy).toHaveBeenCalledWith(
 			expect.objectContaining({ userSync: undefined }),
+		);
+	});
+});
+describe('isInPrebidFloorPriceTest', () => {
+	test('when user is in variant test group, pbjs.setConfig to be called with floor price values', async () => {
+		jest.mocked(isUserInTestGroup)
+			.mockReturnValueOnce(false)
+			.mockReturnValueOnce(true);
+
+		const setConfigSpy = jest.spyOn(window.pbjs, 'setConfig');
+
+		await prebid.initialise(window, mockConsentState);
+
+		expect(setConfigSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				floors: {
+					data: {
+						schema: {
+							fields: ['mediaType', 'size'],
+						},
+						values: {
+							'*|*': 0.1,
+						},
+					},
+				},
+			}),
+		);
+	});
+	test('when user is not in variant test group, pbjs.setConfig to be called without floor price values', async () => {
+		jest.mocked(isUserInTestGroup)
+			.mockReturnValueOnce(false)
+			.mockReturnValueOnce(false);
+
+		const setConfigSpy = jest.spyOn(window.pbjs, 'setConfig');
+
+		await prebid.initialise(window, mockConsentState);
+
+		expect(setConfigSpy).toHaveBeenCalledWith(
+			expect.not.objectContaining({
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest matchers return any
+				floors: expect.anything(),
+			}),
 		);
 	});
 });

--- a/bundle/src/lib/header-bidding/prebid/index.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.spec.ts
@@ -658,6 +658,7 @@ describe('commercial-loading-userids-async experiment', () => {
 	});
 });
 describe('isInPrebidFloorPriceTest', () => {
+	/* eslint-disable @typescript-eslint/no-unsafe-assignment -- Jest matchers return any */
 	test('when user is in variant test group, pbjs.setConfig to be called with floor price values', async () => {
 		jest.mocked(isUserInTestGroup)
 			.mockReturnValueOnce(false)
@@ -669,19 +670,18 @@ describe('isInPrebidFloorPriceTest', () => {
 
 		expect(setConfigSpy).toHaveBeenCalledWith(
 			expect.objectContaining({
-				floors: {
-					data: {
-						schema: {
-							fields: ['mediaType', 'size'],
-						},
-						values: {
-							'*|*': 0.1,
-						},
-					},
-				},
+				floors: expect.objectContaining({
+					enabled: true,
+					data: expect.objectContaining({
+						schema: { fields: ['mediaType'] },
+						values: { '*': 0.1 },
+						default: 0.1,
+					}),
+				}),
 			}),
 		);
 	});
+	/* eslint-enable @typescript-eslint/no-unsafe-assignment */
 	test('when user is not in variant test group, pbjs.setConfig to be called without floor price values', async () => {
 		jest.mocked(isUserInTestGroup)
 			.mockReturnValueOnce(false)

--- a/bundle/src/lib/header-bidding/prebid/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.ts
@@ -49,6 +49,11 @@ const initialise = async (
 		'variant',
 	);
 
+	const isInPrebidFloorPriceTest = isUserInTestGroup(
+		'commercial-prebid-price-floor',
+		'variant',
+	);
+
 	// For control group users, await userSync before setConfig so it's included immediately.
 	// For test group users, skip the await — userSync will be merged into the config
 	// at the end of initialise via mergeConfig.
@@ -60,6 +65,20 @@ const initialise = async (
 		 */
 		bidderTimeout: PREBID_TIMEOUT,
 
+		...(isInPrebidFloorPriceTest
+			? {
+					floors: {
+						data: {
+							schema: {
+								fields: ['mediaType', 'size'],
+							},
+							values: {
+								'*|*': 0.1,
+							},
+						},
+					},
+				}
+			: {}),
 		/**
 		 * Prebid supports an additional timeout buffer to account for noisiness in
 		 * timing JavaScript on the page. This value is passed to the Prebid config

--- a/bundle/src/lib/header-bidding/prebid/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.ts
@@ -64,17 +64,18 @@ const initialise = async (
 		 * The amount of time reserved for the auction
 		 */
 		bidderTimeout: PREBID_TIMEOUT,
-
+		/**
+		 * Applying one global floor price of £0.10 for all bids.
+		 * Initially gated behind an AB test.
+		 */
 		...(isInPrebidFloorPriceTest
 			? {
 					floors: {
+						enabled: true,
 						data: {
-							schema: {
-								fields: ['mediaType', 'size'],
-							},
-							values: {
-								'*|*': 0.1,
-							},
+							schema: { fields: ['mediaType'] },
+							values: { '*': 0.1 },
+							default: 0.1,
 						},
 					},
 				}

--- a/bundle/src/lib/header-bidding/prebid/modules/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/modules/index.ts
@@ -29,6 +29,9 @@ import 'prebid.js/modules/userId';
 import 'prebid.js/modules/rtdModule';
 import 'prebid.js/modules/permutiveRtdProvider';
 
+// Price floors
+import 'prebid.js/modules/priceFloors';
+
 // Guardian specific adapters that we have modified or created
 import './appnexusBidAdapter';
 import './openxBidAdapter';


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Adds floor price configuration to Prebid via [pbjs.setConfig](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), gated behind an A/B test (commercial-prebid-price-floor).

We're applying a static $0.10 global floor — the minimum we'd ever floor at — to assess the impact on bid response rate.

This V1 approach:

Applies a single global floor (*|*: all media types, all sizes)
Ignores context (geo, device, slot, format)
Tests whether filtering low bids improves effective bidding
Tests added to verify floor config is included/excluded based on test group membership.

## Why?
We currently don't pass floor prices to our Prebid partners. Several partners have requested this, stating it helps filter unwinnable bids and improves effective bidding.

If V1 shows positive results, V2 would introduce more granular floors across dimensions like region, device, and slot.



### Testing:

https://theguardian.com/ab-tests/opt-in/commercial-prebid-price-floor:variant

Go to an article to can check in Chrome dev tools to confirm you're in the test:
window.guardian.modules.abTests.getParticipations()

<img width="270" height="269" alt="Screenshot 2026-04-22 at 16 06 08" src="https://github.com/user-attachments/assets/6d011c17-5a2b-4e7d-847a-cdc63170cc57" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214026334703343