### PR TITLE
Update Teads Prebid inline1 MPU mapping and add AU/NZ placement IDs

### DIFF
--- a/bundle/playwright/tests/prebid.spec.ts
+++ b/bundle/playwright/tests/prebid.spec.ts
@@ -58,7 +58,7 @@ test.describe('Prebid', () => {
 		);
 
 		expect(bidders).toBeTruthy();
-		expect(bidders).toHaveLength(9);
+		expect(bidders).toHaveLength(10);
 		[
 			'oxd',
 			'and',
@@ -69,6 +69,7 @@ test.describe('Prebid', () => {
 			'criteo',
 			'ttd',
 			'rubicon',
+			'teads',
 		].forEach((bidder) => {
 			expect(bidders).toContain(bidder);
 		});

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -829,7 +829,7 @@ describe('getTeadsParams', () => {
 				});
 			},
 		);
-		test('should return correct pageD and placementID for MPU sized inline1 slots, in Uk when it is on desktop', () => {
+		test('should return correct pageId and placementID for MPU sized inline1 slots, in Uk when it is on desktop', () => {
 			isInUk.mockReturnValue(true);
 			getBreakpointKey.mockReturnValue('D');
 			containsMpu.mockReturnValue(true);
@@ -887,7 +887,7 @@ describe('getTeadsParams', () => {
 				});
 			},
 		);
-		test('should return correct pageD and placementID for MPU sized inline1 slots, in RoW when it is on desktop', () => {
+		test('should return correct pageId and placementID for MPU sized inline1 slots, in RoW when it is on desktop', () => {
 			isInRow.mockReturnValue(true);
 			getBreakpointKey.mockReturnValue('D');
 			containsMpu.mockReturnValue(true);
@@ -945,7 +945,7 @@ describe('getTeadsParams', () => {
 				});
 			},
 		);
-		test('should return correct pageD and placementID for MPU sized inline1 slots, in RoW when it is on desktop', () => {
+		test('should return correct pageId and placementID for MPU sized inline1 slots, in US when it is on desktop', () => {
 			isInUsa.mockReturnValue(true);
 			getBreakpointKey.mockReturnValue('D');
 			containsMpu.mockReturnValue(true);
@@ -1003,7 +1003,7 @@ describe('getTeadsParams', () => {
 				});
 			},
 		);
-		test('should return correct pageD and placementID for MPU sized inline1 slots, in AU/NZ when it is on desktop', () => {
+		test('should return correct pageId and placementId for MPU sized inline1 slots, in AU/NZ when it is on desktop', () => {
 			isInAuOrNz.mockReturnValue(true);
 			getBreakpointKey.mockReturnValue('D');
 			containsMpu.mockReturnValue(true);

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -503,6 +503,49 @@ describe('bids', () => {
 			unit: '560429384',
 		});
 	});
+
+	test('should pass inline1 slotId through to Teads params for desktop MPU in UK', () => {
+		const mockShouldInclude = jest.fn().mockReturnValue(true);
+		jest.mocked(shouldIncludeBidder).mockReturnValue(mockShouldInclude);
+		isInUk.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('D');
+		containsMpu.mockReturnValue(true);
+
+		const teadsBid = bids(
+			'dfp-ad--inline1',
+			[[300, 250]],
+			mockPageTargeting,
+			'gpid',
+			mockConsentState,
+		).find((bid) => bid.bidder === 'teads');
+
+		expect(teadsBid?.params).toEqual({
+			pageId: 265029,
+			placementId: 248133,
+		});
+	});
+
+	test('should pass inline2 slotId through to Ozone params for mobile MPU in US', () => {
+		const mockShouldInclude = jest.fn().mockReturnValue(true);
+		jest.mocked(shouldIncludeBidder).mockReturnValue(mockShouldInclude);
+		isInUsa.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('M');
+		containsMpu.mockReturnValue(true);
+
+		const ozoneBid = bids(
+			'dfp-ad--inline2',
+			[[300, 250]],
+			mockPageTargeting,
+			'gpid',
+			mockConsentState,
+		).find((bid) => bid.bidder === 'ozone');
+
+		expect(ozoneBid?.params).toMatchObject({
+			publisherId: 'OZONEGMG0001',
+			siteId: '4204204209',
+			placementId: '1500001025',
+		});
+	});
 });
 
 describe('triplelift adapter', () => {
@@ -922,7 +965,7 @@ describe('getTeadsParams', () => {
 			[[728, 90], 'LEADERBOARD', containsLeaderboard],
 			[[970, 250], 'BILLBOARD', containsBillboard],
 		])(
-			'should return correct placement and page ID for %s in US when on desktop',
+			'should return correct placement and page ID for %s in AU/NZ when on desktop',
 			(size, label, mockFunction) => {
 				isInAuOrNz.mockReturnValue(true);
 				getBreakpointKey.mockReturnValue('D');
@@ -937,7 +980,7 @@ describe('getTeadsParams', () => {
 			[[300, 250], 'MPU', containsMpu],
 			[[320, 480], 'PORTRAIT', containsPortraitInterstitial],
 		])(
-			'should return correct placement and page ID for %s in US when on mobile',
+			'should return correct placement and page ID for %s in AU/NZ when on mobile',
 			(size, label, mockFunction) => {
 				isInAuOrNz.mockReturnValue(true);
 				getBreakpointKey.mockReturnValue('M');
@@ -949,7 +992,7 @@ describe('getTeadsParams', () => {
 			},
 		);
 		test.each([[[320, 50], 'MOBILE STICKY', containsMobileSticky]])(
-			'should return correct placement and page ID for %s in US when mobile sticky on mobile',
+			'should return correct placement and page ID for %s in AU/NZ when mobile sticky on mobile',
 			(size, label, mockFunction) => {
 				isInAuOrNz.mockReturnValue(true);
 				getBreakpointKey.mockReturnValue('M');
@@ -960,7 +1003,7 @@ describe('getTeadsParams', () => {
 				});
 			},
 		);
-		test('should return correct pageD and placementID for MPU sized inline1 slots, in RoW when it is on desktop', () => {
+		test('should return correct pageD and placementID for MPU sized inline1 slots, in AU/NZ when it is on desktop', () => {
 			isInAuOrNz.mockReturnValue(true);
 			getBreakpointKey.mockReturnValue('D');
 			containsMpu.mockReturnValue(true);

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -786,6 +786,17 @@ describe('getTeadsParams', () => {
 				});
 			},
 		);
+		test('should return correct pageD and placementID for MPU sized inline1 slots, in Uk when it is on desktop', () => {
+			isInUk.mockReturnValue(true);
+			getBreakpointKey.mockReturnValue('D');
+			containsMpu.mockReturnValue(true);
+			expect(
+				getTeadsParams([[300, 250]], 'dfp-ad--inline1'),
+			).toStrictEqual({
+				pageId: 265029,
+				placementId: 248133,
+			});
+		});
 	});
 	describe('Rest of World Region', () => {
 		test.each([
@@ -833,6 +844,17 @@ describe('getTeadsParams', () => {
 				});
 			},
 		);
+		test('should return correct pageD and placementID for MPU sized inline1 slots, in RoW when it is on desktop', () => {
+			isInRow.mockReturnValue(true);
+			getBreakpointKey.mockReturnValue('D');
+			containsMpu.mockReturnValue(true);
+			expect(
+				getTeadsParams([[300, 250]], 'dfp-ad--inline1'),
+			).toStrictEqual({
+				pageId: 265030,
+				placementId: 248134,
+			});
+		});
 	});
 	describe('US Region', () => {
 		test.each([
@@ -880,6 +902,75 @@ describe('getTeadsParams', () => {
 				});
 			},
 		);
+		test('should return correct pageD and placementID for MPU sized inline1 slots, in RoW when it is on desktop', () => {
+			isInUsa.mockReturnValue(true);
+			getBreakpointKey.mockReturnValue('D');
+			containsMpu.mockReturnValue(true);
+			expect(
+				getTeadsParams([[300, 250]], 'dfp-ad--inline1'),
+			).toStrictEqual({
+				pageId: 248135,
+				placementId: 265031,
+			});
+		});
+	});
+	describe('AU or NZ Region', () => {
+		test.each([
+			[[300, 250], 'MPU', containsMpu],
+			[[300, 600], 'DMPU', containsDmpu],
+			[[160, 600], 'WS', containsWS],
+			[[728, 90], 'LEADERBOARD', containsLeaderboard],
+			[[970, 250], 'BILLBOARD', containsBillboard],
+		])(
+			'should return correct placement and page ID for %s in US when on desktop',
+			(size, label, mockFunction) => {
+				isInAuOrNz.mockReturnValue(true);
+				getBreakpointKey.mockReturnValue('D');
+				mockFunction.mockReturnValue(true);
+				expect(getTeadsParams([size as Size])).toStrictEqual({
+					pageId: 247434,
+					placementId: 264330,
+				});
+			},
+		);
+		test.each([
+			[[300, 250], 'MPU', containsMpu],
+			[[320, 480], 'PORTRAIT', containsPortraitInterstitial],
+		])(
+			'should return correct placement and page ID for %s in US when on mobile',
+			(size, label, mockFunction) => {
+				isInAuOrNz.mockReturnValue(true);
+				getBreakpointKey.mockReturnValue('M');
+				mockFunction.mockReturnValue(true);
+				expect(getTeadsParams([size as Size])).toStrictEqual({
+					pageId: 247435,
+					placementId: 264331,
+				});
+			},
+		);
+		test.each([[[320, 50], 'MOBILE STICKY', containsMobileSticky]])(
+			'should return correct placement and page ID for %s in US when mobile sticky on mobile',
+			(size, label, mockFunction) => {
+				isInAuOrNz.mockReturnValue(true);
+				getBreakpointKey.mockReturnValue('M');
+				mockFunction.mockReturnValue(true);
+				expect(getTeadsParams([size as Size])).toStrictEqual({
+					pageId: 247436,
+					placementId: 264332,
+				});
+			},
+		);
+		test('should return correct pageD and placementID for MPU sized inline1 slots, in RoW when it is on desktop', () => {
+			isInAuOrNz.mockReturnValue(true);
+			getBreakpointKey.mockReturnValue('D');
+			containsMpu.mockReturnValue(true);
+			expect(
+				getTeadsParams([[300, 250]], 'dfp-ad--inline1'),
+			).toStrictEqual({
+				pageId: 248136,
+				placementId: 265032,
+			});
+		});
 	});
 });
 

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -266,11 +266,19 @@ const openxBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
 const isCrosswordPage = (pageTargeting: PageTargeting = {}) =>
 	pageTargeting.s === 'crosswords';
 
-const getTeadsParams = (sizes: Size[]): PrebidTeadsParams | undefined => {
+const getTeadsParams = (
+	sizes: Size[],
+	slotId?: string,
+): PrebidTeadsParams | undefined => {
 	const breakpoint = getBreakpointKey();
 	const isDesktop = breakpoint === 'D' || breakpoint === 'T';
 
 	if (isInUk()) {
+		if (isDesktop) {
+			if (slotId === 'dfp-ad--inline1' && containsMpu(sizes)) {
+				return { pageId: 265029, placementId: 248133 };
+			}
+		}
 		if (isDesktop) {
 			if (
 				containsMpu(sizes) ||
@@ -289,6 +297,11 @@ const getTeadsParams = (sizes: Size[]): PrebidTeadsParams | undefined => {
 		}
 	}
 	if (isInRow()) {
+		if (isDesktop) {
+			if (slotId === 'dfp-ad--inline1' && containsMpu(sizes)) {
+				return { pageId: 265030, placementId: 248134 };
+			}
+		}
 		if (isDesktop) {
 			if (
 				containsMpu(sizes) ||
@@ -311,6 +324,11 @@ const getTeadsParams = (sizes: Size[]): PrebidTeadsParams | undefined => {
 	}
 	if (isInUsa()) {
 		if (isDesktop) {
+			if (slotId === 'dfp-ad--inline1' && containsMpu(sizes)) {
+				return { pageId: 248135, placementId: 265031 };
+			}
+		}
+		if (isDesktop) {
 			if (
 				containsMpu(sizes) ||
 				containsDmpu(sizes) ||
@@ -327,6 +345,30 @@ const getTeadsParams = (sizes: Size[]): PrebidTeadsParams | undefined => {
 			}
 			if (containsMobileSticky(sizes)) {
 				return { pageId: 244730, placementId: 261620 };
+			}
+		}
+	}
+	if (isInAuOrNz()) {
+		if (isDesktop) {
+			if (slotId === 'dfp-ad--inline1' && containsMpu(sizes)) {
+				return { pageId: 248136, placementId: 265032 };
+			}
+			if (
+				containsMpu(sizes) ||
+				containsDmpu(sizes) ||
+				containsWS(sizes) ||
+				containsLeaderboard(sizes) ||
+				containsBillboard(sizes)
+			) {
+				return { pageId: 247434, placementId: 264330 };
+			}
+		}
+		if (breakpoint === 'M') {
+			if (containsMpu(sizes) || containsPortraitInterstitial(sizes)) {
+				return { pageId: 247435, placementId: 264331 };
+			}
+			if (containsMobileSticky(sizes)) {
+				return { pageId: 247436, placementId: 264332 };
 			}
 		}
 	}
@@ -387,7 +429,7 @@ const teadsBidder: PrebidBidder = {
 	name: 'teads',
 	switchName: 'prebidTeads',
 	bidParams: (_slotId: string, sizes: Size[]): PrebidTeadsParams => {
-		const params = getTeadsParams(sizes);
+		const params = getTeadsParams(sizes, _slotId);
 		return params ?? { pageId: 0, placementId: 0 };
 	},
 };

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -278,8 +278,6 @@ const getTeadsParams = (
 			if (slotId === 'dfp-ad--inline1' && containsMpu(sizes)) {
 				return { pageId: 265029, placementId: 248133 };
 			}
-		}
-		if (isDesktop) {
 			if (
 				containsMpu(sizes) ||
 				containsDmpu(sizes) ||
@@ -301,8 +299,6 @@ const getTeadsParams = (
 			if (slotId === 'dfp-ad--inline1' && containsMpu(sizes)) {
 				return { pageId: 265030, placementId: 248134 };
 			}
-		}
-		if (isDesktop) {
 			if (
 				containsMpu(sizes) ||
 				containsDmpu(sizes) ||
@@ -327,8 +323,6 @@ const getTeadsParams = (
 			if (slotId === 'dfp-ad--inline1' && containsMpu(sizes)) {
 				return { pageId: 248135, placementId: 265031 };
 			}
-		}
-		if (isDesktop) {
 			if (
 				containsMpu(sizes) ||
 				containsDmpu(sizes) ||

--- a/bundle/src/lib/header-bidding/utils.spec.ts
+++ b/bundle/src/lib/header-bidding/utils.spec.ts
@@ -304,7 +304,6 @@ describe('Utils', () => {
 		describe('shouldIncludeTeads', () => {
 			test('should be true if geolocation is GB, in AB test variant, switch on, and consent given', () => {
 				window.guardian.config.switches.prebidTeads = true;
-				jest.mocked(isUserInTestGroup).mockReturnValue(true);
 				getLocale.mockReturnValue('GB');
 				getConsentFor.mockReturnValue(true);
 				expect(shouldInclude('teads')).toBe(true);
@@ -312,7 +311,6 @@ describe('Utils', () => {
 
 			test('should be true if geolocation is in USA or RoW', () => {
 				window.guardian.config.switches.prebidTeads = true;
-				jest.mocked(isUserInTestGroup).mockReturnValue(true);
 				const testGeos: CountryCode[] = [
 					'FK',
 					'GI',
@@ -329,17 +327,8 @@ describe('Utils', () => {
 				}
 			});
 
-			test('should be false if user is NOT in AB test variant', () => {
-				window.guardian.config.switches.prebidTeads = true;
-				jest.mocked(isUserInTestGroup).mockReturnValue(false);
-				getLocale.mockReturnValue('GB');
-				getConsentFor.mockReturnValue(true);
-				expect(shouldInclude('teads')).toBe(false);
-			});
-
 			test('should be false if geolocation is in an unsupported region', () => {
 				window.guardian.config.switches.prebidTeads = true;
-				jest.mocked(isUserInTestGroup).mockReturnValue(true);
 				const testGeos: CountryCode[] = ['AU', 'CA', 'NZ'];
 				for (const testGeo of testGeos) {
 					getLocale.mockReturnValue(testGeo);
@@ -350,7 +339,6 @@ describe('Utils', () => {
 
 			test('should be false if consent not given', () => {
 				window.guardian.config.switches.prebidTeads = true;
-				jest.mocked(isUserInTestGroup).mockReturnValue(true);
 				getLocale.mockReturnValue('GB');
 				getConsentFor.mockReturnValue(false);
 				expect(shouldInclude('teads')).toBe(false);

--- a/bundle/src/lib/header-bidding/utils.spec.ts
+++ b/bundle/src/lib/header-bidding/utils.spec.ts
@@ -329,7 +329,7 @@ describe('Utils', () => {
 
 			test('should be false if geolocation is in an unsupported region', () => {
 				window.guardian.config.switches.prebidTeads = true;
-				const testGeos: CountryCode[] = ['AU', 'CA', 'NZ'];
+				const testGeos: CountryCode[] = ['CA'];
 				for (const testGeo of testGeos) {
 					getLocale.mockReturnValue(testGeo);
 					getConsentFor.mockReturnValue(true);

--- a/bundle/src/lib/header-bidding/utils.ts
+++ b/bundle/src/lib/header-bidding/utils.ts
@@ -156,10 +156,6 @@ export const isSwitchedOn = (switchName: string): boolean =>
 export const shouldIncludeBidder =
 	(consentState: ConsentState) =>
 	(bidder: BidderCode): boolean => {
-		const isInTeadsTest = isUserInTestGroup(
-			'commercial-teads-prebid',
-			'variant',
-		);
 		switch (bidder) {
 			case 'and':
 				return (
@@ -225,7 +221,6 @@ export const shouldIncludeBidder =
 				);
 			case 'teads':
 				return (
-					isInTeadsTest &&
 					isSwitchedOn('prebidTeads') &&
 					getConsentFor('teads', consentState) &&
 					(isInUk() || isInUsa() || isInRow())

--- a/bundle/src/lib/header-bidding/utils.ts
+++ b/bundle/src/lib/header-bidding/utils.ts
@@ -223,7 +223,7 @@ export const shouldIncludeBidder =
 				return (
 					isSwitchedOn('prebidTeads') &&
 					getConsentFor('teads', consentState) &&
-					(isInUk() || isInUsa() || isInRow())
+					(isInUk() || isInUsa() || isInRow() || isInAuOrNz())
 				);
 		}
 	};


### PR DESCRIPTION


<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
- Updates `Teads` placement mapping for inline1 slots on desktop when the ad size is MPU [300, 250], across UK, RoW, US, and AU/NZ.
- Adds full `Teads` page and placement ID mappings for AU/NZ across desktop and mobile size groups.
- Removes AB test gate and exposes the feature to all users.

## Why?
This extends the Teads + Prebid integration introduced in PR #2567 and delivers the contractual mapping updates for inline1 and AU/NZ regions.


### Tested Slot sizes in CODE  for new AUS and NZ region:

| dfp-inline1 MPU | Billboard + Leaderboard |
|-----| -----|
| <img width="805" height="123" alt="Screenshot 2026-06-26 at 12 30 30" src="https://github.com/user-attachments/assets/9f16f7e3-ac0a-4b63-bdec-606a1a7c029e" /> |  <img width="440" height="195" alt="Screenshot 2026-06-26 at 12 30 38" src="https://github.com/user-attachments/assets/c14a1a3d-905a-43ea-bd81-fe6ee22c125e" /> |  
| <img width="801" height="238" alt="Screenshot 2026-06-26 at 12 28 22" src="https://github.com/user-attachments/assets/7918a220-454d-4f90-b989-afac7eceeeff" /> |  <img width="799" height="239" alt="Screenshot 2026-06-26 at 12 28 37" src="https://github.com/user-attachments/assets/2b73a529-cfa1-41d7-aee0-c22d94b58318" /> | 

### Desktop/Tablet inline1 slot with the new assigned Page ID and Placement ID
| Region / mapping | Evidence |
| --- | --- |
| UK | <img width="766" height="314" alt="Screenshot 2026-06-26 at 15 59 15" src="https://github.com/user-attachments/assets/e4af5a08-63d7-46c5-8897-19cc3142e561" /> |
| AU/NZ | <img width="723" height="308" alt="Screenshot 2026-06-26 at 16 12 35" src="https://github.com/user-attachments/assets/779f57a2-a9c2-48e1-82d8-0b3ee89000fa" /> |
| RoW (FR, CY) | <img width="768" height="304" alt="Screenshot 2026-06-26 at 16 06 59" src="https://github.com/user-attachments/assets/58fe9c49-c2ab-4e6a-80b0-ce435adb3789" /> |
| US | <img width="746" height="301" alt="Screenshot 2026-06-26 at 16 15 31" src="https://github.com/user-attachments/assets/71b82d8e-6ad1-45de-a977-05b11da3ab1c" /> |

