### PR TITLE
Remove unused Prebid config: timeoutBuffer

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/index.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.spec.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition -- temporary until v10 migration complete */
 
 import { hashEmailForClient } from '@guardian/commercial-core/email-hash';
-import { type ConsentState } from '@guardian/consent-manager';
-import { getConsentFor } from '@guardian/consent-manager';
+import { type ConsentState, getConsentFor } from '@guardian/consent-manager';
 import { isUserInTestGroup } from '../../../ab-testing';
 import { pubmatic } from '../../__vendor/pubmatic';
 import { getAdvertById as getAdvertById_ } from '../../dfp/get-advert-by-id';
@@ -141,7 +140,6 @@ describe('initialise', () => {
 				},
 			},
 			priceGranularity: 'custom',
-			timeoutBuffer: 400,
 			userSync: {
 				syncDelay: 3000,
 				syncEnabled: true,

--- a/bundle/src/lib/header-bidding/prebid/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.ts
@@ -2,8 +2,8 @@ import type { AdSize } from '@guardian/commercial-core/ad-sizes';
 import { createAdSize } from '@guardian/commercial-core/ad-sizes';
 import { PREBID_TIMEOUT } from '@guardian/commercial-core/constants/prebid-timeout';
 import { EventTimer } from '@guardian/commercial-core/event-timer';
-import { onConsent } from '@guardian/consent-manager';
 import type { ConsentState } from '@guardian/consent-manager';
+import { onConsent } from '@guardian/consent-manager';
 import { isString, log } from '@guardian/libs';
 import { flatten } from 'lodash-es';
 import type { AnalyticsConfig } from 'prebid.js/dist/libraries/analyticsAdapter/AnalyticsAdapter';
@@ -73,12 +73,6 @@ const initialise = async (
 					},
 				}
 			: {}),
-		/**
-		 * Prebid supports an additional timeout buffer to account for noisiness in
-		 * timing JavaScript on the page. This value is passed to the Prebid config
-		 * and is adjustable via this constant
-		 */
-		timeoutBuffer: 400,
 		priceGranularity: 'custom',
 		customPriceBucket: priceGranularity,
 		userSync,


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

Removes Prebid config: `timeoutBuffer`

## Why?

This is no longer used by Prebid:
- https://github.com/prebid/Prebid.js/issues/11959
- https://github.com/prebid/Prebid.js/pull/11960

I spent some time looking into how we might update this value when tweaking Prebid timeouts for optimisation purposes. It turns out Prebid no longer use this value, so I'd like to remove it to stop other devs going down this path!