### PR TITLE
Add Permutive consent check to initPermutive

### DIFF
--- a/bundle/src/init/consented/prepare-permutive.spec.ts
+++ b/bundle/src/init/consented/prepare-permutive.spec.ts
@@ -437,10 +437,6 @@ describe('Generating Permutive payload utils', () => {
 			window.guardian.config.switches.permutive = true;
 		});
 
-		afterEach(() => {
-			window.guardian.config.switches.permutive = false;
-		});
-
 		it('does not call getEmail when Permutive consent is not granted', async () => {
 			mockOnConsent({ canTarget: false, framework: null });
 			mockGetConsentFor(false);

--- a/bundle/src/init/consented/prepare-permutive.spec.ts
+++ b/bundle/src/init/consented/prepare-permutive.spec.ts
@@ -1,5 +1,7 @@
+import type { ConsentState } from '@guardian/consent-manager';
+import { getConsentFor, onConsent } from '@guardian/consent-manager';
 import type { Edition } from '../../types/global';
-import { _ } from './prepare-permutive';
+import { _, initPermutive } from './prepare-permutive';
 
 const testPageConfig = {
 	pageId: 'world/2019/nov/29',
@@ -27,6 +29,11 @@ const testOphanConfig = {
 	pageViewId: 'pageViewId',
 	browserId: 'browserId',
 };
+
+jest.mock('@guardian/consent-manager', () => ({
+	getConsentFor: jest.fn().mockReturnValue(true),
+	onConsent: jest.fn(),
+}));
 
 jest.mock('../../lib/identity/api', () => ({
 	getEmail: jest.fn().mockResolvedValue(null),
@@ -417,6 +424,33 @@ describe('Generating Permutive payload utils', () => {
 			await _.runPermutive(validConfigForPayload, mockPermutive);
 			expect(mockPermutive.identify).not.toHaveBeenCalled();
 			expect(logger).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('initPermutive', () => {
+		const mockOnConsent = (consentState: ConsentState) =>
+			(onConsent as jest.Mock).mockResolvedValue(consentState);
+		const mockGetConsentFor = (hasConsent: boolean) =>
+			(getConsentFor as jest.Mock).mockReturnValue(hasConsent);
+
+		beforeEach(() => {
+			window.guardian.config.switches.permutive = true;
+		});
+
+		afterEach(() => {
+			window.guardian.config.switches.permutive = false;
+		});
+
+		it('does not call getEmail when Permutive consent is not granted', async () => {
+			mockOnConsent({ canTarget: false, framework: null });
+			mockGetConsentFor(false);
+			const getEmail = jest.requireMock<{ getEmail: jest.Mock }>(
+				'../../lib/identity/api',
+			).getEmail;
+
+			await initPermutive();
+
+			expect(getEmail).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/bundle/src/init/consented/prepare-permutive.ts
+++ b/bundle/src/init/consented/prepare-permutive.ts
@@ -1,4 +1,5 @@
 import { hashEmailForClient } from '@guardian/commercial-core/email-hash';
+import { getConsentFor, onConsent } from '@guardian/consent-manager';
 import { log } from '@guardian/libs';
 import { reportError } from '../../lib/error/report-error';
 import { getEmail } from '../../lib/identity/api';
@@ -162,8 +163,6 @@ const runPermutive = async (
 		if (!permutiveGlobal?.addon) {
 			throw new Error('Global Permutive setup error');
 		}
-		// TODO: Consider adding a consent gate here using getConsentFor('permutive', consentState)
-		// to ensure Permutive only runs when the user has granted targeting consent.
 
 		const identities = await generatePermutiveIdentities(pageConfig);
 
@@ -264,12 +263,19 @@ const initPermutiveSegmentation = async () => {
 	await runPermutive(permutiveConfig, window.permutive);
 };
 
-export const initPermutive = () => {
-	if (window.guardian.config.switches.permutive) {
-		void initPermutiveSegmentation();
-	}
-	return Promise.resolve();
-};
+export const initPermutive = () =>
+	onConsent()
+		.then((consentState) => {
+			if (
+				window.guardian.config.switches.permutive &&
+				getConsentFor('permutive', consentState)
+			) {
+				return initPermutiveSegmentation();
+			}
+		})
+		.catch((e) => {
+			log('commercial', '⚠️ Failed to execute Permutive', e);
+		});
 
 export const _ = {
 	isEmpty,


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Added a `getConsentFor('permutive', consentState)` check inside `initPermutive`, following the same pattern already [used by A9](https://github.com/guardian/commercial/blob/main/bundle/src/init/consented/prepare-a9.ts#L43). If a user specifically opts out of Permutive, all related setup is skipped.

## Why?
Ensure privacy/GDPR is comprehensively respected

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213805716944216