### PR TITLE
Remove `commercial-loading-userids-async` test logic

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/index.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.spec.ts
@@ -602,67 +602,10 @@ describe('Prebid.js bidWon Events', () => {
 		},
 	);
 });
-describe('commercial-loading-userids-async experiment', () => {
-	test('when user is not in variant test group, pbjs.setConfig to be called with userIds', async () => {
-		jest.mocked(isUserInTestGroup)
-			.mockReturnValueOnce(false) // userids-async → not in test
-			.mockReturnValueOnce(false); // price-floor → not in test
-		mockGetConsentForID5(true);
-		(getEmail as jest.Mock).mockReturnValue('');
-		window.guardian.config.switches.prebidUserSync = true;
-		const setConfigSpy = jest.spyOn(window.pbjs, 'setConfig');
-
-		await prebid.initialise(window, mockConsentState);
-
-		expect(setConfigSpy).toHaveBeenCalledWith(
-			expect.objectContaining({
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest matchers return any
-				userSync: expect.objectContaining({
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest matchers return any
-					userIds: expect.arrayContaining([
-						expect.objectContaining({ name: 'sharedId' }),
-						expect.objectContaining({ name: 'id5Id' }),
-					]),
-				}),
-			}),
-		);
-	});
-	test('when user is in test group, mergeConfig is called with all resolved userIds after promises settle', async () => {
-		jest.mocked(isUserInTestGroup)
-			.mockReturnValueOnce(true) // userids-async → in test
-			.mockReturnValueOnce(false); // price-floor → not in test
-		mockGetConsentForID5(true);
-		(getEmail as jest.Mock).mockReturnValue('');
-		window.guardian.config.switches.prebidUserSync = true;
-		const mergeConfigSpy = jest.spyOn(window.pbjs, 'mergeConfig');
-		const setConfigSpy = jest.spyOn(window.pbjs, 'setConfig');
-
-		await prebid.initialise(window, mockConsentState);
-
-		expect(mergeConfigSpy).toHaveBeenCalledWith(
-			expect.objectContaining({
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest matchers return any
-				userSync: expect.objectContaining({
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest matchers return any
-					userIds: expect.arrayContaining([
-						expect.objectContaining({ name: 'sharedId' }),
-						expect.objectContaining({ name: 'id5Id' }),
-					]),
-				}),
-			}),
-		);
-
-		expect(setConfigSpy).toHaveBeenCalledWith(
-			expect.objectContaining({ userSync: undefined }),
-		);
-	});
-});
 describe('isInPrebidFloorPriceTest', () => {
 	/* eslint-disable @typescript-eslint/no-unsafe-assignment -- Jest matchers return any */
 	test('when user is in variant test group, pbjs.setConfig to be called with floor price values', async () => {
-		jest.mocked(isUserInTestGroup)
-			.mockReturnValueOnce(false)
-			.mockReturnValueOnce(true);
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
 
 		const setConfigSpy = jest.spyOn(window.pbjs, 'setConfig');
 
@@ -683,9 +626,7 @@ describe('isInPrebidFloorPriceTest', () => {
 	});
 	/* eslint-enable @typescript-eslint/no-unsafe-assignment */
 	test('when user is not in variant test group, pbjs.setConfig to be called without floor price values', async () => {
-		jest.mocked(isUserInTestGroup)
-			.mockReturnValueOnce(false)
-			.mockReturnValueOnce(false);
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
 
 		const setConfigSpy = jest.spyOn(window.pbjs, 'setConfig');
 

--- a/bundle/src/lib/header-bidding/prebid/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.ts
@@ -41,23 +41,12 @@ const initialise = async (
 ): Promise<void> => {
 	initialised = true;
 
-	const userSyncPromise: Promise<UserSyncConfig> =
-		getUserSyncSettings(consentState);
-
-	const isInTest = isUserInTestGroup(
-		'commercial-loading-userids-async',
-		'variant',
-	);
+	const userSync: UserSyncConfig = await getUserSyncSettings(consentState);
 
 	const isInPrebidFloorPriceTest = isUserInTestGroup(
 		'commercial-prebid-price-floor',
 		'variant',
 	);
-
-	// For control group users, await userSync before setConfig so it's included immediately.
-	// For test group users, skip the await — userSync will be merged into the config
-	// at the end of initialise via mergeConfig.
-	const initialUserSyncConfig = isInTest ? undefined : await userSyncPromise;
 
 	window.pbjs.setConfig({
 		/**
@@ -88,10 +77,7 @@ const initialise = async (
 		timeoutBuffer: 400,
 		priceGranularity: 'custom',
 		customPriceBucket: priceGranularity,
-		userSync:
-			!isInTest && initialUserSyncConfig
-				? initialUserSyncConfig
-				: undefined,
+		userSync,
 		ortb2: {
 			site: {
 				ext: {
@@ -160,17 +146,6 @@ const initialise = async (
 		advert.hasPrebidSize = true;
 		advert.size = size;
 	});
-
-	// For test group users, await the userSync promise here — after setConfig and bidder
-	// setup have run without blocking — so userIds are still ready before the first ad request.
-	const userSyncConfig = isInTest ? await userSyncPromise : undefined;
-
-	// update config and adjust slot size when prebid ad loads
-	if (userSyncConfig) {
-		window.pbjs.mergeConfig({
-			userSync: userSyncConfig,
-		} as unknown as Record<string, unknown>);
-	}
 };
 
 const bidsBackHandler = (


### PR DESCRIPTION
## What does this change?

Removes the `commercial-loading-userids-async` AB test logic to fall back to the original logic implemented before #2429


## Why?

Removes code referencing this AB test and reverts it back to the original logic until we decide whether to move forward with the change or not.