### PR TITLE
Update value of exported constant `TOP_ABOVE_NAV_HEIGHT`

### DIFF
--- a/.changeset/jolly-towns-stay.md
+++ b/.changeset/jolly-towns-stay.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial-core': minor
+---
+
+Updates value of exported constant TOP_ABOVE_NAV_HEIGHT

--- a/core/src/constants/index.spec.ts
+++ b/core/src/constants/index.spec.ts
@@ -3,7 +3,7 @@ import { AD_LABEL_HEIGHT, PREBID_TIMEOUT, TOP_ABOVE_NAV_HEIGHT } from '.';
 // These tests ensure that we look twice when changing a constant
 describe('Constant values are constant', () => {
 	test('TOP_ABOVE_NAV_HEIGHT', () => {
-		expect(TOP_ABOVE_NAV_HEIGHT).toBe(90);
+		expect(TOP_ABOVE_NAV_HEIGHT).toBe(250);
 	});
 
 	test('PREBID_TIMEOUT', () => {

--- a/core/src/constants/top-above-nav-height.ts
+++ b/core/src/constants/top-above-nav-height.ts
@@ -1,17 +1,36 @@
 /**
  * Unit: pixels.
  *
- * The majority of ads in the top banner are 250px high. We ran an experiment
- * in October 2021 to set the minimum height to 250, and let smaller ads be
- * centred in the space. We did not process with this option, as it had a
- * negative impact on viewability and revenue.
+ * The initial height on page load of the top-above-nav ad slot. This excludes
+ * the height of the ad label and any padding around the slot.
  *
  */
-export const TOP_ABOVE_NAV_HEIGHT = 90;
+export const TOP_ABOVE_NAV_HEIGHT = 250;
 
 /*
 Further Notes
 =============
+
+The top-above-nav ad slot is served at the very top of the page from the tablet
+breakpoint onwards. There are two main ad sizes that are served in this slot:
+billboard (970x250) and leaderboard (728x90). The majority of ads we serve are
+billboard and over time this percentage is slowly increasing.
+
+AB Test July 2025
+
+We ran an experiment in July 2025. The initial height was set to perfectly
+accommodate a 250px tall ad, with the slot contracting to fit if a 90px tall
+ad was served. This time, revenue was unchanged and viewability had a 1% drop.
+It was decided to rollout this change for the benefits to the user.
+- Test: https://github.com/guardian/dotcom-rendering/pull/14198
+- Rollout: https://github.com/guardian/dotcom-rendering/pull/14510
+
+
+AB Test October 2021
+
+We ran an experiment in October 2021 to set the minimum height to 250, and let
+smaller ads be centred in the space. We did not process with this option, as it
+had a negative impact on viewability and revenue.
 
 There was a very positive impact on CLS (Cumulative Layout Shift), which is good
 for UX. However, the negative commercial impact meant we kept a height of 90px.

--- a/docs/deployment/readme.md
+++ b/docs/deployment/readme.md
@@ -3,7 +3,7 @@
 ## This repo
 When building in production, as well as generating bundle javascripts, cloudformation for updating a key in parameter store is created. This key is used by the frontend to determine the path to the commercial bundle.
 
-This is neccessary as the production bundle files have a hash in their paths for cache busting, so the path is not the same for each build.
+This is necessary as the production bundle files have a hash in their paths for cache busting, so the path is not the same for each build.
 
 As part of the CI process a build is created in riff-raff with the javascripts and cloudformation. When deployment is initiated in riff-raff (automatically on prod, or manually for PRs on CODE) the javascripts are uploaded to the dotcom static S3 bucket, and the cloudformation updating the bundlepath is executed.
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

Updates the value of the constant `TOP_ABOVE_NAV_HEIGHT` from 90px to 250px

## Why?

The initial height of the top-above-nav ad slot is now 250px (plus ad label and padding), so this value was out of date.

This value is currently unused by DCAR, so this doesn't actually change anything. After this is merged, we can use this constant within DCAR to control the initial height of the ad space within the top-above-nav slot.

## Alternatives?

We remove this constant and delete the file, letting DCAR control the initial height of the top-above-nav ad slot. This would make it harder to find the useful comment about the AB testing, but we could add this to handbook/other documentation for visibility.