### PR TITLE
Use ad label constant instead of redefining

### DIFF
--- a/.changeset/easy-toys-read.md
+++ b/.changeset/easy-toys-read.md
@@ -1,5 +1,0 @@
----
-'@guardian/commercial-core': patch
----
-
-Use ad label constant everywhere

--- a/.changeset/easy-toys-read.md
+++ b/.changeset/easy-toys-read.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial-core': patch
+---
+
+Use ad label constant everywhere

--- a/bundle/src/lib/creatives/page-skin.ts
+++ b/bundle/src/lib/creatives/page-skin.ts
@@ -1,3 +1,4 @@
+import { AD_LABEL_HEIGHT } from '@guardian/commercial-core/constants/ad-label-height';
 import fastdom from 'fastdom';
 import { isAdFree } from '../ad-free';
 import {
@@ -10,7 +11,6 @@ const pageSkin = (): void => {
 	const hasPageSkin = window.guardian.config.page.hasPageSkin;
 	const isInAUEdition =
 		window.guardian.config.page.edition.toLowerCase() === 'au';
-	const adLabelHeight = 24;
 	let topPosition = 0;
 	let truskinRendered = false;
 	let pageskinRendered = false;
@@ -45,7 +45,7 @@ const pageSkin = (): void => {
 				document.querySelector<HTMLElement>('.new-header');
 			if (navHeader) {
 				topPosition = truskinRendered
-					? navHeader.offsetTop + adLabelHeight
+					? navHeader.offsetTop + AD_LABEL_HEIGHT
 					: navHeader.offsetTop + navHeader.offsetHeight;
 			}
 		}
@@ -85,7 +85,7 @@ const pageSkin = (): void => {
 			const topBannerBottom = topBannerAdBoundaries.bottom;
 			const fabricScrollStartPosition =
 				topBannerAdBoundaries.height +
-				adLabelHeight -
+				AD_LABEL_HEIGHT -
 				headerBoundaries.height;
 
 			if (

--- a/bundle/src/lib/messenger/passback.ts
+++ b/bundle/src/lib/messenger/passback.ts
@@ -1,4 +1,5 @@
 import { adSizes } from '@guardian/commercial-core/ad-sizes';
+import { AD_LABEL_HEIGHT } from '@guardian/commercial-core/constants/ad-label-height';
 import { log } from '@guardian/libs';
 import { breakpoints } from '@guardian/source/foundations';
 import { getCurrentBreakpoint } from '../detect/detect-breakpoint';
@@ -8,8 +9,6 @@ import fastdom from '../fastdom-promise';
 import type { RegisterListener } from '../messenger';
 
 type PassbackMessagePayload = { source: string };
-
-const adLabelHeight = 24;
 
 /**
  * Passback size mappings
@@ -188,7 +187,7 @@ const initPassbackMessage = (register: RegisterListener): void => {
 					// position absolute to position over the container slot
 					passbackElement.style.position = 'absolute';
 					// account for the ad label
-					passbackElement.style.top = `${adLabelHeight}px`;
+					passbackElement.style.top = `${AD_LABEL_HEIGHT}px`;
 					// take the full width so it will center horizontally
 					passbackElement.style.width = '100%';
 
@@ -307,7 +306,8 @@ const initPassbackMessage = (register: RegisterListener): void => {
 											(getCurrentBreakpoint() === 'mobile'
 												? adHeight
 												: adSizes.outstreamDesktop
-														.height) + adLabelHeight
+														.height) +
+											AD_LABEL_HEIGHT
 										}px`;
 										log(
 											'commercial',
@@ -326,7 +326,7 @@ const initPassbackMessage = (register: RegisterListener): void => {
 											'center';
 										passbackElement.style.alignItems =
 											'center';
-										passbackElement.style.height = `calc(100% - ${adLabelHeight}px)`;
+										passbackElement.style.height = `calc(100% - ${AD_LABEL_HEIGHT}px)`;
 
 										/**
 										 * Also resize the initial outstream iframe so it doesn't block text selection


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

Use the constant AD_LABEL_HEIGHT for the height of the ad label, instead of redefining this value.

## Why?

If we were to update the height of the ad label in the future, we can be confident that every part of the code that uses the height of the ad label is updated.