### PR TITLE
update global ad event adr doc

### DIFF
--- a/docs/architecture/proposals/003-global-advert-event-listeners.md
+++ b/docs/architecture/proposals/003-global-advert-event-listeners.md
@@ -10,6 +10,8 @@ At the moment there is no supported API for determining the current lifecycle st
 
 Instead, some consumers inspect CSS classes or attributes that are added to the advert's DOM element. For example, the top-above-nav advert receives an `top-above-nav-ad-rendered` class once it has rendered.
 
+All ad slots when rendered have a class added `ad-slot--rendered` which can also be used currently to determine the rendered state.
+
 If the attribute is not yet present, the only option is to observe the DOM using a `MutationObserver` until it appears.
 
 This approach has a number of drawbacks:

--- a/docs/architecture/proposals/003-global-advert-event-listeners.md
+++ b/docs/architecture/proposals/003-global-advert-event-listeners.md
@@ -27,7 +27,7 @@ This approach has a number of drawbacks:
 
 Global advert events allow consumers to react to lifecycle changes, but they do not communicate the current status of an advert.
 
-If a listener is registered after an event has already been fired, there is no way to determine the advert's current lifecycle position without inspecting the DOM.
+If a listener is registered after an event has already been fired, there is no way to determine the advert's current lifecycle position.
 
 One possible approach would be to expose the current status of every advert alongside the lifecycle events.
 

--- a/docs/architecture/proposals/003-global-advert-event-listeners.md
+++ b/docs/architecture/proposals/003-global-advert-event-listeners.md
@@ -4,9 +4,56 @@
 
 ## Context
 
-There is currently no standard way for other code on the page (outside the commercial bundle) to listen for advert lifecycle events, for example to run code when an advert has rendered.
+### Current approach
+
+At the moment there is no supported API for determining the current lifecycle status of an advert.
+
+Instead, some consumers inspect CSS classes or attributes that are added to the advert's DOM element. For example, the top-above-nav advert receives an `ad-slot--rendered` class once it has rendered.
+
+If the attribute is not yet present, the only option is to observe the DOM using a `MutationObserver` until it appears.
+
+This approach has a number of drawbacks:
+
+- It couples consumers to DOM implementation details.
+- It only exposes a small subset of the advert lifecycle.
+- It requires polling or DOM observation rather than subscribing to advert lifecycle changes.
+- It is not a documented or supported interface.
+
+### The gap
+
+Global advert events allow consumers to react to lifecycle changes, but they do not communicate the current status of an advert.
+
+If a listener is registered after an event has already been fired, there is no way to determine the advert's current lifecycle position without inspecting the DOM.
 
 ## Proposal
+
+### Short-term: adStatus object
+
+One possible approach would be to expose the current status of every advert alongside the lifecycle events.
+
+```ts
+window.guardian.commercial.adStatus = {
+	inline1: 'ready',
+	'top-above-nav': 'loaded',
+	merchandising: 'rendered',
+	'merchandising-high': 'fetched',
+	// ...
+};
+```
+
+The available statuses would be:
+
+- ready – the advert has been defined and is ready to be prepared.
+- preparing – header bidding is running.
+- prepared – the advert is ready to be fetched from GAM.
+- fetching – the advert is fetching from GAM.
+- fetched – the response has been received from GAM.
+- loading – the creative is being loaded into the slot.
+- loaded – the creative has loaded into the slot.
+- rendered – the advert has finished rendering (adOnPage).
+- The status would be updated whenever the corresponding lifecycle event is fired, allowing consumers to both subscribe to future changes and inspect the current status at any point.
+
+### Long-term: onAdvertEvent API
 
 Export a function that allows other code to register event listeners for Advert lifecycle events.
 

--- a/docs/architecture/proposals/003-global-advert-event-listeners.md
+++ b/docs/architecture/proposals/003-global-advert-event-listeners.md
@@ -8,7 +8,7 @@
 
 At the moment there is no supported API for determining the current lifecycle status of an advert.
 
-Instead, some consumers inspect CSS classes or attributes that are added to the advert's DOM element. For example, the top-above-nav advert receives an `ad-slot--rendered` class once it has rendered.
+Instead, some consumers inspect CSS classes or attributes that are added to the advert's DOM element. For example, the top-above-nav advert receives an `top-above-nav-ad-rendered` class once it has rendered.
 
 If the attribute is not yet present, the only option is to observe the DOM using a `MutationObserver` until it appears.
 

--- a/docs/architecture/proposals/003-global-advert-event-listeners.md
+++ b/docs/architecture/proposals/003-global-advert-event-listeners.md
@@ -4,7 +4,7 @@
 
 ## Context
 
-### Current approach
+### Current solution:
 
 At the moment there is no supported API for determining the current lifecycle status of an advert.
 
@@ -19,15 +19,13 @@ This approach has a number of drawbacks:
 - It requires polling or DOM observation rather than subscribing to advert lifecycle changes.
 - It is not a documented or supported interface.
 
+## Proposal
+
 ### The gap
 
 Global advert events allow consumers to react to lifecycle changes, but they do not communicate the current status of an advert.
 
 If a listener is registered after an event has already been fired, there is no way to determine the advert's current lifecycle position without inspecting the DOM.
-
-## Proposal
-
-### Short-term: adStatus object
 
 One possible approach would be to expose the current status of every advert alongside the lifecycle events.
 
@@ -53,9 +51,7 @@ The available statuses would be:
 - rendered – the advert has finished rendering (adOnPage).
 - The status would be updated whenever the corresponding lifecycle event is fired, allowing consumers to both subscribe to future changes and inspect the current status at any point.
 
-### Long-term: onAdvertEvent API
-
-Export a function that allows other code to register event listeners for Advert lifecycle events.
+#### Export a function that allows other code to register event listeners for Advert lifecycle events.
 
 ```ts
 import { onAdvertEvent } from '@guardian/commercial';


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Updates the `003-global-advert-event-listeners.md` highlighting the use of the `Mutation Observer` and the `onAdvert` window
## Why?

This offers a more immediate and robust solution for the "interactive" team to use, with a clearer pathway to a long term robust solution to deal with possible data attribute name changes.
