### PR TITLE
Add LiveRamp ATS Analytics adapter to Prebid

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/id-handlers/liveramp.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/liveramp.ts
@@ -109,3 +109,4 @@ export const getUserIdForLiveRamp = async (
 };
 
 export type { LiverampUserIdConfig };
+export { ATS_PLACEMENT_ID };

--- a/bundle/src/lib/header-bidding/prebid/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.ts
@@ -33,6 +33,7 @@ import { consentManagement } from './consent-management';
 import { configurePermutive } from './external/permutive';
 import { getUserSyncSettings } from './id-handlers';
 import { getIntentIQAnalyticsConfig } from './intent-iq-analytics';
+import { getLiveRampATSAnalyticsConfig } from './liveramp-ats-analytics';
 import { PrebidAdUnit } from './prebid-ad-unit';
 import { priceGranularity } from './price-config';
 
@@ -133,6 +134,10 @@ const initialise = async (
 	const intentIQAnalytics = getIntentIQAnalyticsConfig(consentState);
 	if (intentIQAnalytics) {
 		analytics.push(intentIQAnalytics);
+	}
+	const liveRampATSAnalytics = getLiveRampATSAnalyticsConfig(consentState);
+	if (liveRampATSAnalytics) {
+		analytics.push(liveRampATSAnalytics);
 	}
 	window.pbjs.enableAnalytics(analytics);
 

--- a/bundle/src/lib/header-bidding/prebid/liveramp-ats-analytics.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/liveramp-ats-analytics.spec.ts
@@ -1,0 +1,62 @@
+import type { ConsentState } from '@guardian/consent-manager';
+import { getConsentFor } from '@guardian/consent-manager';
+import { isSwitchedOn } from '../utils';
+import { ATS_PLACEMENT_ID } from './id-handlers/liveramp';
+import { getLiveRampATSAnalyticsConfig } from './liveramp-ats-analytics';
+
+jest.mock('@guardian/consent-manager', () => ({
+	getConsentFor: jest.fn(),
+}));
+
+jest.mock('../utils', () => ({
+	isSwitchedOn: jest.fn(),
+}));
+
+const mockConsentState = {} as ConsentState;
+
+describe('getLiveRampATSAnalyticsConfig', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	test('returns config when switch is on and consent is given', () => {
+		jest.mocked(isSwitchedOn).mockReturnValue(true);
+		jest.mocked(getConsentFor).mockReturnValue(true);
+
+		const result = getLiveRampATSAnalyticsConfig(mockConsentState);
+
+		expect(result).toEqual({
+			provider: 'atsAnalytics',
+			options: {
+				pid: String(ATS_PLACEMENT_ID),
+			},
+		});
+	});
+
+	test('returns undefined when switch is off', () => {
+		jest.mocked(isSwitchedOn).mockReturnValue(false);
+		jest.mocked(getConsentFor).mockReturnValue(true);
+
+		const result = getLiveRampATSAnalyticsConfig(mockConsentState);
+
+		expect(result).toBeUndefined();
+	});
+
+	test('returns undefined when consent is not given', () => {
+		jest.mocked(isSwitchedOn).mockReturnValue(true);
+		jest.mocked(getConsentFor).mockReturnValue(false);
+
+		const result = getLiveRampATSAnalyticsConfig(mockConsentState);
+
+		expect(result).toBeUndefined();
+	});
+
+	test('returns undefined when both switch is off and consent is not given', () => {
+		jest.mocked(isSwitchedOn).mockReturnValue(false);
+		jest.mocked(getConsentFor).mockReturnValue(false);
+
+		const result = getLiveRampATSAnalyticsConfig(mockConsentState);
+
+		expect(result).toBeUndefined();
+	});
+});

--- a/bundle/src/lib/header-bidding/prebid/liveramp-ats-analytics.ts
+++ b/bundle/src/lib/header-bidding/prebid/liveramp-ats-analytics.ts
@@ -1,0 +1,21 @@
+import type { ConsentState } from '@guardian/consent-manager';
+import { getConsentFor } from '@guardian/consent-manager';
+import type { AnalyticsConfig } from 'prebid.js/dist/libraries/analyticsAdapter/AnalyticsAdapter';
+import { isSwitchedOn } from '../utils';
+import { ATS_PLACEMENT_ID } from './id-handlers/liveramp';
+
+export const getLiveRampATSAnalyticsConfig = (
+	consentState: ConsentState,
+): AnalyticsConfig<'atsAnalytics'> | undefined => {
+	const isEnabled = isSwitchedOn('prebidLiveramp');
+	const hasConsent = getConsentFor('liveramp', consentState);
+
+	if (isEnabled && hasConsent) {
+		return {
+			provider: 'atsAnalytics',
+			options: {
+				pid: String(ATS_PLACEMENT_ID),
+			},
+		};
+	}
+};

--- a/bundle/src/lib/header-bidding/prebid/modules/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/modules/index.ts
@@ -27,6 +27,7 @@ import 'prebid.js/modules/uid2IdSystem';
 import 'prebid.js/modules/userId';
 import 'prebid.js/modules/intentIqIdSystem';
 import 'prebid.js/modules/intentIqAnalyticsAdapter';
+import 'prebid.js/modules/atsAnalyticsAdapter';
 
 // Real time data
 import 'prebid.js/modules/rtdModule';


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

Enables the LiveRamp ATS Analytics adapter in Prebid.js to allow reporting on header bidding performance metrics.

Added `getLiveRampATSAnalyticsConfig` a new analytics config helper gated behind the existing `prebidLiveramp` switch and `liveramp` consent, following the same pattern as `getIntentIQAnalyticsConfig` and wired the config into `pbjs.enableAnalytics` alongside the existing GU and IntentIQ adapters.

append `?pbjs_debug=true` to url to test

<img width="489" height="255" alt="image" src="https://github.com/user-attachments/assets/636255a4-1076-457f-9af1-068f0b8292dc" />






---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215177503072018