### PR TITLE
enables mobile-sticky on US liveblog articles

### DIFF
--- a/bundle/src/lib/header-bidding/utils.spec.ts
+++ b/bundle/src/lib/header-bidding/utils.spec.ts
@@ -441,6 +441,22 @@ describe('Utils', () => {
 			},
 		);
 
+		test('should be true for US LiveBlog on mobile when user is not in holdback', () => {
+			window.guardian.config.page.contentType = 'LiveBlog';
+			getLocale.mockReturnValue('US');
+			matchesBreakpoints.mockReturnValue(true);
+			jest.mocked(isUserInTestGroup).mockReturnValue(false);
+			expect(shouldIncludeMobileSticky()).toBe(true);
+		});
+
+		test('should be false for US LiveBlog on mobile when user is in holdback', () => {
+			window.guardian.config.page.contentType = 'LiveBlog';
+			getLocale.mockReturnValue('US');
+			matchesBreakpoints.mockReturnValue(true);
+			jest.mocked(isUserInTestGroup).mockReturnValue(true);
+			expect(shouldIncludeMobileSticky()).toBe(false);
+		});
+
 		test('should be false if all conditions true except pageId or content type ', () => {
 			window.guardian.config.page.contentType = 'Network Front';
 			window.guardian.config.page.pageId = 'lifeandstyle/';

--- a/bundle/src/lib/header-bidding/utils.ts
+++ b/bundle/src/lib/header-bidding/utils.ts
@@ -248,6 +248,8 @@ export const shouldIncludeMobileSticky = once(
 		}) &&
 			!isInUk() &&
 			(isValidPageForMobileSticky() ||
+				// We intentionally use variant as the holdback arm for this test.
+				// Only users not in variant are eligible for this LiveBlog US mobile-sticky path.
 				(!isUserInTestGroup(
 					'commercial-mobile-sticky-liveblog-us',
 					'variant',

--- a/bundle/src/lib/header-bidding/utils.ts
+++ b/bundle/src/lib/header-bidding/utils.ts
@@ -50,15 +50,6 @@ const isValidPageForMobileSticky = (): boolean => {
 	);
 };
 
-const isLiveBlogPageInUs = (): boolean => {
-	const { contentType } = window.guardian.config.page;
-	return contentType === 'LiveBlog' && isInUsa();
-};
-
-// Use a holdback AB test: users in holdback do not get mobile-sticky on eligible US LiveBlog pages.
-const isMobileStickyLiveblogUsEnabled = (): boolean =>
-	!isUserInTestGroup('commercial-mobile-sticky-liveblog-us', 'holdback');
-
 /**
  * Cleans an object for targetting. Removes empty strings and other falsy values.
  * @param o object with falsy values
@@ -257,7 +248,12 @@ export const shouldIncludeMobileSticky = once(
 		}) &&
 			!isInUk() &&
 			(isValidPageForMobileSticky() ||
-				(isMobileStickyLiveblogUsEnabled() && isLiveBlogPageInUs())) &&
+				(!isUserInTestGroup(
+					'commercial-mobile-sticky-liveblog-us',
+					'variant',
+				) &&
+					window.guardian.config.page.contentType === 'LiveBlog' &&
+					isInUsa())) &&
 			!window.guardian.config.page.isHosted),
 );
 

--- a/bundle/src/lib/header-bidding/utils.ts
+++ b/bundle/src/lib/header-bidding/utils.ts
@@ -50,6 +50,15 @@ const isValidPageForMobileSticky = (): boolean => {
 	);
 };
 
+const isLiveBlogPageInUs = (): boolean => {
+	const { contentType } = window.guardian.config.page;
+	return contentType === 'LiveBlog' && isInUsa();
+};
+
+// Use a holdback AB test: users in holdback do not get mobile-sticky on eligible US LiveBlog pages.
+const isMobileStickyLiveblogUsEnabled = (): boolean =>
+	!isUserInTestGroup('commercial-mobile-sticky-liveblog-us', 'holdback');
+
 /**
  * Cleans an object for targetting. Removes empty strings and other falsy values.
  * @param o object with falsy values
@@ -247,7 +256,8 @@ export const shouldIncludeMobileSticky = once(
 			max: 'mobileLandscape',
 		}) &&
 			!isInUk() &&
-			isValidPageForMobileSticky() &&
+			(isValidPageForMobileSticky() ||
+				(isMobileStickyLiveblogUsEnabled() && isLiveBlogPageInUs())) &&
 			!window.guardian.config.page.isHosted),
 );
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->
## What does this change?
This change extends mobile-sticky ad eligibility to US LiveBlog pages.

- Adds a dedicated US LiveBlog eligibility check.
- Keeps existing mobile-sticky eligibility logic unchanged for current supported page types.
- Gates the US LiveBlog path behind the `commercial-mobile-sticky-liveblog-us` AB test.
- Uses a holdback setup so users in the holdback variant do not receive mobile-sticky on US LiveBlog pages.


## Why?
We want to safely roll out mobile-sticky ads on US LiveBlog pages while preserving existing behaviour elsewhere.
A 5% holdback lets us compare outcomes against a control group before wider rollout.