### PR TITLE
update and fix `hangtime` conditions in US for inline2

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -755,7 +755,7 @@ describe('getOzonePlacementId', () => {
 		);
 	});
 
-	test('should return correct placementID for hangtime ads in inline2 in US or CAN', () => {
+	test('should return correct placementID for hangtime ads in inline2 in US', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -730,13 +730,6 @@ describe('getOzonePlacementId', () => {
 		expect(getOzonePlacementId([[320, 50]])).toBe('3500014217');
 	});
 
-	test('should return correct placementID in US if none of the conditions are met', () => {
-		isInUsa.mockReturnValue(true);
-		getBreakpointKey.mockReturnValue('M');
-		containsMpu.mockReturnValue(true);
-		expect(getOzonePlacementId([[300, 250]])).toBe('1500001036');
-	});
-
 	test('should return correct placementID for mobile-sticky in ROW', () => {
 		isInRow.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
@@ -763,7 +756,7 @@ describe('getOzonePlacementId', () => {
 	});
 
 	test('should return correct placementID for hangtime ads in inline2 in US or CAN', () => {
-		isInUsOrCa.mockReturnValue(true);
+		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
 		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline2')).toBe(

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -285,6 +285,10 @@ const getOzonePlacementId = (
 				return '3500014217';
 			}
 
+			if (slotId === 'dfp-ad--inline2' && containsMpu(sizes)) {
+				return '1500001025';
+			}
+
 			if (containsMpu(sizes)) {
 				return '1500001036';
 			}


### PR DESCRIPTION

<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Adds Ozone hangtime placement ID (1500001025) for mobile inline2 slots in the US, by placing the check before the generic MPU fallback (1500001036) inside the isInUsa() block.

Also fixes the existing test for US inline2 hangtime, which was previously mocking isInUsOrCa instead of isInUsa — passing accidentally via the UK/ROW fallback path rather than the US code path.

## Why?
The hangtime placement ID (1500001025) was unreachable for US traffic. The generic mobile MPU fallback (1500001036) returned first, so inline2 in the US never got the hangtime-specific placement.

### Test




Tested in CODE:

| | Before - 1500001036 | After - 1500001025 |
|---|---|---|
| US mobile inline2 | <img width="804" height="611" alt="Screenshot 2026-04-23 at 17 07 50" src="https://github.com/user-attachments/assets/afe4be2a-95d7-464d-ac06-99d4b2fb8079" /> | <img width="805" height="610" alt="Screenshot 2026-04-23 at 17 05 06" src="https://github.com/user-attachments/assets/fe8795c4-1d24-40e4-b7e1-ea16311f0aa9" /> |



  | After
-- | --
UK mobile inline2 still hangtime: 1500001025 | <img height="400" height="500" alt="Screenshot 2026-04-23 at 17 50 04" src="https://github.com/user-attachments/assets/950f1f90-9f39-4e75-b64e-364fe3fb562c" />


