### PR TITLE
Update IntentIQ US test exposure and refine naming for consistency

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/intent-iq-analytics.ts
+++ b/bundle/src/lib/header-bidding/prebid/intent-iq-analytics.ts
@@ -10,7 +10,7 @@ import {
 	NON_EU_PARTNER_ID,
 } from './id-handlers/intent-iq';
 
-const isUserInTestGroupIntentIQ = isUserInTestGroup(
+const canRunIntentIqInAllowedRegions = isUserInTestGroup(
 	'commercial-user-module-intentIq',
 	'variant',
 );
@@ -27,7 +27,7 @@ export const getIntentIQAnalyticsConfig = (
 	const hasConsent = getConsentFor('intentIQ', consentState);
 
 	const isNonUSEligible =
-		isUserInTestGroupIntentIQ && isUserInIntentIQRegion();
+		canRunIntentIqInAllowedRegions && isUserInIntentIQRegion();
 
 	const isUSEligible = canRunIntentIqInUS && isInUsa();
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Updates naming of test group inclusion group: isUserInTestGroupIntentIQ > canRunIntentIqInAllowedRegions
## Why?
This updates the variable naming of the allowed groups in the intentIQ test groups for consistency with the naming of those not in the test groups, so its similar to `canRunIntentIqInUS`