### PR TITLE
update the prebid-price-floor abTest naming from variant to `holdback`

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.ts
@@ -49,7 +49,7 @@ const initialise = async (
 	// We're holding back 5% of users, who will not get any price floors applied
 	const canUsePriceFloors = !isUserInTestGroup(
 		'commercial-prebid-price-floor-holdback',
-		'variant',
+		'holdback',
 	);
 
 	window.pbjs.setConfig({


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Updates the the "variant" naming for the holdback group to "holdback"
## Why?
We thought it might be clearer to rename the variant naming for clarity and be inline with the DCR ABTest config