### PR TITLE
integrate teads with prebid

### DIFF
--- a/bundle/src/lib/header-bidding/prebid-types.ts
+++ b/bundle/src/lib/header-bidding/prebid-types.ts
@@ -118,7 +118,8 @@ type BidderCode =
 	| 'triplelift'
 	| 'trustx'
 	| 'xhb'
-	| 'ttd';
+	| 'ttd'
+	| 'teads';
 
 type PrebidParams =
 	| PrebidAppNexusParams
@@ -146,6 +147,11 @@ type PrebidMediaTypes = {
 	};
 };
 
+type PrebidTeadsParams = {
+	pageId: number;
+	placementId: number;
+};
+
 type SlotFlatMap = (slot: HeaderBiddingSlot) => HeaderBiddingSlot[];
 
 export type {
@@ -169,5 +175,6 @@ export type {
 	PrebidParams,
 	PrebidBidder,
 	PrebidMediaTypes,
+	PrebidTeadsParams,
 	SlotFlatMap,
 };

--- a/bundle/src/lib/header-bidding/prebid-types.ts
+++ b/bundle/src/lib/header-bidding/prebid-types.ts
@@ -133,6 +133,7 @@ type PrebidParams =
 	| PrebidTripleLiftParams
 	| PrebidTrustXParams
 	| PrebidXaxisParams
+	| PrebidTeadsParams
 	| PrebidTheTradeDeskParams;
 
 type PrebidBidder = {

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -17,6 +17,8 @@ import {
 	containsMobileSticky as containsMobileSticky_,
 	containsMpu as containsMpu_,
 	containsMpuOrDmpu as containsMpuOrDmpu_,
+	containsPortraitInterstitial as containsPortraitInterstitial_,
+	containsWS as containsWS_,
 	getBreakpointKey as getBreakpointKey_,
 	shouldIncludeBidder,
 	stripMobileSuffix as stripMobileSuffix_,
@@ -54,6 +56,7 @@ const {
 	getTrustXAdUnitId,
 	indexExchangeBidders,
 	getOzonePlacementId,
+	getTeadsPlacementId
 } = _;
 
 jest.mock('lib/page-targeting', () => ({
@@ -72,6 +75,8 @@ jest.mock('../../utils', () => ({
 	containsMobileSticky: jest.fn(),
 	containsMpu: jest.fn(),
 	containsMpuOrDmpu: jest.fn(),
+	containsPortraitInterstitial: jest.fn(),
+	containsWS: jest.fn(),
 	getBreakpointKey: jest.fn(),
 	stripMobileSuffix: jest.fn(),
 }));
@@ -83,8 +88,11 @@ const containsLeaderboardOrBillboard =
 const containsMobileSticky = containsMobileSticky_ as jest.Mock;
 const containsMpu = containsMpu_ as jest.Mock;
 const containsMpuOrDmpu = containsMpuOrDmpu_ as jest.Mock;
+const containsPortraitInterstitial = containsPortraitInterstitial_ as jest.Mock
+const containsWS = containsWS_ as jest.Mock;
 const stripMobileSuffix = stripMobileSuffix_ as jest.Mock;
 const getBreakpointKey = getBreakpointKey_ as jest.Mock;
+
 
 jest.mock('@guardian/commercial-core/geo/geo-utils');
 const isInAuOrNz = isInAuOrNz_ as jest.Mock;
@@ -696,6 +704,98 @@ describe('getXaxisPlacementId', () => {
 		]);
 	});
 });
+
+describe('getTeadsPlacementId', () => {
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+	describe('UK Region', () => {
+		test.each([
+			[[300, 250], 'MPU', containsMpu],
+			[[300, 600], 'DMPU', containsDmpu],
+			[[728, 90], 'Leaderboard', containsLeaderboard],
+			[[970, 250], 'Billboard', containsBillboard],
+			[[160, 600], 'WS', containsWS]
+		])('should return correct placement and page ID for %s in UK when on desktop', (size, label, mockFunction) => {
+			isInUk.mockReturnValue(true);
+			getBreakpointKey.mockReturnValue('D');
+			(mockFunction).mockReturnValue(true);
+			expect(getTeadsPlacementId([size as Size])).toStrictEqual({ pageId: 244722, placementId: 261612 })
+		})
+		test.each([
+			[[300, 250], 'MPU', containsMpu],
+			[[320, 480], 'PORTRAIT', containsPortraitInterstitial],
+		])('should return correct placement and page ID for %s in UK when on mobile', (size, label, mockFunction) => {
+			isInUk.mockReturnValue(true);
+			getBreakpointKey.mockReturnValue('M');
+			mockFunction.mockReturnValue(true);
+			expect(getTeadsPlacementId([size as Size])).toStrictEqual({ pageId: 244724, placementId: 261614 })
+		})
+	})
+	describe('Rest of World Region', () => {
+		test.each([
+			[[300, 250], 'MPU', containsMpu],
+			[[300, 600], 'DMPU', containsDmpu],
+			[[160, 600], 'WS', containsWS],
+			[[728, 90], 'LEADERBOARD', containsLeaderboard],
+			[[970, 250], 'BILLBOARD', containsBillboard]
+
+		])('should return correct placement and page ID for %s in RoW when on desktop', (size, label, mockFucntion) => {
+			isInRow.mockReturnValue(true)
+			getBreakpointKey.mockReturnValue('D')
+			mockFucntion.mockReturnValue(true)
+			expect(getTeadsPlacementId([size as Size])).toStrictEqual({ pageId: 244725, placementId: 261615 })
+		})
+		test.each([
+			[[300, 250], 'MPU', containsMpu],
+			[[320, 480], 'PORTRAIT', containsPortraitInterstitial],
+		])('should return correct placement and page ID for %s in RoW when on mobile', (size, label, mockFucntion) => {
+			isInRow.mockReturnValue(true)
+			getBreakpointKey.mockReturnValue('M')
+			mockFucntion.mockReturnValue(true)
+			expect(getTeadsPlacementId([size as Size])).toStrictEqual({ pageId: 244726, placementId: 261616 })
+		})
+		test.each([
+			[[320, 50], 'MOBILE STICKY', containsMobileSticky],
+		])('should return correct placement and page ID for %s in RoW when mobile sticky on mobile', (size, label, mockFucntion) => {
+			isInRow.mockReturnValue(true)
+			getBreakpointKey.mockReturnValue('M')
+			mockFucntion.mockReturnValue(true)
+			expect(getTeadsPlacementId([size as Size])).toStrictEqual({ pageId: 244723, placementId: 261613 })
+		})
+	})
+	describe('US Region', ()=>{
+		test.each([
+			[[300, 250], 'MPU', containsMpu],
+			[[300, 600], 'DMPU', containsDmpu],
+			[[160, 600], 'WS', containsWS],
+			[[728, 90], 'LEADERBOARD', containsLeaderboard],
+			[[970, 250], 'BILLBOARD', containsBillboard]
+		])('should return correct placement and page ID for %s in US when on desktop', (size, label, mockFunction)=>{
+			isInUsa.mockReturnValue(true)
+			getBreakpointKey.mockReturnValue('D')
+			mockFunction.mockReturnValue(true)
+			expect(getTeadsPlacementId([size as Size])).toStrictEqual({pageId: 244728,placementId: 261618 })
+		})
+		test.each([
+			[[300, 250], 'MPU', containsMpu],
+			[[320, 480], 'PORTRAIT', containsPortraitInterstitial],
+		])('should return correct placement and page ID for %s in US when on mobile', (size, label, mockFunction)=>{
+			isInUsa.mockReturnValue(true)
+			getBreakpointKey.mockReturnValue('M')
+			mockFunction.mockReturnValue(true)
+			expect(getTeadsPlacementId([size as Size])).toStrictEqual({pageId: 244729 ,placementId: 261619 })
+		})
+		test.each([
+			[[320, 50], 'MOBILE STICKY', containsMobileSticky],
+		])('should return correct placement and page ID for %s in US when mobile sticky on mobile', (size, label, mockFunction)=>{
+			isInUsa.mockReturnValue(true)
+			getBreakpointKey.mockReturnValue('M')
+			mockFunction.mockReturnValue(true)
+			expect(getTeadsPlacementId([size as Size])).toStrictEqual({pageId: 244730 ,placementId: 261620 })
+		})
+	})
+})
 
 describe('getOzonePlacementId', () => {
 	afterEach(() => {

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -56,7 +56,7 @@ const {
 	getTrustXAdUnitId,
 	indexExchangeBidders,
 	getOzonePlacementId,
-	getTeadsPlacementId
+	getTeadsPlacementId,
 } = _;
 
 jest.mock('lib/page-targeting', () => ({
@@ -88,11 +88,10 @@ const containsLeaderboardOrBillboard =
 const containsMobileSticky = containsMobileSticky_ as jest.Mock;
 const containsMpu = containsMpu_ as jest.Mock;
 const containsMpuOrDmpu = containsMpuOrDmpu_ as jest.Mock;
-const containsPortraitInterstitial = containsPortraitInterstitial_ as jest.Mock
+const containsPortraitInterstitial = containsPortraitInterstitial_ as jest.Mock;
 const containsWS = containsWS_ as jest.Mock;
 const stripMobileSuffix = stripMobileSuffix_ as jest.Mock;
 const getBreakpointKey = getBreakpointKey_ as jest.Mock;
-
 
 jest.mock('@guardian/commercial-core/geo/geo-utils');
 const isInAuOrNz = isInAuOrNz_ as jest.Mock;
@@ -715,87 +714,130 @@ describe('getTeadsPlacementId', () => {
 			[[300, 600], 'DMPU', containsDmpu],
 			[[728, 90], 'Leaderboard', containsLeaderboard],
 			[[970, 250], 'Billboard', containsBillboard],
-			[[160, 600], 'WS', containsWS]
-		])('should return correct placement and page ID for %s in UK when on desktop', (size, label, mockFunction) => {
-			isInUk.mockReturnValue(true);
-			getBreakpointKey.mockReturnValue('D');
-			(mockFunction).mockReturnValue(true);
-			expect(getTeadsPlacementId([size as Size])).toStrictEqual({ pageId: 244722, placementId: 261612 })
-		})
+			[[160, 600], 'WS', containsWS],
+		])(
+			'should return correct placement and page ID for %s in UK when on desktop',
+			(size, label, mockFunction) => {
+				isInUk.mockReturnValue(true);
+				getBreakpointKey.mockReturnValue('D');
+				mockFunction.mockReturnValue(true);
+				expect(getTeadsPlacementId([size as Size])).toStrictEqual({
+					pageId: 244722,
+					placementId: 261612,
+				});
+			},
+		);
 		test.each([
 			[[300, 250], 'MPU', containsMpu],
 			[[320, 480], 'PORTRAIT', containsPortraitInterstitial],
-		])('should return correct placement and page ID for %s in UK when on mobile', (size, label, mockFunction) => {
-			isInUk.mockReturnValue(true);
-			getBreakpointKey.mockReturnValue('M');
-			mockFunction.mockReturnValue(true);
-			expect(getTeadsPlacementId([size as Size])).toStrictEqual({ pageId: 244724, placementId: 261614 })
-		})
-	})
+		])(
+			'should return correct placement and page ID for %s in UK when on mobile',
+			(size, label, mockFunction) => {
+				isInUk.mockReturnValue(true);
+				getBreakpointKey.mockReturnValue('M');
+				mockFunction.mockReturnValue(true);
+				expect(getTeadsPlacementId([size as Size])).toStrictEqual({
+					pageId: 244724,
+					placementId: 261614,
+				});
+			},
+		);
+	});
 	describe('Rest of World Region', () => {
 		test.each([
 			[[300, 250], 'MPU', containsMpu],
 			[[300, 600], 'DMPU', containsDmpu],
 			[[160, 600], 'WS', containsWS],
 			[[728, 90], 'LEADERBOARD', containsLeaderboard],
-			[[970, 250], 'BILLBOARD', containsBillboard]
-
-		])('should return correct placement and page ID for %s in RoW when on desktop', (size, label, mockFucntion) => {
-			isInRow.mockReturnValue(true)
-			getBreakpointKey.mockReturnValue('D')
-			mockFucntion.mockReturnValue(true)
-			expect(getTeadsPlacementId([size as Size])).toStrictEqual({ pageId: 244725, placementId: 261615 })
-		})
+			[[970, 250], 'BILLBOARD', containsBillboard],
+		])(
+			'should return correct placement and page ID for %s in RoW when on desktop',
+			(size, label, mockFucntion) => {
+				isInRow.mockReturnValue(true);
+				getBreakpointKey.mockReturnValue('D');
+				mockFucntion.mockReturnValue(true);
+				expect(getTeadsPlacementId([size as Size])).toStrictEqual({
+					pageId: 244725,
+					placementId: 261615,
+				});
+			},
+		);
 		test.each([
 			[[300, 250], 'MPU', containsMpu],
 			[[320, 480], 'PORTRAIT', containsPortraitInterstitial],
-		])('should return correct placement and page ID for %s in RoW when on mobile', (size, label, mockFucntion) => {
-			isInRow.mockReturnValue(true)
-			getBreakpointKey.mockReturnValue('M')
-			mockFucntion.mockReturnValue(true)
-			expect(getTeadsPlacementId([size as Size])).toStrictEqual({ pageId: 244726, placementId: 261616 })
-		})
-		test.each([
-			[[320, 50], 'MOBILE STICKY', containsMobileSticky],
-		])('should return correct placement and page ID for %s in RoW when mobile sticky on mobile', (size, label, mockFucntion) => {
-			isInRow.mockReturnValue(true)
-			getBreakpointKey.mockReturnValue('M')
-			mockFucntion.mockReturnValue(true)
-			expect(getTeadsPlacementId([size as Size])).toStrictEqual({ pageId: 244723, placementId: 261613 })
-		})
-	})
-	describe('US Region', ()=>{
+		])(
+			'should return correct placement and page ID for %s in RoW when on mobile',
+			(size, label, mockFucntion) => {
+				isInRow.mockReturnValue(true);
+				getBreakpointKey.mockReturnValue('M');
+				mockFucntion.mockReturnValue(true);
+				expect(getTeadsPlacementId([size as Size])).toStrictEqual({
+					pageId: 244726,
+					placementId: 261616,
+				});
+			},
+		);
+		test.each([[[320, 50], 'MOBILE STICKY', containsMobileSticky]])(
+			'should return correct placement and page ID for %s in RoW when mobile sticky on mobile',
+			(size, label, mockFucntion) => {
+				isInRow.mockReturnValue(true);
+				getBreakpointKey.mockReturnValue('M');
+				mockFucntion.mockReturnValue(true);
+				expect(getTeadsPlacementId([size as Size])).toStrictEqual({
+					pageId: 244723,
+					placementId: 261613,
+				});
+			},
+		);
+	});
+	describe('US Region', () => {
 		test.each([
 			[[300, 250], 'MPU', containsMpu],
 			[[300, 600], 'DMPU', containsDmpu],
 			[[160, 600], 'WS', containsWS],
 			[[728, 90], 'LEADERBOARD', containsLeaderboard],
-			[[970, 250], 'BILLBOARD', containsBillboard]
-		])('should return correct placement and page ID for %s in US when on desktop', (size, label, mockFunction)=>{
-			isInUsa.mockReturnValue(true)
-			getBreakpointKey.mockReturnValue('D')
-			mockFunction.mockReturnValue(true)
-			expect(getTeadsPlacementId([size as Size])).toStrictEqual({pageId: 244728,placementId: 261618 })
-		})
+			[[970, 250], 'BILLBOARD', containsBillboard],
+		])(
+			'should return correct placement and page ID for %s in US when on desktop',
+			(size, label, mockFunction) => {
+				isInUsa.mockReturnValue(true);
+				getBreakpointKey.mockReturnValue('D');
+				mockFunction.mockReturnValue(true);
+				expect(getTeadsPlacementId([size as Size])).toStrictEqual({
+					pageId: 244728,
+					placementId: 261618,
+				});
+			},
+		);
 		test.each([
 			[[300, 250], 'MPU', containsMpu],
 			[[320, 480], 'PORTRAIT', containsPortraitInterstitial],
-		])('should return correct placement and page ID for %s in US when on mobile', (size, label, mockFunction)=>{
-			isInUsa.mockReturnValue(true)
-			getBreakpointKey.mockReturnValue('M')
-			mockFunction.mockReturnValue(true)
-			expect(getTeadsPlacementId([size as Size])).toStrictEqual({pageId: 244729 ,placementId: 261619 })
-		})
-		test.each([
-			[[320, 50], 'MOBILE STICKY', containsMobileSticky],
-		])('should return correct placement and page ID for %s in US when mobile sticky on mobile', (size, label, mockFunction)=>{
-			isInUsa.mockReturnValue(true)
-			getBreakpointKey.mockReturnValue('M')
-			mockFunction.mockReturnValue(true)
-			expect(getTeadsPlacementId([size as Size])).toStrictEqual({pageId: 244730 ,placementId: 261620 })
-		})
-	})
-})
+		])(
+			'should return correct placement and page ID for %s in US when on mobile',
+			(size, label, mockFunction) => {
+				isInUsa.mockReturnValue(true);
+				getBreakpointKey.mockReturnValue('M');
+				mockFunction.mockReturnValue(true);
+				expect(getTeadsPlacementId([size as Size])).toStrictEqual({
+					pageId: 244729,
+					placementId: 261619,
+				});
+			},
+		);
+		test.each([[[320, 50], 'MOBILE STICKY', containsMobileSticky]])(
+			'should return correct placement and page ID for %s in US when mobile sticky on mobile',
+			(size, label, mockFunction) => {
+				isInUsa.mockReturnValue(true);
+				getBreakpointKey.mockReturnValue('M');
+				mockFunction.mockReturnValue(true);
+				expect(getTeadsPlacementId([size as Size])).toStrictEqual({
+					pageId: 244730,
+					placementId: 261620,
+				});
+			},
+		);
+	});
+});
 
 describe('getOzonePlacementId', () => {
 	afterEach(() => {

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '@guardian/commercial-core/geo/geo-utils';
 import { type ConsentState } from '@guardian/consent-manager';
 import type { Size } from 'prebid.js/dist/src/types/common';
+import { isUserInTestGroup } from '../../../../ab-testing';
 import type { PrebidBidder } from '../../prebid-types';
 import {
 	containsBillboard as containsBillboard_,
@@ -80,6 +81,11 @@ jest.mock('../../utils', () => ({
 	getBreakpointKey: jest.fn(),
 	stripMobileSuffix: jest.fn(),
 }));
+
+jest.mock('../../../../ab-testing', () => ({
+	isUserInTestGroup: jest.fn(),
+}));
+
 const containsBillboard = containsBillboard_ as jest.Mock;
 const containsDmpu = containsDmpu_ as jest.Mock;
 const containsLeaderboard = containsLeaderboard_ as jest.Mock;
@@ -339,6 +345,44 @@ describe('bids', () => {
 		jest.mocked(shouldIncludeBidder).mockReturnValue(mockShouldInclude);
 
 		expect(getBidders()).toEqual(['xhb']);
+	});
+	test('should include teadsBidder when user is in the AB Test variant', () => {
+		const mockShouldInclude = jest
+			.fn()
+			.mockReturnValueOnce(false) // ix
+			.mockReturnValueOnce(false) // criteo
+			.mockReturnValueOnce(false) // trustx
+			.mockReturnValueOnce(false) // triplelift
+			.mockReturnValueOnce(false) // and
+			.mockReturnValueOnce(false) // xhb
+			.mockReturnValueOnce(false) // pubmatic
+			.mockReturnValueOnce(false) // ozone
+			.mockReturnValueOnce(false) // oxd
+			.mockReturnValueOnce(false) // kargo
+			.mockReturnValueOnce(true); // teads
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
+		jest.mocked(shouldIncludeBidder).mockReturnValue(mockShouldInclude);
+
+		expect(getBidders()).toEqual(['teads']);
+	});
+	test('should NOT include teadsBidder when user is NOT in the AB Test variant', () => {
+		const mockShouldInclude = jest
+			.fn()
+			.mockReturnValueOnce(false) // ix
+			.mockReturnValueOnce(false) // criteo
+			.mockReturnValueOnce(false) // trustx
+			.mockReturnValueOnce(false) // triplelift
+			.mockReturnValueOnce(false) // and
+			.mockReturnValueOnce(false) // xhb
+			.mockReturnValueOnce(false) // pubmatic
+			.mockReturnValueOnce(false) // ozone
+			.mockReturnValueOnce(false) // oxd
+			.mockReturnValueOnce(false) // kargo
+			.mockReturnValueOnce(true); // rubicon (teads skipped due to short-circuit)
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
+		jest.mocked(shouldIncludeBidder).mockReturnValue(mockShouldInclude);
+
+		expect(getBidders()).toEqual(['rubicon']);
 	});
 
 	test('should only include bidder being tested, even when it should not be included', () => {

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -57,7 +57,7 @@ const {
 	getTrustXAdUnitId,
 	indexExchangeBidders,
 	getOzonePlacementId,
-	getTeadsPlacementId,
+	getTeadsParams,
 } = _;
 
 jest.mock('lib/page-targeting', () => ({
@@ -748,7 +748,7 @@ describe('getXaxisPlacementId', () => {
 	});
 });
 
-describe('getTeadsPlacementId', () => {
+describe('getTeadsParams', () => {
 	afterEach(() => {
 		jest.resetAllMocks();
 	});
@@ -765,7 +765,7 @@ describe('getTeadsPlacementId', () => {
 				isInUk.mockReturnValue(true);
 				getBreakpointKey.mockReturnValue('D');
 				mockFunction.mockReturnValue(true);
-				expect(getTeadsPlacementId([size as Size])).toStrictEqual({
+				expect(getTeadsParams([size as Size])).toStrictEqual({
 					pageId: 244722,
 					placementId: 261612,
 				});
@@ -780,7 +780,7 @@ describe('getTeadsPlacementId', () => {
 				isInUk.mockReturnValue(true);
 				getBreakpointKey.mockReturnValue('M');
 				mockFunction.mockReturnValue(true);
-				expect(getTeadsPlacementId([size as Size])).toStrictEqual({
+				expect(getTeadsParams([size as Size])).toStrictEqual({
 					pageId: 244724,
 					placementId: 261614,
 				});
@@ -800,7 +800,7 @@ describe('getTeadsPlacementId', () => {
 				isInRow.mockReturnValue(true);
 				getBreakpointKey.mockReturnValue('D');
 				mockFucntion.mockReturnValue(true);
-				expect(getTeadsPlacementId([size as Size])).toStrictEqual({
+				expect(getTeadsParams([size as Size])).toStrictEqual({
 					pageId: 244725,
 					placementId: 261615,
 				});
@@ -815,7 +815,7 @@ describe('getTeadsPlacementId', () => {
 				isInRow.mockReturnValue(true);
 				getBreakpointKey.mockReturnValue('M');
 				mockFucntion.mockReturnValue(true);
-				expect(getTeadsPlacementId([size as Size])).toStrictEqual({
+				expect(getTeadsParams([size as Size])).toStrictEqual({
 					pageId: 244726,
 					placementId: 261616,
 				});
@@ -827,7 +827,7 @@ describe('getTeadsPlacementId', () => {
 				isInRow.mockReturnValue(true);
 				getBreakpointKey.mockReturnValue('M');
 				mockFucntion.mockReturnValue(true);
-				expect(getTeadsPlacementId([size as Size])).toStrictEqual({
+				expect(getTeadsParams([size as Size])).toStrictEqual({
 					pageId: 244723,
 					placementId: 261613,
 				});
@@ -847,7 +847,7 @@ describe('getTeadsPlacementId', () => {
 				isInUsa.mockReturnValue(true);
 				getBreakpointKey.mockReturnValue('D');
 				mockFunction.mockReturnValue(true);
-				expect(getTeadsPlacementId([size as Size])).toStrictEqual({
+				expect(getTeadsParams([size as Size])).toStrictEqual({
 					pageId: 244728,
 					placementId: 261618,
 				});
@@ -862,7 +862,7 @@ describe('getTeadsPlacementId', () => {
 				isInUsa.mockReturnValue(true);
 				getBreakpointKey.mockReturnValue('M');
 				mockFunction.mockReturnValue(true);
-				expect(getTeadsPlacementId([size as Size])).toStrictEqual({
+				expect(getTeadsParams([size as Size])).toStrictEqual({
 					pageId: 244729,
 					placementId: 261619,
 				});
@@ -874,7 +874,7 @@ describe('getTeadsPlacementId', () => {
 				isInUsa.mockReturnValue(true);
 				getBreakpointKey.mockReturnValue('M');
 				mockFunction.mockReturnValue(true);
-				expect(getTeadsPlacementId([size as Size])).toStrictEqual({
+				expect(getTeadsParams([size as Size])).toStrictEqual({
 					pageId: 244730,
 					placementId: 261620,
 				});

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -378,8 +378,8 @@ describe('bids', () => {
 			.mockReturnValueOnce(false) // ozone
 			.mockReturnValueOnce(false) // oxd
 			.mockReturnValueOnce(false) // kargo
-			.mockReturnValueOnce(true); // rubicon (teads skipped due to short-circuit)
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
+			.mockReturnValueOnce(false) // teads
+			.mockReturnValueOnce(true); // rubicon
 		jest.mocked(shouldIncludeBidder).mockReturnValue(mockShouldInclude);
 
 		expect(getBidders()).toEqual(['rubicon']);

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -267,7 +267,7 @@ const openxBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
 const isCrosswordPage = (pageTargeting: PageTargeting = {}) =>
 	pageTargeting.s === 'crosswords';
 
-const getTeadsPlacementId = (sizes: Size[]): PrebidTeadsParams | undefined => {
+const getTeadsParams = (sizes: Size[]): PrebidTeadsParams | undefined => {
 	const breakpoint = getBreakpointKey();
 	const isDesktop = breakpoint === 'D' || breakpoint === 'T';
 
@@ -388,7 +388,7 @@ const teadsBidder: PrebidBidder = {
 	name: 'teads',
 	switchName: 'prebidTeads',
 	bidParams: (_slotId: string, sizes: Size[]): PrebidTeadsParams => {
-		const params = getTeadsPlacementId(sizes);
+		const params = getTeadsParams(sizes);
 		return params ?? { pageId: 0, placementId: 0 };
 	},
 };
@@ -657,5 +657,5 @@ export const _ = {
 	getTrustXAdUnitId,
 	indexExchangeBidders,
 	getOzonePlacementId,
-	getTeadsPlacementId,
+	getTeadsParams,
 };

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -267,10 +267,11 @@ const isCrosswordPage = (pageTargeting: PageTargeting = {}) =>
 	pageTargeting.s === 'crosswords';
 
 const getTeadsPlacementId = (sizes: Size[]): PrebidTeadsParams | undefined => {
+	const breakpoint = getBreakpointKey();
+	const isDesktop = breakpoint === 'D' || breakpoint === 'T';
+
 	if (isInUk()) {
-		console.log(sizes);
-		// return { pageId: 244722, placementId: 7777 };
-		if (getBreakpointKey() === 'D') {
+		if (isDesktop) {
 			if (
 				containsMpu(sizes) ||
 				containsDmpu(sizes) ||
@@ -281,14 +282,14 @@ const getTeadsPlacementId = (sizes: Size[]): PrebidTeadsParams | undefined => {
 				return { pageId: 244722, placementId: 261612 };
 			}
 		}
-		if (getBreakpointKey() === 'M') {
+		if (breakpoint === 'M') {
 			if (containsMpu(sizes) || containsPortraitInterstitial(sizes)) {
 				return { pageId: 244724, placementId: 261614 };
 			}
 		}
 	}
 	if (isInRow()) {
-		if (getBreakpointKey() === 'D') {
+		if (isDesktop) {
 			if (
 				containsMpu(sizes) ||
 				containsDmpu(sizes) ||
@@ -299,7 +300,7 @@ const getTeadsPlacementId = (sizes: Size[]): PrebidTeadsParams | undefined => {
 				return { pageId: 244725, placementId: 261615 };
 			}
 		}
-		if (getBreakpointKey() === 'M') {
+		if (breakpoint === 'M') {
 			if (containsMpu(sizes) || containsPortraitInterstitial(sizes)) {
 				return { pageId: 244726, placementId: 261616 };
 			}
@@ -309,7 +310,7 @@ const getTeadsPlacementId = (sizes: Size[]): PrebidTeadsParams | undefined => {
 		}
 	}
 	if (isInUsa()) {
-		if (getBreakpointKey() === 'D') {
+		if (isDesktop) {
 			if (
 				containsMpu(sizes) ||
 				containsDmpu(sizes) ||
@@ -320,12 +321,12 @@ const getTeadsPlacementId = (sizes: Size[]): PrebidTeadsParams | undefined => {
 				return { pageId: 244728, placementId: 261618 };
 			}
 		}
-		if (getBreakpointKey() === 'M') {
+		if (breakpoint === 'M') {
 			if (containsMpu(sizes) || containsPortraitInterstitial(sizes)) {
-				return { pageId: 244729, placementId: 261619 }
+				return { pageId: 244729, placementId: 261619 };
 			}
 			if (containsMobileSticky(sizes)) {
-				return { pageId: 244730, placementId: 261620 }
+				return { pageId: 244730, placementId: 261620 };
 			}
 		}
 	}

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -10,6 +10,7 @@ import type { ConsentState } from '@guardian/consent-manager';
 import { log } from '@guardian/libs';
 import type { AdUnitBidDefinition } from 'prebid.js/dist/src/adUnits';
 import type { Size } from 'prebid.js/dist/src/types/common';
+import { isUserInTestGroup } from '../../../../ab-testing';
 import type { PrebidIndexSite } from '../../../../types/global';
 import { dfpEnv } from '../../../dfp/dfp-env';
 import { buildAppNexusTargetingObject } from '../../../page-targeting';
@@ -602,6 +603,10 @@ const currentBidders = (
 	gpid: string,
 	consentState: ConsentState,
 ): PrebidBidder[] => {
+	const isInTeadsTest = isUserInTestGroup(
+		'commercial-teads-prebid',
+		'variant',
+	);
 	const shouldInclude = shouldIncludeBidder(consentState);
 
 	const ixBidders = shouldInclude('ix')
@@ -618,7 +623,7 @@ const currentBidders = (
 		[shouldInclude('ozone'), ozoneBidder(pageTargeting)],
 		[shouldInclude('oxd'), openxBidder(pageTargeting)],
 		[shouldInclude('kargo'), kargoBidder],
-		[shouldInclude('teads'), teadsBidder],
+		[isInTeadsTest && shouldInclude('teads'), teadsBidder],
 		[shouldInclude('rubicon'), magniteBidder],
 		[shouldInclude('ttd'), theTradeDeskBidder(gpid)],
 	];

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -651,4 +651,5 @@ export const _ = {
 	getTrustXAdUnitId,
 	indexExchangeBidders,
 	getOzonePlacementId,
+	getTeadsPlacementId,
 };

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -603,10 +603,10 @@ const currentBidders = (
 	gpid: string,
 	consentState: ConsentState,
 ): PrebidBidder[] => {
-	const isInTeadsTest = isUserInTestGroup(
-		'commercial-teads-prebid',
-		'variant',
-	);
+	// const isInTeadsTest = isUserInTestGroup(
+	// 	'commercial-teads-prebid',
+	// 	'variant',
+	// );
 	const shouldInclude = shouldIncludeBidder(consentState);
 
 	const ixBidders = shouldInclude('ix')
@@ -623,7 +623,7 @@ const currentBidders = (
 		[shouldInclude('ozone'), ozoneBidder(pageTargeting)],
 		[shouldInclude('oxd'), openxBidder(pageTargeting)],
 		[shouldInclude('kargo'), kargoBidder],
-		[isInTeadsTest && shouldInclude('teads'), teadsBidder],
+		[shouldInclude('teads'), teadsBidder],
 		[shouldInclude('rubicon'), magniteBidder],
 		[shouldInclude('ttd'), theTradeDeskBidder(gpid)],
 	];

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -1,6 +1,7 @@
 import {
 	isInAuOrNz,
 	isInRow,
+	isInUk,
 	isInUsa,
 	isInUsOrCa,
 } from '@guardian/commercial-core/geo/geo-utils';
@@ -23,6 +24,7 @@ import type {
 	PrebidOpenXParams,
 	PrebidOzoneParams,
 	PrebidPubmaticParams,
+	PrebidTeadsParams,
 	PrebidTheTradeDeskParams,
 	PrebidTripleLiftParams,
 	PrebidTrustXParams,
@@ -37,6 +39,8 @@ import {
 	containsMobileSticky,
 	containsMpu,
 	containsMpuOrDmpu,
+	containsPortraitInterstitial,
+	containsWS,
 	getBreakpointKey,
 	shouldIncludeBidder,
 	stripDfpAdPrefixFrom,
@@ -262,6 +266,72 @@ const openxBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
 const isCrosswordPage = (pageTargeting: PageTargeting = {}) =>
 	pageTargeting.s === 'crosswords';
 
+const getTeadsPlacementId = (sizes: Size[]): PrebidTeadsParams | undefined => {
+	if (isInUk()) {
+		console.log(sizes);
+		// return { pageId: 244722, placementId: 7777 };
+		if (getBreakpointKey() === 'D') {
+			if (
+				containsMpu(sizes) ||
+				containsDmpu(sizes) ||
+				containsWS(sizes) ||
+				containsLeaderboard(sizes) ||
+				containsBillboard(sizes)
+			) {
+				return { pageId: 244722, placementId: 261612 };
+			}
+		}
+		if (getBreakpointKey() === 'M') {
+			if (containsMpu(sizes) || containsPortraitInterstitial(sizes)) {
+				return { pageId: 244724, placementId: 261614 };
+			}
+		}
+	}
+	if (isInRow()) {
+		if (getBreakpointKey() === 'D') {
+			if (
+				containsMpu(sizes) ||
+				containsDmpu(sizes) ||
+				containsWS(sizes) ||
+				containsLeaderboard(sizes) ||
+				containsBillboard(sizes)
+			) {
+				return { pageId: 244725, placementId: 261615 };
+			}
+		}
+		if (getBreakpointKey() === 'M') {
+			if (containsMpu(sizes) || containsPortraitInterstitial(sizes)) {
+				return { pageId: 244726, placementId: 261616 };
+			}
+			if (containsMobileSticky(sizes)) {
+				return { pageId: 244723, placementId: 261613 };
+			}
+		}
+	}
+	if (isInUsa()) {
+		if (getBreakpointKey() === 'D') {
+			if (
+				containsMpu(sizes) ||
+				containsDmpu(sizes) ||
+				containsWS(sizes) ||
+				containsLeaderboard(sizes) ||
+				containsBillboard(sizes)
+			) {
+				return { pageId: 244728, placementId: 261618 };
+			}
+		}
+		if (getBreakpointKey() === 'M') {
+			if (containsMpu(sizes) || containsPortraitInterstitial(sizes)) {
+				return { pageId: 244729, placementId: 261619 }
+			}
+			if (containsMobileSticky(sizes)) {
+				return { pageId: 244730, placementId: 261620 }
+			}
+		}
+	}
+
+	return undefined;
+};
 const getOzonePlacementId = (
 	sizes: Size[],
 	slotId?: string,
@@ -310,6 +380,15 @@ const getOzonePlacementId = (
 	}
 
 	return '0420420500';
+};
+
+const teadsBidder: PrebidBidder = {
+	name: 'teads',
+	switchName: 'prebidTeads',
+	bidParams: (_slotId: string, sizes: Size[]): PrebidTeadsParams => {
+		const params = getTeadsPlacementId(sizes);
+		return params ?? { pageId: 0, placementId: 0 };
+	},
 };
 
 const ozoneBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
@@ -538,6 +617,7 @@ const currentBidders = (
 		[shouldInclude('ozone'), ozoneBidder(pageTargeting)],
 		[shouldInclude('oxd'), openxBidder(pageTargeting)],
 		[shouldInclude('kargo'), kargoBidder],
+		[shouldInclude('teads'), teadsBidder],
 		[shouldInclude('rubicon'), magniteBidder],
 		[shouldInclude('ttd'), theTradeDeskBidder(gpid)],
 	];

--- a/bundle/src/lib/header-bidding/prebid/modules/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/modules/index.ts
@@ -15,6 +15,7 @@ import 'prebid.js/modules/tripleliftBidAdapter';
 import 'prebid.js/modules/kargoBidAdapter';
 import 'prebid.js/modules/rubiconBidAdapter';
 import 'prebid.js/modules/ttdBidAdapter';
+import 'prebid.js/modules/teadsBidAdapter';
 
 // User IDs
 import 'prebid.js/modules/euidIdSystem';

--- a/bundle/src/lib/header-bidding/utils.spec.ts
+++ b/bundle/src/lib/header-bidding/utils.spec.ts
@@ -310,15 +310,7 @@ describe('Utils', () => {
 				expect(shouldInclude('teads')).toBe(true);
 			});
 
-			test('should be false if user is NOT in AB test variant', () => {
-				window.guardian.config.switches.prebidTeads = true;
-				jest.mocked(isUserInTestGroup).mockReturnValue(false);
-				getLocale.mockReturnValue('GB');
-				getConsentFor.mockReturnValue(true);
-				expect(shouldInclude('teads')).toBe(false);
-			});
-
-			test('should be false if geolocation is not GB', () => {
+			test('should be true if geolocation is in USA or RoW', () => {
 				window.guardian.config.switches.prebidTeads = true;
 				jest.mocked(isUserInTestGroup).mockReturnValue(true);
 				const testGeos: CountryCode[] = [
@@ -328,11 +320,27 @@ describe('Utils', () => {
 					'IM',
 					'JE',
 					'SH',
-					'AU',
 					'US',
-					'CA',
-					'NZ',
 				];
+				for (const testGeo of testGeos) {
+					getLocale.mockReturnValue(testGeo);
+					getConsentFor.mockReturnValue(true);
+					expect(shouldInclude('teads')).toBe(true);
+				}
+			});
+
+			test('should be false if user is NOT in AB test variant', () => {
+				window.guardian.config.switches.prebidTeads = true;
+				jest.mocked(isUserInTestGroup).mockReturnValue(false);
+				getLocale.mockReturnValue('GB');
+				getConsentFor.mockReturnValue(true);
+				expect(shouldInclude('teads')).toBe(false);
+			});
+
+			test('should be false if geolocation is in an unsupported region', () => {
+				window.guardian.config.switches.prebidTeads = true;
+				jest.mocked(isUserInTestGroup).mockReturnValue(true);
+				const testGeos: CountryCode[] = ['AU', 'CA', 'NZ'];
 				for (const testGeo of testGeos) {
 					getLocale.mockReturnValue(testGeo);
 					getConsentFor.mockReturnValue(true);

--- a/bundle/src/lib/header-bidding/utils.spec.ts
+++ b/bundle/src/lib/header-bidding/utils.spec.ts
@@ -5,6 +5,7 @@ import {
 	getConsentFor as getConsentFor_,
 } from '@guardian/consent-manager';
 import type { CountryCode } from '@guardian/libs';
+import { isUserInTestGroup } from '../../ab-testing';
 import type { SourceBreakpoint } from '../detect/detect-breakpoint';
 import {
 	getCurrentTweakpoint as getCurrentTweakpoint_,
@@ -65,6 +66,10 @@ jest.mock('@guardian/commercial-core/geo/get-locale', () => ({
 jest.mock('lib/detect/detect-breakpoint', () => ({
 	getCurrentTweakpoint: jest.fn(() => 'mobile'),
 	matchesBreakpoints: jest.fn(),
+}));
+
+jest.mock('../../ab-testing', () => ({
+	isUserInTestGroup: jest.fn(),
 }));
 
 const resetConfig = () => {
@@ -294,6 +299,53 @@ describe('Utils', () => {
 					getConsentFor.mockReturnValue(true);
 					expect(shouldInclude('xhb')).toBe(false);
 				}
+			});
+		});
+		describe('shouldIncludeTeads', () => {
+			test('should be true if geolocation is GB, in AB test variant, switch on, and consent given', () => {
+				window.guardian.config.switches.prebidTeads = true;
+				jest.mocked(isUserInTestGroup).mockReturnValue(true);
+				getLocale.mockReturnValue('GB');
+				getConsentFor.mockReturnValue(true);
+				expect(shouldInclude('teads')).toBe(true);
+			});
+
+			test('should be false if user is NOT in AB test variant', () => {
+				window.guardian.config.switches.prebidTeads = true;
+				jest.mocked(isUserInTestGroup).mockReturnValue(false);
+				getLocale.mockReturnValue('GB');
+				getConsentFor.mockReturnValue(true);
+				expect(shouldInclude('teads')).toBe(false);
+			});
+
+			test('should be false if geolocation is not GB', () => {
+				window.guardian.config.switches.prebidTeads = true;
+				jest.mocked(isUserInTestGroup).mockReturnValue(true);
+				const testGeos: CountryCode[] = [
+					'FK',
+					'GI',
+					'GG',
+					'IM',
+					'JE',
+					'SH',
+					'AU',
+					'US',
+					'CA',
+					'NZ',
+				];
+				for (const testGeo of testGeos) {
+					getLocale.mockReturnValue(testGeo);
+					getConsentFor.mockReturnValue(true);
+					expect(shouldInclude('teads')).toBe(false);
+				}
+			});
+
+			test('should be false if consent not given', () => {
+				window.guardian.config.switches.prebidTeads = true;
+				jest.mocked(isUserInTestGroup).mockReturnValue(true);
+				getLocale.mockReturnValue('GB');
+				getConsentFor.mockReturnValue(false);
+				expect(shouldInclude('teads')).toBe(false);
 			});
 		});
 	});

--- a/bundle/src/lib/header-bidding/utils.ts
+++ b/bundle/src/lib/header-bidding/utils.ts
@@ -1,6 +1,7 @@
 import {
 	isInAuOrNz,
 	isInCanada,
+	isInRow,
 	isInUk,
 	isInUsa,
 	isInUsOrCa,
@@ -226,7 +227,8 @@ export const shouldIncludeBidder =
 				return (
 					isInTeadsTest &&
 					isSwitchedOn('prebidTeads') &&
-					getConsentFor('teads', consentState)
+					getConsentFor('teads', consentState) &&
+					(isInUk() || isInUsa() || isInRow())
 				);
 		}
 	};

--- a/bundle/src/lib/header-bidding/utils.ts
+++ b/bundle/src/lib/header-bidding/utils.ts
@@ -226,8 +226,7 @@ export const shouldIncludeBidder =
 				return (
 					isInTeadsTest &&
 					isSwitchedOn('prebidTeads') &&
-					getConsentFor('teads', consentState) &&
-					isInUk()
+					getConsentFor('teads', consentState)
 				);
 		}
 	};

--- a/bundle/src/lib/header-bidding/utils.ts
+++ b/bundle/src/lib/header-bidding/utils.ts
@@ -10,6 +10,7 @@ import { getConsentFor } from '@guardian/consent-manager';
 import { isString } from '@guardian/libs';
 import { once } from 'lodash-es';
 import type { Size } from 'prebid.js/dist/src/types/common';
+import { isUserInTestGroup } from '../../ab-testing';
 import {
 	getCurrentTweakpoint,
 	matchesBreakpoints,
@@ -154,6 +155,10 @@ export const isSwitchedOn = (switchName: string): boolean =>
 export const shouldIncludeBidder =
 	(consentState: ConsentState) =>
 	(bidder: BidderCode): boolean => {
+		const isInTeadsTest = isUserInTestGroup(
+			'commercial-teads-prebid',
+			'variant',
+		);
 		switch (bidder) {
 			case 'and':
 				return (
@@ -219,6 +224,7 @@ export const shouldIncludeBidder =
 				);
 			case 'teads':
 				return (
+					isInTeadsTest &&
 					isSwitchedOn('prebidTeads') &&
 					getConsentFor('teads', consentState) &&
 					isInUk()

--- a/bundle/src/lib/header-bidding/utils.ts
+++ b/bundle/src/lib/header-bidding/utils.ts
@@ -217,6 +217,12 @@ export const shouldIncludeBidder =
 					getConsentFor('xandr', consentState) &&
 					isInUk()
 				);
+			case 'teads':
+				return (
+					isSwitchedOn('prebidTeads') &&
+					getConsentFor('teads', consentState) &&
+					isInUk()
+				);
 		}
 	};
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Adds a `teadsBidder` to the Prebid configuration
Includes within it a `getTeadsPlacementId` function to return the correct page and placement ID for the various, sizes, regions and breakpoints.

## Why?
The proposal is to start including Teads as bidder for each Prebid Ad Unit alongside our existing bidders.

We want to use the targeting defined in this sheet Global Placement Mapping so we can map the appropriate pageId and placementId to an Ad Unit's slot sizes.

We are using additional dimensions for targeting in order to select the pageId and placementId:
- Geo (UK, ROW and US) 
- Platform (everything will be ‘web’)
- Device Category (‘Mobile’ or ‘Desktop’)


### Tests

Tested with: http://localhost:3030/Article/https://www.theguardian.com/sport/2023/nov/22/ronnie-osullivan-warns-he-will-quit-snooker-if-he-cannot-play-in-china?ab-commercial-teads-prebid=variant

<img width="400"  alt="Screenshot 2026-05-27 at 14 21 10" src="https://github.com/user-attachments/assets/c4421aa3-6442-4508-a8e6-486b33b1ce08" />

`Teads` request

<img width="500" alt="Screenshot 2026-05-28 at 12 17 10" src="https://github.com/user-attachments/assets/d88c91f6-eeb9-4a9c-91b9-262a12d4aef5" />


