### PR TITLE
adds price floors AB test gate for users outside of holdback test

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/index.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.spec.ts
@@ -606,8 +606,8 @@ describe('Prebid.js bidWon Events', () => {
 });
 describe('isInPrebidFloorPriceTest', () => {
 	/* eslint-disable @typescript-eslint/no-unsafe-assignment -- Jest matchers return any */
-	test('when user is in variant test group, pbjs.setConfig to be called with floor price values', async () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
+	test('when user can use price floors and is not in the variant holdback group, pbjs.setConfig is called with floor price values', async () => {
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
 
 		const setConfigSpy = jest.spyOn(window.pbjs, 'setConfig');
 		await prebid.initialise(window, mockConsentState);
@@ -626,8 +626,8 @@ describe('isInPrebidFloorPriceTest', () => {
 		);
 	});
 	/* eslint-enable @typescript-eslint/no-unsafe-assignment */
-	test('when user is not in variant test group, pbjs.setConfig to be called without floor price values', async () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
+	test('when user is in the variant holdback group, pbjs.setConfig is called without floor price values', async () => {
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
 
 		const setConfigSpy = jest.spyOn(window.pbjs, 'setConfig');
 

--- a/bundle/src/lib/header-bidding/prebid/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.ts
@@ -46,8 +46,9 @@ const initialise = async (
 
 	const userSync: UserSyncConfig = await getUserSyncSettings(consentState);
 
-	const isInPrebidFloorPriceTest = isUserInTestGroup(
-		'commercial-prebid-price-floor',
+	// We're holding back 5% of users, who will not get any price floors applied
+	const canUsePriceFloors = !isUserInTestGroup(
+		'commercial-prebid-price-floor-holdback',
 		'variant',
 	);
 
@@ -58,9 +59,8 @@ const initialise = async (
 		bidderTimeout: PREBID_TIMEOUT,
 		/**
 		 * Applying one global floor price of £0.10 for all bids.
-		 * Initially gated behind an AB test.
 		 */
-		...(isInPrebidFloorPriceTest
+		...(canUsePriceFloors
 			? {
 					floors: {
 						enabled: true,


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
This PR adds an A/B test gate for the Prebid Price Floors feature, ensuring that the appropriate price floor configuration is only passed to window.pbjs.setConfig for users enrolled in the test variant.
## Why?
We want to incrementally roll out different iterations of Prebid Price Floors behind A/B tests. As part of this rollout, 5% of users will remain in the control group without the feature enabled, while the remaining users will receive the Price Floors configuration.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215066183685575