### PR TITLE
Add US-specific IntentIQ gating for ID and analytics with tests

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/id-handlers/intent-iq.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/intent-iq.spec.ts
@@ -101,3 +101,74 @@ describe('getUserIdForIntentIQ - when user is NOT in test group', () => {
 		expect(result).toEqual(undefined);
 	});
 });
+
+describe('getUserIdForIntentIQ - when user is in US region test group', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+	test('when locale is US and US experiment is variant', async () => {
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false); // isUserInTestGroupIntentIQ
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true); // isUserInTestGroupIntentIQForUS
+		jest.mocked(getLocale).mockReturnValue('US');
+
+		const result = await getUserIdForIntentIQ();
+
+		expect(result).toEqual({
+			name: 'intentIqId',
+			params: {
+				partner: 377078111,
+				gamObjectReference: {},
+			},
+			storage: {
+				type: 'html5',
+				name: 'intentIqId',
+				expires: 0,
+				refreshInSeconds: 0,
+			},
+		});
+	});
+	test('when locale is US and both experiments are variant', async () => {
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true); // isUserInTestGroupIntentIQ
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true); // isUserInTestGroupIntentIQForUS
+		jest.mocked(getLocale).mockReturnValue('US');
+
+		const result = await getUserIdForIntentIQ();
+
+		expect(result).toEqual({
+			name: 'intentIqId',
+			params: {
+				partner: 377078111,
+				gamObjectReference: {},
+			},
+			storage: {
+				type: 'html5',
+				name: 'intentIqId',
+				expires: 0,
+				refreshInSeconds: 0,
+			},
+		});
+	});
+});
+describe('getUserIdForIntentIQ - when user is not in US region test group', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+	test('when locale is US and US experiment is control', async () => {
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false); // isUserInTestGroupIntentIQ
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false); // isUserInTestGroupIntentIQForUS
+		jest.mocked(getLocale).mockReturnValueOnce('US');
+
+		const result = await getUserIdForIntentIQ();
+
+		expect(result).toEqual(undefined);
+	});
+	test('when locale is US and only global experiment is variant', async () => {
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true); // isUserInTestGroupIntentIQ
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false); // isUserInTestGroupIntentIQForUS
+		jest.mocked(getLocale).mockReturnValueOnce('US');
+
+		const result = await getUserIdForIntentIQ();
+
+		expect(result).toEqual(undefined);
+	});
+});

--- a/bundle/src/lib/header-bidding/prebid/id-handlers/intent-iq.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/intent-iq.spec.ts
@@ -1,3 +1,4 @@
+import { isInUsa } from '@guardian/commercial-core/geo/geo-utils';
 import { getLocale } from '@guardian/commercial-core/geo/get-locale';
 import { isUserInTestGroup } from '../../../../ab-testing';
 import { getUserIdForIntentIQ } from './intent-iq';
@@ -7,6 +8,9 @@ jest.mock('../../../../ab-testing', () => ({
 }));
 jest.mock('@guardian/commercial-core/geo/get-locale');
 
+jest.mock('@guardian/commercial-core/geo/geo-utils', () => ({
+	isInUsa: jest.fn(),
+}));
 // @ts-expect-error -- mock global googletag
 global.googletag = {};
 
@@ -102,14 +106,14 @@ describe('getUserIdForIntentIQ - when user is NOT in test group', () => {
 	});
 });
 
-describe('getUserIdForIntentIQ - when user is in US region test group', () => {
+describe('getUserIdForIntentIQ - when US user not in holdback', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
 	});
-	test('when locale is US and US experiment is variant', async () => {
+	test('when locale is US and US experiment is holdback', async () => {
 		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false); // isUserInTestGroupIntentIQ
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true); // isUserInTestGroupIntentIQForUS
-		jest.mocked(getLocale).mockReturnValue('US');
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false); // canRunIntentIqInUS
+		jest.mocked(isInUsa).mockReturnValue(true);
 
 		const result = await getUserIdForIntentIQ();
 
@@ -127,10 +131,10 @@ describe('getUserIdForIntentIQ - when user is in US region test group', () => {
 			},
 		});
 	});
-	test('when locale is US and both experiments are variant', async () => {
+	test('when locale is US and user is in first experiment and not in holdback', async () => {
 		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true); // isUserInTestGroupIntentIQ
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true); // isUserInTestGroupIntentIQForUS
-		jest.mocked(getLocale).mockReturnValue('US');
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false); // canRunIntentIqInUS
+		jest.mocked(isInUsa).mockReturnValue(true);
 
 		const result = await getUserIdForIntentIQ();
 
@@ -149,23 +153,23 @@ describe('getUserIdForIntentIQ - when user is in US region test group', () => {
 		});
 	});
 });
-describe('getUserIdForIntentIQ - when user is not in US region test group', () => {
+describe('getUserIdForIntentIQ - when user is in US and in test holdback group', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
 	});
-	test('when locale is US and US experiment is control', async () => {
+	test('when locale is US and US experiment is in holdback', async () => {
 		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false); // isUserInTestGroupIntentIQ
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false); // isUserInTestGroupIntentIQForUS
-		jest.mocked(getLocale).mockReturnValueOnce('US');
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true); // canRunIntentIqInUS
+		jest.mocked(isInUsa).mockReturnValueOnce(true);
 
 		const result = await getUserIdForIntentIQ();
 
 		expect(result).toEqual(undefined);
 	});
-	test('when locale is US and only global experiment is variant', async () => {
+	test('when locale is US and only global experiment is variant and also in holdback', async () => {
 		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true); // isUserInTestGroupIntentIQ
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false); // isUserInTestGroupIntentIQForUS
-		jest.mocked(getLocale).mockReturnValueOnce('US');
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true); // canRunIntentIqInUS
+		jest.mocked(isInUsa).mockReturnValueOnce(true);
 
 		const result = await getUserIdForIntentIQ();
 

--- a/bundle/src/lib/header-bidding/prebid/id-handlers/intent-iq.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/intent-iq.ts
@@ -2,9 +2,9 @@ import { getLocale } from '@guardian/commercial-core/geo/get-locale';
 import type { UserIdConfig } from 'prebid.js/dist/modules/userId/spec';
 import { isUserInTestGroup } from '../../../../ab-testing';
 
-//IntentIQ do not support every country, it's recommended if we cap them to the countries listed
+//IntentIQ does not support every country, it's recommended if we cap them to the countries listed
+// US has been removed from the non-EU region list for testing purposes and is handled separately.
 const intentIQNonEURegions = [
-	'US',
 	'CA',
 	'AU',
 	'NZ',
@@ -25,7 +25,7 @@ const allowedIntentIQRegions = [...intentIQEURegions, ...intentIQNonEURegions];
 const isUserInIntentIQRegion = () =>
 	allowedIntentIQRegions.includes(getLocale());
 const isUserInAllowedEURegion = () => intentIQEURegions.includes(getLocale());
-
+const isUserInUSRegion = () => getLocale() === 'US';
 const EU_PARTNER_ID = 946158046;
 const NON_EU_PARTNER_ID = 377078111;
 
@@ -36,8 +36,16 @@ const getUserIdForIntentIQ = async (): Promise<
 		'commercial-user-module-intentIq',
 		'variant',
 	);
+	const isUserInTestGroupIntentIQForUS = isUserInTestGroup(
+		'commercial-user-module-intentIq-us-region',
+		'variant',
+	);
 	const isEU = isUserInAllowedEURegion();
-	if (isUserInTestGroupIntentIQ && isUserInIntentIQRegion()) {
+	const isUS = isUserInUSRegion();
+	if (
+		(isUserInTestGroupIntentIQ && isUserInIntentIQRegion()) ||
+		(isUS && isUserInTestGroupIntentIQForUS)
+	) {
 		return Promise.resolve({
 			name: 'intentIqId',
 			params: {

--- a/bundle/src/lib/header-bidding/prebid/id-handlers/intent-iq.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/intent-iq.ts
@@ -1,3 +1,4 @@
+import { isInUsa } from '@guardian/commercial-core/geo/geo-utils';
 import { getLocale } from '@guardian/commercial-core/geo/get-locale';
 import type { UserIdConfig } from 'prebid.js/dist/modules/userId/spec';
 import { isUserInTestGroup } from '../../../../ab-testing';
@@ -25,7 +26,6 @@ const allowedIntentIQRegions = [...intentIQEURegions, ...intentIQNonEURegions];
 const isUserInIntentIQRegion = () =>
 	allowedIntentIQRegions.includes(getLocale());
 const isUserInAllowedEURegion = () => intentIQEURegions.includes(getLocale());
-const isUserInUSRegion = () => getLocale() === 'US';
 const EU_PARTNER_ID = 946158046;
 const NON_EU_PARTNER_ID = 377078111;
 
@@ -36,15 +36,17 @@ const getUserIdForIntentIQ = async (): Promise<
 		'commercial-user-module-intentIq',
 		'variant',
 	);
-	const isUserInTestGroupIntentIQForUS = isUserInTestGroup(
+	/**
+	 * Released to all audience apart from holdback group in the US
+	 */
+	const canRunIntentIqInUS = !isUserInTestGroup(
 		'commercial-user-module-intentIq-us-region',
-		'variant',
+		'holdback',
 	);
 	const isEU = isUserInAllowedEURegion();
-	const isUS = isUserInUSRegion();
 	if (
 		(isUserInTestGroupIntentIQ && isUserInIntentIQRegion()) ||
-		(isUS && isUserInTestGroupIntentIQForUS)
+		(canRunIntentIqInUS && isInUsa())
 	) {
 		return Promise.resolve({
 			name: 'intentIqId',

--- a/bundle/src/lib/header-bidding/prebid/intent-iq-analytics.ts
+++ b/bundle/src/lib/header-bidding/prebid/intent-iq-analytics.ts
@@ -1,4 +1,4 @@
-import { getLocale } from '@guardian/commercial-core/geo/get-locale';
+import { isInUsa } from '@guardian/commercial-core/geo/geo-utils';
 import type { ConsentState } from '@guardian/consent-manager';
 import { getConsentFor } from '@guardian/consent-manager';
 import type { AnalyticsConfig } from 'prebid.js/dist/libraries/analyticsAdapter/AnalyticsAdapter';
@@ -15,12 +15,10 @@ const isUserInTestGroupIntentIQ = isUserInTestGroup(
 	'variant',
 );
 
-const isUserInTestGroupIntentIQForUS = isUserInTestGroup(
+const canRunIntentIqInUS = !isUserInTestGroup(
 	'commercial-user-module-intentIq-us-region',
-	'variant',
+	'holdback',
 );
-
-const isUserInUSRegion = () => getLocale() === 'US';
 
 export const getIntentIQAnalyticsConfig = (
 	consentState: ConsentState,
@@ -31,7 +29,7 @@ export const getIntentIQAnalyticsConfig = (
 	const isNonUSEligible =
 		isUserInTestGroupIntentIQ && isUserInIntentIQRegion();
 
-	const isUSEligible = isUserInTestGroupIntentIQForUS && isUserInUSRegion();
+	const isUSEligible = canRunIntentIqInUS && isInUsa();
 
 	const enabledAnalytics = (isNonUSEligible || isUSEligible) && hasConsent;
 

--- a/bundle/src/lib/header-bidding/prebid/intent-iq-analytics.ts
+++ b/bundle/src/lib/header-bidding/prebid/intent-iq-analytics.ts
@@ -1,3 +1,4 @@
+import { getLocale } from '@guardian/commercial-core/geo/get-locale';
 import type { ConsentState } from '@guardian/consent-manager';
 import { getConsentFor } from '@guardian/consent-manager';
 import type { AnalyticsConfig } from 'prebid.js/dist/libraries/analyticsAdapter/AnalyticsAdapter';
@@ -14,15 +15,27 @@ const isUserInTestGroupIntentIQ = isUserInTestGroup(
 	'variant',
 );
 
+const isUserInTestGroupIntentIQForUS = isUserInTestGroup(
+	'commercial-user-module-intentIq-us-region',
+	'variant',
+);
+
+const isUserInUSRegion = () => getLocale() === 'US';
+
 export const getIntentIQAnalyticsConfig = (
 	consentState: ConsentState,
 ): AnalyticsConfig<'iiqAnalytics'> | undefined => {
 	const isEU = isUserInAllowedEURegion();
-	if (
-		isUserInTestGroupIntentIQ &&
-		getConsentFor('intentIQ', consentState) &&
-		isUserInIntentIQRegion()
-	) {
+	const hasConsent = getConsentFor('intentIQ', consentState);
+
+	const isNonUSEligible =
+		isUserInTestGroupIntentIQ && isUserInIntentIQRegion();
+
+	const isUSEligible = isUserInTestGroupIntentIQForUS && isUserInUSRegion();
+
+	const enabledAnalytics = (isNonUSEligible || isUSEligible) && hasConsent;
+
+	if (enabledAnalytics) {
 		return {
 			provider: 'iiqAnalytics',
 			options: {


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Adds US region holdback gating for the IntentIQ user ID and analytics. 

## Why?
IntentIQ is currently enabled through the existing experiment setup across regions.
For the US, we now want a dedicated holdback model so that:

**Expected traffic split**
US:

Control: 5% -> 5%
Variant: 5% -> 95%
All other regions:

Control: unchanged at 5%
Variant: unchanged at 5%

This PR also updates tests to cover US holdback and non-holdback paths.