### PR TITLE
rename intentIQ test name to deal with truncation in GAM

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/id-handlers/intent-iq.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/intent-iq.ts
@@ -40,7 +40,7 @@ const getUserIdForIntentIQ = async (): Promise<
 	 * Released to all audience apart from holdback group in the US
 	 */
 	const canRunIntentIqInUS = !isUserInTestGroup(
-		'commercial-user-module-intentIq-us-region',
+		'commercial-user-module-intentIq-us',
 		'holdback',
 	);
 	const isEU = isUserInAllowedEURegion();

--- a/bundle/src/lib/header-bidding/prebid/intent-iq-analytics.ts
+++ b/bundle/src/lib/header-bidding/prebid/intent-iq-analytics.ts
@@ -16,7 +16,7 @@ const canRunIntentIqInAllowedRegions = isUserInTestGroup(
 );
 
 const canRunIntentIqInUS = !isUserInTestGroup(
-	'commercial-user-module-intentIq-us-region',
+	'commercial-user-module-intentIq-us',
 	'holdback',
 );
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Renaming the test config name: `commercial-user-module-intentIq-us-region` > `commercial-user-module-intentIq-us`
## Why?
The previous key is too long for reliable GAM reporting breakout.
Shortening the key allows GAM to report this experiment dimension correctly while keeping behavior unchanged.