### PR TITLE
Bump ophan tracker to v5

### DIFF
--- a/bundle/package.json
+++ b/bundle/package.json
@@ -47,7 +47,7 @@
 		"@guardian/identity-auth": "16.0.0",
 		"@guardian/identity-auth-frontend": "18.0.0",
 		"@guardian/libs": "32.0.0",
-		"@guardian/ophan-tracker-js": "0.0.0-canary-20260622142809",
+		"@guardian/ophan-tracker-js": "5.0.0",
 		"@guardian/source": "12.2.1",
 		"@playwright/test": "1.60.0",
 		"@types/google-publisher-tag": "1.20260420.0",

--- a/bundle/package.json
+++ b/bundle/package.json
@@ -47,7 +47,7 @@
 		"@guardian/identity-auth": "16.0.0",
 		"@guardian/identity-auth-frontend": "18.0.0",
 		"@guardian/libs": "32.0.0",
-		"@guardian/ophan-tracker-js": "3.0.0",
+		"@guardian/ophan-tracker-js": "0.0.0-canary-20260622142809",
 		"@guardian/source": "12.2.1",
 		"@playwright/test": "1.60.0",
 		"@types/google-publisher-tag": "1.20260420.0",

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
 		"@guardian/consent-manager": "1.0.0"
 	},
 	"devDependencies": {
-		"@guardian/ophan-tracker-js": "3.0.0",
+		"@guardian/ophan-tracker-js": "0.0.0-canary-20260622142809",
 		"@types/jest": "30.0.0",
 		"@types/node": "25.6.0",
 		"jest": "30.3.0",

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
 		"@guardian/consent-manager": "1.0.0"
 	},
 	"devDependencies": {
-		"@guardian/ophan-tracker-js": "0.0.0-canary-20260622142809",
+		"@guardian/ophan-tracker-js": "5.0.0",
 		"@types/jest": "30.0.0",
 		"@types/node": "25.6.0",
 		"jest": "30.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,22 +85,22 @@ importers:
         version: link:../core
       '@guardian/consent-manager':
         specifier: 1.0.0
-        version: 1.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)
+        version: 1.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/core-web-vitals':
         specifier: 20.0.0
-        version: 20.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)(web-vitals@5.2.0)
+        version: 20.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)(web-vitals@5.2.0)
       '@guardian/identity-auth':
         specifier: 16.0.0
-        version: 16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)
+        version: 16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/identity-auth-frontend':
         specifier: 18.0.0
-        version: 18.0.0(@guardian/identity-auth@16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)
+        version: 18.0.0(@guardian/identity-auth@16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/libs':
         specifier: 32.0.0
-        version: 32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)
+        version: 32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/ophan-tracker-js':
-        specifier: 0.0.0-canary-20260622142809
-        version: 0.0.0-canary-20260622142809
+        specifier: 5.0.0
+        version: 5.0.0
       '@guardian/source':
         specifier: 12.2.1
         version: 12.2.1(tslib@2.8.1)(typescript@5.9.3)
@@ -211,14 +211,14 @@ importers:
     dependencies:
       '@guardian/consent-manager':
         specifier: 1.0.0
-        version: 1.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)
+        version: 1.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/libs':
         specifier: 32.0.0
-        version: 32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)
+        version: 32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3)
     devDependencies:
       '@guardian/ophan-tracker-js':
-        specifier: 0.0.0-canary-20260622142809
-        version: 0.0.0-canary-20260622142809
+        specifier: 5.0.0
+        version: 5.0.0
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
@@ -1126,8 +1126,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/ophan-tracker-js@0.0.0-canary-20260622142809':
-    resolution: {integrity: sha512-pTORQe4S7axSxAlLWjhwYGDKCMea00uo7a3VryUSknoKH61mUI7EdHM72nmBJdWbGvXFdAP4NnQNlzgcZLk1TQ==}
+  '@guardian/ophan-tracker-js@5.0.0':
+    resolution: {integrity: sha512-mUzRsr25A8K5pCaisNQctt3lFEAm7SC4KTbglbyu7FkCDVaTuiNMz3jgj9LcPpQw/csPMdEEe2nUpqCiqCZlHA==}
     engines: {node: '>=16'}
 
   '@guardian/prettier@10.0.0':
@@ -6677,17 +6677,17 @@ snapshots:
       browserslist: 4.28.2
       tslib: 2.8.1
 
-  '@guardian/consent-manager@1.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)':
+  '@guardian/consent-manager@1.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
-      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)
-      '@guardian/ophan-tracker-js': 0.0.0-canary-20260622142809
+      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3)
+      '@guardian/ophan-tracker-js': 5.0.0
       tslib: 2.8.1
     optionalDependencies:
       typescript: 5.9.3
 
-  '@guardian/core-web-vitals@20.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)(web-vitals@5.2.0)':
+  '@guardian/core-web-vitals@20.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)(web-vitals@5.2.0)':
     dependencies:
-      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)
+      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3)
       tslib: 2.8.1
       web-vitals: 5.2.0
     optionalDependencies:
@@ -6715,29 +6715,29 @@ snapshots:
       - supports-color
       - typescript
 
-  '@guardian/identity-auth-frontend@18.0.0(@guardian/identity-auth@16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)':
+  '@guardian/identity-auth-frontend@18.0.0(@guardian/identity-auth@16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
-      '@guardian/identity-auth': 16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)
-      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)
+      '@guardian/identity-auth': 16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)
+      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3)
       tslib: 2.8.1
     optionalDependencies:
       typescript: 5.9.3
 
-  '@guardian/identity-auth@16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)':
+  '@guardian/identity-auth@16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
-      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)
+      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3)
       tslib: 2.8.1
     optionalDependencies:
       typescript: 5.9.3
 
-  '@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)':
+  '@guardian/libs@32.0.0(@guardian/ophan-tracker-js@5.0.0)(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
-      '@guardian/ophan-tracker-js': 0.0.0-canary-20260622142809
+      '@guardian/ophan-tracker-js': 5.0.0
       tslib: 2.8.1
     optionalDependencies:
       typescript: 5.9.3
 
-  '@guardian/ophan-tracker-js@0.0.0-canary-20260622142809':
+  '@guardian/ophan-tracker-js@5.0.0':
     dependencies:
       '@guardian/tsconfig': 1.0.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,22 +85,22 @@ importers:
         version: link:../core
       '@guardian/consent-manager':
         specifier: 1.0.0
-        version: 1.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3)
+        version: 1.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/core-web-vitals':
         specifier: 20.0.0
-        version: 20.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)(web-vitals@5.2.0)
+        version: 20.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)(web-vitals@5.2.0)
       '@guardian/identity-auth':
         specifier: 16.0.0
-        version: 16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)
+        version: 16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/identity-auth-frontend':
         specifier: 18.0.0
-        version: 18.0.0(@guardian/identity-auth@16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)
+        version: 18.0.0(@guardian/identity-auth@16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/libs':
         specifier: 32.0.0
-        version: 32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3)
+        version: 32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/ophan-tracker-js':
-        specifier: 3.0.0
-        version: 3.0.0
+        specifier: 0.0.0-canary-20260622142809
+        version: 0.0.0-canary-20260622142809
       '@guardian/source':
         specifier: 12.2.1
         version: 12.2.1(tslib@2.8.1)(typescript@5.9.3)
@@ -211,14 +211,14 @@ importers:
     dependencies:
       '@guardian/consent-manager':
         specifier: 1.0.0
-        version: 1.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3)
+        version: 1.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)
       '@guardian/libs':
         specifier: 32.0.0
-        version: 32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3)
+        version: 32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)
     devDependencies:
       '@guardian/ophan-tracker-js':
-        specifier: 3.0.0
-        version: 3.0.0
+        specifier: 0.0.0-canary-20260622142809
+        version: 0.0.0-canary-20260622142809
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
@@ -1126,8 +1126,8 @@ packages:
       typescript:
         optional: true
 
-  '@guardian/ophan-tracker-js@3.0.0':
-    resolution: {integrity: sha512-p5KDMSkldYfi9LOdEnuZRFDyHh++CxnxnERWNP87RhDNPe21a/xGSnaj7a9rnmcCIZlMuKndF3OCN50ZDAs6uA==}
+  '@guardian/ophan-tracker-js@0.0.0-canary-20260622142809':
+    resolution: {integrity: sha512-pTORQe4S7axSxAlLWjhwYGDKCMea00uo7a3VryUSknoKH61mUI7EdHM72nmBJdWbGvXFdAP4NnQNlzgcZLk1TQ==}
     engines: {node: '>=16'}
 
   '@guardian/prettier@10.0.0':
@@ -6677,17 +6677,17 @@ snapshots:
       browserslist: 4.28.2
       tslib: 2.8.1
 
-  '@guardian/consent-manager@1.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3)':
+  '@guardian/consent-manager@1.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
-      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3)
-      '@guardian/ophan-tracker-js': 3.0.0
+      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)
+      '@guardian/ophan-tracker-js': 0.0.0-canary-20260622142809
       tslib: 2.8.1
     optionalDependencies:
       typescript: 5.9.3
 
-  '@guardian/core-web-vitals@20.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)(web-vitals@5.2.0)':
+  '@guardian/core-web-vitals@20.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)(web-vitals@5.2.0)':
     dependencies:
-      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3)
+      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)
       tslib: 2.8.1
       web-vitals: 5.2.0
     optionalDependencies:
@@ -6715,29 +6715,29 @@ snapshots:
       - supports-color
       - typescript
 
-  '@guardian/identity-auth-frontend@18.0.0(@guardian/identity-auth@16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)':
+  '@guardian/identity-auth-frontend@18.0.0(@guardian/identity-auth@16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3))(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
-      '@guardian/identity-auth': 16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)
-      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3)
+      '@guardian/identity-auth': 16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)
+      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)
       tslib: 2.8.1
     optionalDependencies:
       typescript: 5.9.3
 
-  '@guardian/identity-auth@16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)':
+  '@guardian/identity-auth@16.0.0(@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
-      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3)
+      '@guardian/libs': 32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)
       tslib: 2.8.1
     optionalDependencies:
       typescript: 5.9.3
 
-  '@guardian/libs@32.0.0(@guardian/ophan-tracker-js@3.0.0)(tslib@2.8.1)(typescript@5.9.3)':
+  '@guardian/libs@32.0.0(@guardian/ophan-tracker-js@0.0.0-canary-20260622142809)(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
-      '@guardian/ophan-tracker-js': 3.0.0
+      '@guardian/ophan-tracker-js': 0.0.0-canary-20260622142809
       tslib: 2.8.1
     optionalDependencies:
       typescript: 5.9.3
 
-  '@guardian/ophan-tracker-js@3.0.0':
+  '@guardian/ophan-tracker-js@0.0.0-canary-20260622142809':
     dependencies:
       '@guardian/tsconfig': 1.0.1
 


### PR DESCRIPTION
## What changed
- Bumps @guardian/ophan-tracker-js to 5.0.0 in core and bundle.
- Refreshes pnpm lockfile resolution for dependent Guardian packages.

## Verification
- pnpm --store-dir=/tmp/commercial-pnpm-store tsc
- pnpm --store-dir=/tmp/commercial-pnpm-store lint
- pnpm --store-dir=/tmp/commercial-pnpm-store test
- pnpm --store-dir=/tmp/commercial-pnpm-store build