### PR TITLE
expose intent iq to all users

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/id-handlers/intent-iq.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/intent-iq.spec.ts
@@ -1,11 +1,6 @@
-import { isInUsa } from '@guardian/commercial-core/geo/geo-utils';
 import { getLocale } from '@guardian/commercial-core/geo/get-locale';
-import { isUserInTestGroup } from '../../../../ab-testing';
 import { getUserIdForIntentIQ } from './intent-iq';
 
-jest.mock('../../../../ab-testing', () => ({
-	isUserInTestGroup: jest.fn(),
-}));
 jest.mock('@guardian/commercial-core/geo/get-locale');
 
 jest.mock('@guardian/commercial-core/geo/geo-utils', () => ({
@@ -14,12 +9,11 @@ jest.mock('@guardian/commercial-core/geo/geo-utils', () => ({
 // @ts-expect-error -- mock global googletag
 global.googletag = {};
 
-describe('getUserIdForIntentIQ - when user is in test group', () => {
+describe('getUserIdForIntentIQ', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
 	});
 	test('should generate correct EU userID config, in an allowed EU region (GB)', async () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
 		jest.mocked(getLocale).mockReturnValue('GB');
 
 		const result = await getUserIdForIntentIQ();
@@ -42,7 +36,6 @@ describe('getUserIdForIntentIQ - when user is in test group', () => {
 		});
 	});
 	test('should generate correct non-EU userID config, in an allowed non-EU region Japan (JP)', async () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
 		jest.mocked(getLocale).mockReturnValue('JP');
 
 		const result = await getUserIdForIntentIQ();
@@ -62,7 +55,6 @@ describe('getUserIdForIntentIQ - when user is in test group', () => {
 		});
 	});
 	test('should return undefined as userID config, in not allowed EU region (Cyprus)', async () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
 		jest.mocked(getLocale).mockReturnValueOnce('CY');
 
 		const result = await getUserIdForIntentIQ();
@@ -70,106 +62,7 @@ describe('getUserIdForIntentIQ - when user is in test group', () => {
 		expect(result).toEqual(undefined);
 	});
 	test('should return undefined as userID config, for users in an unsupported region (CZ)', async () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
 		jest.mocked(getLocale).mockReturnValueOnce('CZ');
-
-		const result = await getUserIdForIntentIQ();
-
-		expect(result).toEqual(undefined);
-	});
-});
-
-describe('getUserIdForIntentIQ - when user is NOT in test group', () => {
-	test('should return undefined userID config, in an allowed EU region (GB)', async () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
-		jest.mocked(getLocale).mockReturnValueOnce('GB');
-
-		const result = await getUserIdForIntentIQ();
-
-		expect(result).toEqual(undefined);
-	});
-	test('should return undefined userID config, in a non-allowed EU region (Cyprus)', async () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
-		jest.mocked(getLocale).mockReturnValueOnce('CY');
-
-		const result = await getUserIdForIntentIQ();
-
-		expect(result).toEqual(undefined);
-	});
-	test('should return undefined userID config, in an allowed Non-EU region (Japan)', async () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
-		jest.mocked(getLocale).mockReturnValueOnce('JP');
-
-		const result = await getUserIdForIntentIQ();
-
-		expect(result).toEqual(undefined);
-	});
-});
-
-describe('getUserIdForIntentIQ - when US user not in holdback', () => {
-	beforeEach(() => {
-		jest.resetAllMocks();
-	});
-	test('when locale is US and US experiment is holdback', async () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false); // isUserInTestGroupIntentIQ
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false); // canRunIntentIqInUS
-		jest.mocked(isInUsa).mockReturnValue(true);
-
-		const result = await getUserIdForIntentIQ();
-
-		expect(result).toEqual({
-			name: 'intentIqId',
-			params: {
-				partner: 377078111,
-				gamObjectReference: {},
-			},
-			storage: {
-				type: 'html5',
-				name: 'intentIqId',
-				expires: 0,
-				refreshInSeconds: 0,
-			},
-		});
-	});
-	test('when locale is US and user is in first experiment and not in holdback', async () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true); // isUserInTestGroupIntentIQ
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false); // canRunIntentIqInUS
-		jest.mocked(isInUsa).mockReturnValue(true);
-
-		const result = await getUserIdForIntentIQ();
-
-		expect(result).toEqual({
-			name: 'intentIqId',
-			params: {
-				partner: 377078111,
-				gamObjectReference: {},
-			},
-			storage: {
-				type: 'html5',
-				name: 'intentIqId',
-				expires: 0,
-				refreshInSeconds: 0,
-			},
-		});
-	});
-});
-describe('getUserIdForIntentIQ - when user is in US and in test holdback group', () => {
-	beforeEach(() => {
-		jest.resetAllMocks();
-	});
-	test('when locale is US and US experiment is in holdback', async () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false); // isUserInTestGroupIntentIQ
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true); // canRunIntentIqInUS
-		jest.mocked(isInUsa).mockReturnValueOnce(true);
-
-		const result = await getUserIdForIntentIQ();
-
-		expect(result).toEqual(undefined);
-	});
-	test('when locale is US and only global experiment is variant and also in holdback', async () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true); // isUserInTestGroupIntentIQ
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true); // canRunIntentIqInUS
-		jest.mocked(isInUsa).mockReturnValueOnce(true);
 
 		const result = await getUserIdForIntentIQ();
 

--- a/bundle/src/lib/header-bidding/prebid/id-handlers/intent-iq.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/intent-iq.spec.ts
@@ -3,9 +3,6 @@ import { getUserIdForIntentIQ } from './intent-iq';
 
 jest.mock('@guardian/commercial-core/geo/get-locale');
 
-jest.mock('@guardian/commercial-core/geo/geo-utils', () => ({
-	isInUsa: jest.fn(),
-}));
 // @ts-expect-error -- mock global googletag
 global.googletag = {};
 

--- a/bundle/src/lib/header-bidding/prebid/id-handlers/intent-iq.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/intent-iq.ts
@@ -1,10 +1,7 @@
-import { isInUsa } from '@guardian/commercial-core/geo/geo-utils';
 import { getLocale } from '@guardian/commercial-core/geo/get-locale';
 import type { UserIdConfig } from 'prebid.js/dist/modules/userId/spec';
-import { isUserInTestGroup } from '../../../../ab-testing';
 
-//IntentIQ does not support every country, it's recommended if we cap them to the countries listed
-// US has been removed from the non-EU region list for testing purposes and is handled separately.
+// IntentIQ does not support every country, so we restrict it to this allowlist.
 const intentIQNonEURegions = [
 	'CA',
 	'AU',
@@ -17,6 +14,7 @@ const intentIQNonEURegions = [
 	'KR',
 	'MX',
 	'BR',
+	'US',
 ];
 
 const intentIQEURegions = ['GB', 'IE', 'ES', 'FR', 'DE', 'GR', 'AT'];
@@ -32,22 +30,8 @@ const NON_EU_PARTNER_ID = 377078111;
 const getUserIdForIntentIQ = async (): Promise<
 	UserIdConfig<'intentIqId'> | undefined
 > => {
-	const isUserInTestGroupIntentIQ = isUserInTestGroup(
-		'commercial-user-module-intentIq',
-		'variant',
-	);
-	/**
-	 * Released to all audience apart from holdback group in the US
-	 */
-	const canRunIntentIqInUS = !isUserInTestGroup(
-		'commercial-user-module-intentIq-us',
-		'holdback',
-	);
 	const isEU = isUserInAllowedEURegion();
-	if (
-		(isUserInTestGroupIntentIQ && isUserInIntentIQRegion()) ||
-		(canRunIntentIqInUS && isInUsa())
-	) {
+	if (isUserInIntentIQRegion()) {
 		return Promise.resolve({
 			name: 'intentIqId',
 			params: {

--- a/bundle/src/lib/header-bidding/prebid/id-handlers/intent-iq.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/intent-iq.ts
@@ -56,7 +56,6 @@ const getUserIdForIntentIQ = async (): Promise<
 
 export {
 	getUserIdForIntentIQ,
-	intentIQEURegions,
 	isUserInAllowedEURegion,
 	isUserInIntentIQRegion,
 	EU_PARTNER_ID,

--- a/bundle/src/lib/header-bidding/prebid/intent-iq-analytics.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/intent-iq-analytics.spec.ts
@@ -1,0 +1,90 @@
+import { getConsentFor } from '@guardian/consent-manager';
+import type { ConsentState } from '@guardian/consent-manager';
+import {
+	EU_PARTNER_ID,
+	isUserInAllowedEURegion,
+	isUserInIntentIQRegion,
+	NON_EU_PARTNER_ID,
+} from './id-handlers/intent-iq';
+import { getIntentIQAnalyticsConfig } from './intent-iq-analytics';
+
+jest.mock('@guardian/consent-manager', () => ({
+	getConsentFor: jest.fn(),
+}));
+
+jest.mock('./id-handlers/intent-iq', () => ({
+	EU_PARTNER_ID: 946158046,
+	NON_EU_PARTNER_ID: 377078111,
+	isUserInAllowedEURegion: jest.fn(),
+	isUserInIntentIQRegion: jest.fn(),
+}));
+
+// @ts-expect-error -- mock global googletag
+global.googletag = {};
+
+const mockedIsUserInAllowedEURegion = jest.mocked(isUserInAllowedEURegion);
+const mockedIsUserInIntentIQRegion = jest.mocked(isUserInIntentIQRegion);
+const mockedGetConsentFor = jest.mocked(getConsentFor);
+
+const consentState = {} as ConsentState;
+
+describe('getIntentIQAnalyticsConfig', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it('returns EU analytics config for eligible consented EU users', () => {
+		mockedIsUserInAllowedEURegion.mockReturnValue(true);
+		mockedIsUserInIntentIQRegion.mockReturnValue(true);
+		mockedGetConsentFor.mockReturnValue(true);
+
+		const result = getIntentIQAnalyticsConfig(consentState);
+
+		expect(result).toEqual({
+			provider: 'iiqAnalytics',
+			options: {
+				partner: EU_PARTNER_ID,
+				ABTestingConfigurationSource: 'IIQServer',
+				domainName: 'theguardian.com',
+				gamObjectReference: {},
+				reportingServerAddress:
+					'https://reports-gdpr.intentiq.com/report',
+				browserBlackList: 'chrome',
+			},
+		});
+	});
+
+	it('returns non-EU analytics config for eligible consented non-EU users', () => {
+		mockedIsUserInAllowedEURegion.mockReturnValue(false);
+		mockedIsUserInIntentIQRegion.mockReturnValue(true);
+		mockedGetConsentFor.mockReturnValue(true);
+
+		const result = getIntentIQAnalyticsConfig(consentState);
+
+		expect(result).toEqual({
+			provider: 'iiqAnalytics',
+			options: {
+				partner: NON_EU_PARTNER_ID,
+				ABTestingConfigurationSource: 'IIQServer',
+				domainName: 'theguardian.com',
+				gamObjectReference: {},
+			},
+		});
+	});
+
+	it('returns undefined when user is outside allowed regions', () => {
+		mockedIsUserInAllowedEURegion.mockReturnValue(false);
+		mockedIsUserInIntentIQRegion.mockReturnValue(false);
+		mockedGetConsentFor.mockReturnValue(true);
+
+		expect(getIntentIQAnalyticsConfig(consentState)).toBeUndefined();
+	});
+
+	it('returns undefined when consent is missing even in allowed regions', () => {
+		mockedIsUserInAllowedEURegion.mockReturnValue(true);
+		mockedIsUserInIntentIQRegion.mockReturnValue(true);
+		mockedGetConsentFor.mockReturnValue(false);
+
+		expect(getIntentIQAnalyticsConfig(consentState)).toBeUndefined();
+	});
+});

--- a/bundle/src/lib/header-bidding/prebid/intent-iq-analytics.ts
+++ b/bundle/src/lib/header-bidding/prebid/intent-iq-analytics.ts
@@ -1,8 +1,6 @@
-import { isInUsa } from '@guardian/commercial-core/geo/geo-utils';
 import type { ConsentState } from '@guardian/consent-manager';
 import { getConsentFor } from '@guardian/consent-manager';
 import type { AnalyticsConfig } from 'prebid.js/dist/libraries/analyticsAdapter/AnalyticsAdapter';
-import { isUserInTestGroup } from '../../../ab-testing';
 import {
 	EU_PARTNER_ID,
 	isUserInAllowedEURegion,
@@ -10,28 +8,12 @@ import {
 	NON_EU_PARTNER_ID,
 } from './id-handlers/intent-iq';
 
-const canRunIntentIqInAllowedRegions = isUserInTestGroup(
-	'commercial-user-module-intentIq',
-	'variant',
-);
-
-const canRunIntentIqInUS = !isUserInTestGroup(
-	'commercial-user-module-intentIq-us',
-	'holdback',
-);
-
 export const getIntentIQAnalyticsConfig = (
 	consentState: ConsentState,
 ): AnalyticsConfig<'iiqAnalytics'> | undefined => {
 	const isEU = isUserInAllowedEURegion();
 	const hasConsent = getConsentFor('intentIQ', consentState);
-
-	const isNonUSEligible =
-		canRunIntentIqInAllowedRegions && isUserInIntentIQRegion();
-
-	const isUSEligible = canRunIntentIqInUS && isInUsa();
-
-	const enabledAnalytics = (isNonUSEligible || isUSEligible) && hasConsent;
+	const enabledAnalytics = isUserInIntentIQRegion() && hasConsent;
 
 	if (enabledAnalytics) {
 		return {


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
- Removes IntentIQ experiment gating from both modules:
  - `commercial-user-module-intentIq`
  - `commercial-user-module-intentIq-us`
- Keeps IntentIQ enabled only for allowlisted regions (EU + non-EU, including US).
- Updates existing IntentIQ unit tests to match the new eligibility logic.
- Adds a new unit test suite for the IntentIQ analytics config module.

## Why?
The IntentIQ integration has been validated end-to-end with IntentIQ.
We now want to make IntentIQ available to all users in supported regions, without AB-test gating.
- Users outside the allowlist remain excluded.