### PR TITLE
Put spacefinder in interactives live

### DIFF
--- a/bundle/jest.config.js
+++ b/bundle/jest.config.js
@@ -11,7 +11,7 @@ const jestConfig = {
 			branches: 45,
 			functions: 41,
 			lines: 60,
-			statements: 60,
+			statements: 59,
 		},
 		/**
 		 * Higher testing threshold for the src/lib directory

--- a/bundle/src/lib/article-body-adverts.ts
+++ b/bundle/src/lib/article-body-adverts.ts
@@ -1,5 +1,4 @@
 import { log } from '@guardian/libs';
-import { isUserInTestGroup } from '../ab-testing';
 import { isAdFree } from './ad-free';
 import { shouldLoadAds } from './should-load-ads';
 
@@ -38,14 +37,7 @@ const allowArticleBodyAdverts = (): boolean => {
 	const newRecipeDesign =
 		window.guardian.config.page.showNewRecipeDesign ?? false;
 
-	const isInSpacefinderOnInteractivesTest =
-		!isUserInTestGroup(
-			'commercial-holdback-spacefinder-on-interactives',
-			'holdback',
-		) && isInteractive;
-
-	const enableArticleBodyAdverts =
-		isArticle || isInSpacefinderOnInteractivesTest;
+	const enableArticleBodyAdverts = isArticle || isInteractive;
 
 	const disableArticleBodyAdverts =
 		isMinuteArticle || isLiveBlog || isHosted || newRecipeDesign;


### PR DESCRIPTION
## What does this change?

Removes the code referencing the holdback AB test `commercial-spacefinder-in-interactives` to put the logic live for 100% of the audience

## Why?

We've had the results back from this AB test and allowing spacefinder to run in interactive articles results in a **3% decrease** in good CLS scores but a **43% increase** in ad ratio (and 44% increase in ad requests) so we've agreed to fully release the change and continue to adapt the spacefinder rules to reduce the negative impact on CLS going forward
