### PR TITLE
Implement new Ozone Outstream prebid size behind AB test

### DIFF
--- a/.changeset/hip-ads-change.md
+++ b/.changeset/hip-ads-change.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial-core': minor
+---
+
+Adds Outstream Ozone ad size

--- a/bundle/src/define/Advert.ts
+++ b/bundle/src/define/Advert.ts
@@ -1,13 +1,13 @@
 import { EventTimer } from '@guardian/commercial-core';
-import {
-	createAdSize,
-	findAppliedSizesForBreakpoint,
-	slotSizeMappings,
-} from '@guardian/commercial-core/ad-sizes';
 import type {
 	AdSize,
 	SizeMapping,
 	SlotName,
+} from '@guardian/commercial-core/ad-sizes';
+import {
+	createAdSize,
+	findAppliedSizesForBreakpoint,
+	slotSizeMappings,
 } from '@guardian/commercial-core/ad-sizes';
 import type { Breakpoint } from '@guardian/commercial-core/breakpoint';
 import { globalAdEvents } from '@guardian/commercial-core/global-ad-events';
@@ -184,7 +184,9 @@ class Advert extends EventTarget {
 	extraNodeClasses: string[] = [];
 	hasPrebidSize = false;
 	/**
-	 * This property is used to store the promise for the **initial** header bidding bid request, so that if requestBids is called multiple times before the first bid request has completed, it will return the same promise instead of making multiple bid requests
+	 * This property is used to store the promise for the **initial** header bidding bid request, so that
+	 * if requestBids is called multiple times before the first bid request has completed, it will return
+	 * the same promise instead of making multiple bid requests
 	 */
 	headerBiddingBidRequest: Promise<void> | null = null;
 	lineItemId: number | null = null;
@@ -285,7 +287,8 @@ class Advert extends EventTarget {
 	}
 
 	/**
-	 * Listen for a status or statuses in the advert lifecycle. The callback will be called once when the advert reaches the specified status, or immediately if the advert has already reached that status.
+	 * Listen for a status or statuses in the advert lifecycle. The callback will be called once when the
+	 * advert reaches the specified status, or immediately if the advert has already reached that status.
 	 *
 	 * @param listenStatus A status or array of statuses in the advert lifecycle to listen for
 	 * @param callback A callback function that will be called with the status when the advert reaches it
@@ -339,7 +342,8 @@ class Advert extends EventTarget {
 	}
 
 	/**
-	 * Listen for a status in the advert lifecycle, but only call the callback the first time the advert reaches that status. If the advert is already that status, the callback will be called immediately.
+	 * Listen for a status in the advert lifecycle, but only call the callback the first time the advert
+	 * reaches that status. If the advert is already that status, the callback will be called immediately.
 	 *
 	 * @param listenStatus A status or array of statuses in the advert lifecycle to listen for
 	 * @param callback A callback function that will be called with the status when the advert reaches it
@@ -396,7 +400,8 @@ class Advert extends EventTarget {
 			? getSlotSizeMapping(this.node.dataset.name)
 			: {};
 
-		// Data attribute size mappings are used in interactives e.g. https://www.theguardian.com/education/ng-interactive/2021/sep/11/the-best-uk-universities-2022-rankings
+		// Data attribute size mappings are used in interactives e.g.
+		// https://www.theguardian.com/education/ng-interactive/2021/sep/11/the-best-uk-universities-2022-rankings
 		const dataAttrSizeMapping = getSlotSizeMappingsFromDataAttrs(this.node);
 
 		let sizeMapping = concatSizeMappings(
@@ -438,7 +443,8 @@ class Advert extends EventTarget {
 	/**
 	 * Request header bidding bids for this advert
 	 *
-	 * This is sometimes called separately from the display method, for example in the case of Prebid when we want to request bids earlier for certain breakpoints to improve performance.
+	 * This is sometimes called separately from the display method, for example in the case of Prebid
+	 * when we want to request bids earlier for certain breakpoints to improve performance.
 	 *
 	 * @returns A promise that resolves once the bid request has completed
 	 */
@@ -457,7 +463,8 @@ class Advert extends EventTarget {
 	};
 
 	/**
-	 * Refresh the header bidding bids for this advert, this should be called before refreshing the advert if you want to get new bids for the refreshed ad
+	 * Refresh the header bidding bids for this advert, this should be called before refreshing the
+	 * advert if you want to get new bids for the refreshed ad
 	 *
 	 * @returns A promise that resolves once the bid refresh has completed
 	 */
@@ -473,7 +480,8 @@ class Advert extends EventTarget {
 	};
 
 	/**
-	 * Load and display the advert, this should only be called once per advert instance, if you want to update the ad after it has been displayed you should call refresh instead
+	 * Load and display the advert, this should only be called once per advert instance, if you want
+	 * to update the ad after it has been displayed you should call refresh instead
 	 */
 	load(): void {
 		adQueue.add(() => {
@@ -491,7 +499,8 @@ class Advert extends EventTarget {
 	}
 
 	/**
-	 * Refresh the advert, runs header bidding to get new bids, sets targeting and then calls the GPT refresh command for this slot
+	 * Refresh the advert, runs header bidding to get new bids, sets targeting and then calls the
+	 * GPT refresh command for this slot
 	 */
 	refresh(): void {
 		adQueue.add(() => {
@@ -542,7 +551,8 @@ class Advert extends EventTarget {
 	}
 
 	/**
-	 * Display the advert, if the advert has not been displayed before it will load, if it has already been displayed it will refresh to get new header-bidding bids and a new creative
+	 * Display the advert, if the advert has not been displayed before it will load, if it has
+	 * already been displayed it will refresh to get new header-bidding bids and a new creative
 	 */
 	display(): void {
 		if (this.isRendered) {

--- a/bundle/src/events/render-advert.ts
+++ b/bundle/src/events/render-advert.ts
@@ -86,6 +86,9 @@ sizeCallbacks[adSizes.outstreamGoogleDesktop.toString()] = (advert: Advert) =>
 sizeCallbacks[adSizes.outstreamMobile.toString()] = (advert: Advert) =>
 	advert.updateExtraSlotClasses('ad-slot--outstream');
 
+sizeCallbacks[adSizes.outstreamOzone.toString()] = (advert: Advert) =>
+	advert.updateExtraSlotClasses('ad-slot--outstream');
+
 sizeCallbacks[adSizes.googleCard.toString()] = (advert: Advert) =>
 	advert.updateExtraSlotClasses('ad-slot--gc');
 

--- a/bundle/src/lib/dfp/should-refresh.spec.ts
+++ b/bundle/src/lib/dfp/should-refresh.spec.ts
@@ -6,6 +6,7 @@ const outstreamSizes = [
 	adSizes.outstreamDesktop.toString(),
 	adSizes.outstreamMobile.toString(),
 	adSizes.outstreamGoogleDesktop.toString(),
+	adSizes.outstreamOzone.toString(),
 ];
 
 jest.mock('define/init-slot-ias', () => ({

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -1022,12 +1022,24 @@ describe('getOzonePlacementId', () => {
 		jest.resetAllMocks();
 	});
 
-	test('should return correct placementID for inline1 slot', () => {
+	test('should return correct placementID for inline1 slot when in AB test', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
 		containsMobileSticky.mockReturnValue(false);
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
 		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline1')).toBe(
+			'1500001169',
+		);
+	});
+
+	test('should NOT return inline1 placementID for inline1 slot when NOT in AB test', () => {
+		isInUsa.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('M');
+		containsMpu.mockReturnValue(true);
+		containsMobileSticky.mockReturnValue(false);
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
+		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline1')).not.toBe(
 			'1500001169',
 		);
 	});

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -1023,7 +1023,6 @@ describe('getOzonePlacementId', () => {
 	});
 
 	test('should return correct placementID for inline1 slot when in AB test', () => {
-		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
 		containsMobileSticky.mockReturnValue(false);
@@ -1034,7 +1033,6 @@ describe('getOzonePlacementId', () => {
 	});
 
 	test('should NOT return inline1 placementID for inline1 slot when NOT in AB test', () => {
-		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
 		containsMobileSticky.mockReturnValue(false);

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -1022,6 +1022,17 @@ describe('getOzonePlacementId', () => {
 		jest.resetAllMocks();
 	});
 
+
+	test('should return correct placementID for inline1 slot', () => {
+		isInUsa.mockReturnValue(true);
+		getBreakpointKey.mockReturnValue('M');
+		containsMpu.mockReturnValue(true);
+		containsMobileSticky.mockReturnValue(false);
+		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline1')).toBe(
+			'1500001169',
+		);
+	});
+
 	test('should return correct placementID for billboard in US when it is in desktop', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('D');
@@ -1098,7 +1109,7 @@ describe('getOzonePlacementId', () => {
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
 		containsMobileSticky.mockReturnValue(false);
-		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline1')).toBe(
+		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline3')).toBe(
 			'1500001036',
 		);
 	});

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -1047,14 +1047,14 @@ describe('getOzonePlacementId', () => {
 	test('should return correct placementID for billboard in US when it is in desktop', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('D');
-		containsBillboard.mockReturnValue(true);
+		containsLeaderboardOrBillboard.mockReturnValue(true);
 		expect(getOzonePlacementId([[970, 250]])).toBe('3500010912');
 	});
 
 	test('should return correct placementID for mpu in US when it is in desktop', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('D');
-		containsMpu.mockReturnValue(true);
+		containsMpuOrDmpu.mockReturnValue(true);
 		expect(getOzonePlacementId([[300, 250]])).toBe('3500010911');
 	});
 
@@ -1128,7 +1128,7 @@ describe('getOzonePlacementId', () => {
 	test('should NOT return hangtime for desktop inline2 slots', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('D');
-		containsMpu.mockReturnValue(true);
+		containsMpuOrDmpu.mockReturnValue(true);
 		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline2')).toBe(
 			'3500010911',
 		); // ← Should get desktop MPU, not hangtime

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -1022,7 +1022,6 @@ describe('getOzonePlacementId', () => {
 		jest.resetAllMocks();
 	});
 
-
 	test('should return correct placementID for inline1 slot', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -272,7 +272,6 @@ describe('bids', () => {
 		const mockShouldInclude = jest
 			.fn()
 			.mockReturnValueOnce(true) // ix
-			.mockReturnValueOnce(false) // ozone
 			.mockReturnValueOnce(false) // criteo
 			.mockReturnValueOnce(true) // trustx
 			.mockReturnValueOnce(false) // triplelift
@@ -295,7 +294,6 @@ describe('bids', () => {
 		const mockShouldInclude = jest
 			.fn()
 			.mockReturnValueOnce(false) // ix
-			.mockReturnValueOnce(true) // ozone
 			.mockReturnValueOnce(true) // criteo
 			.mockReturnValueOnce(true) // trustx
 			.mockReturnValueOnce(true) // triplelift
@@ -318,7 +316,6 @@ describe('bids', () => {
 		const mockShouldInclude = jest
 			.fn()
 			.mockReturnValueOnce(true) // ix
-			.mockReturnValueOnce(false) // ozone
 			.mockReturnValueOnce(true); // criteo
 		jest.mocked(shouldIncludeBidder).mockReturnValue(mockShouldInclude);
 
@@ -340,7 +337,6 @@ describe('bids', () => {
 		const mockShouldInclude = jest
 			.fn()
 			.mockReturnValueOnce(false) // ix
-			.mockReturnValueOnce(false) // ozone
 			.mockReturnValueOnce(false) // criteo
 			.mockReturnValueOnce(false) // trustx
 			.mockReturnValueOnce(false) // triplelift
@@ -354,12 +350,13 @@ describe('bids', () => {
 		const mockShouldInclude = jest
 			.fn()
 			.mockReturnValueOnce(false) // ix
-			.mockReturnValueOnce(false) // ozone
 			.mockReturnValueOnce(false) // criteo
 			.mockReturnValueOnce(false) // trustx
 			.mockReturnValueOnce(false) // triplelift
 			.mockReturnValueOnce(false) // and
 			.mockReturnValueOnce(false) // xhb
+			.mockReturnValueOnce(false) // ozone - banner
+			.mockReturnValueOnce(false) // ozone - video
 			.mockReturnValueOnce(false) // pubmatic
 			.mockReturnValueOnce(false) // oxd
 			.mockReturnValueOnce(false) // kargo
@@ -373,12 +370,13 @@ describe('bids', () => {
 		const mockShouldInclude = jest
 			.fn()
 			.mockReturnValueOnce(false) // ix
-			.mockReturnValueOnce(false) // ozone
 			.mockReturnValueOnce(false) // criteo
 			.mockReturnValueOnce(false) // trustx
 			.mockReturnValueOnce(false) // triplelift
 			.mockReturnValueOnce(false) // and
 			.mockReturnValueOnce(false) // xhb
+			.mockReturnValueOnce(false) // ozone - banner
+			.mockReturnValueOnce(false) // ozone - video
 			.mockReturnValueOnce(false) // pubmatic
 			.mockReturnValueOnce(false) // oxd
 			.mockReturnValueOnce(false) // kargo
@@ -559,7 +557,6 @@ describe('triplelift adapter', () => {
 		const mockShouldInclude = jest
 			.fn()
 			.mockReturnValueOnce(false) // ix
-			.mockReturnValueOnce(false) // ozone
 			.mockReturnValueOnce(false) // criteo
 			.mockReturnValueOnce(false) // trustx
 			.mockReturnValueOnce(true); // triplelift

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -272,6 +272,7 @@ describe('bids', () => {
 		const mockShouldInclude = jest
 			.fn()
 			.mockReturnValueOnce(true) // ix
+			.mockReturnValueOnce(false) // ozone
 			.mockReturnValueOnce(false) // criteo
 			.mockReturnValueOnce(true) // trustx
 			.mockReturnValueOnce(false) // triplelift
@@ -294,6 +295,7 @@ describe('bids', () => {
 		const mockShouldInclude = jest
 			.fn()
 			.mockReturnValueOnce(false) // ix
+			.mockReturnValueOnce(true) // ozone
 			.mockReturnValueOnce(true) // criteo
 			.mockReturnValueOnce(true) // trustx
 			.mockReturnValueOnce(true) // triplelift
@@ -316,6 +318,7 @@ describe('bids', () => {
 		const mockShouldInclude = jest
 			.fn()
 			.mockReturnValueOnce(true) // ix
+			.mockReturnValueOnce(false) // ozone
 			.mockReturnValueOnce(true); // criteo
 		jest.mocked(shouldIncludeBidder).mockReturnValue(mockShouldInclude);
 
@@ -337,6 +340,7 @@ describe('bids', () => {
 		const mockShouldInclude = jest
 			.fn()
 			.mockReturnValueOnce(false) // ix
+			.mockReturnValueOnce(false) // ozone
 			.mockReturnValueOnce(false) // criteo
 			.mockReturnValueOnce(false) // trustx
 			.mockReturnValueOnce(false) // triplelift
@@ -350,13 +354,13 @@ describe('bids', () => {
 		const mockShouldInclude = jest
 			.fn()
 			.mockReturnValueOnce(false) // ix
+			.mockReturnValueOnce(false) // ozone
 			.mockReturnValueOnce(false) // criteo
 			.mockReturnValueOnce(false) // trustx
 			.mockReturnValueOnce(false) // triplelift
 			.mockReturnValueOnce(false) // and
 			.mockReturnValueOnce(false) // xhb
 			.mockReturnValueOnce(false) // pubmatic
-			.mockReturnValueOnce(false) // ozone
 			.mockReturnValueOnce(false) // oxd
 			.mockReturnValueOnce(false) // kargo
 			.mockReturnValueOnce(true); // teads
@@ -369,13 +373,13 @@ describe('bids', () => {
 		const mockShouldInclude = jest
 			.fn()
 			.mockReturnValueOnce(false) // ix
+			.mockReturnValueOnce(false) // ozone
 			.mockReturnValueOnce(false) // criteo
 			.mockReturnValueOnce(false) // trustx
 			.mockReturnValueOnce(false) // triplelift
 			.mockReturnValueOnce(false) // and
 			.mockReturnValueOnce(false) // xhb
 			.mockReturnValueOnce(false) // pubmatic
-			.mockReturnValueOnce(false) // ozone
 			.mockReturnValueOnce(false) // oxd
 			.mockReturnValueOnce(false) // kargo
 			.mockReturnValueOnce(false) // teads
@@ -555,6 +559,7 @@ describe('triplelift adapter', () => {
 		const mockShouldInclude = jest
 			.fn()
 			.mockReturnValueOnce(false) // ix
+			.mockReturnValueOnce(false) // ozone
 			.mockReturnValueOnce(false) // criteo
 			.mockReturnValueOnce(false) // trustx
 			.mockReturnValueOnce(true); // triplelift
@@ -1022,95 +1027,85 @@ describe('getOzonePlacementId', () => {
 		jest.resetAllMocks();
 	});
 
-	test('should return correct placementID for inline1 slot when in AB test', () => {
+	test('should return inline1 placementID for video media type', () => {
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
 		containsMobileSticky.mockReturnValue(false);
 		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
-		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline1')).toBe(
-			'1500001169',
-		);
-	});
-
-	test('should NOT return inline1 placementID for inline1 slot when NOT in AB test', () => {
-		getBreakpointKey.mockReturnValue('M');
-		containsMpu.mockReturnValue(true);
-		containsMobileSticky.mockReturnValue(false);
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
-		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline1')).not.toBe(
-			'1500001169',
-		);
+		expect(
+			getOzonePlacementId([[300, 250]], 'video', 'dfp-ad--inline1'),
+		).toBe('1500001169');
 	});
 
 	test('should return correct placementID for billboard in US when it is in desktop', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('D');
 		containsLeaderboardOrBillboard.mockReturnValue(true);
-		expect(getOzonePlacementId([[970, 250]])).toBe('3500010912');
+		expect(getOzonePlacementId([[970, 250]], 'banner')).toBe('3500010912');
 	});
 
 	test('should return correct placementID for mpu in US when it is in desktop', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('D');
 		containsMpuOrDmpu.mockReturnValue(true);
-		expect(getOzonePlacementId([[300, 250]])).toBe('3500010911');
+		expect(getOzonePlacementId([[300, 250]], 'banner')).toBe('3500010911');
 	});
 
 	test('should return correct placementID for mpu in US when it is in mobile', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
-		expect(getOzonePlacementId([[300, 250]])).toBe('1500001036');
+		expect(getOzonePlacementId([[300, 250]], 'banner')).toBe('1500001036');
 	});
 
 	test('should return correct placementID for mobile-sticky in US', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMobileSticky.mockReturnValue(true);
-		expect(getOzonePlacementId([[320, 50]])).toBe('3500014217');
+		expect(getOzonePlacementId([[320, 50]], 'banner')).toBe('3500014217');
 	});
 
 	test('should return correct placementID for mobile-sticky in ROW', () => {
 		isInRow.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMobileSticky.mockReturnValue(true);
-		expect(getOzonePlacementId([[320, 50]])).toBe('1500000260');
+		expect(getOzonePlacementId([[320, 50]], 'banner')).toBe('1500000260');
 	});
 
 	test('should return correct placementID for hangtime ads in inline2 in UK', () => {
 		isInUk.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
-		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline2')).toBe(
-			'1500001025',
-		);
+		expect(
+			getOzonePlacementId([[300, 250]], 'banner', 'dfp-ad--inline2'),
+		).toBe('1500001025');
 	});
 
 	test('should return correct placementID for hangtime ads in inline2 in ROW', () => {
 		isInRow.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
-		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline2')).toBe(
-			'1500001025',
-		);
+		expect(
+			getOzonePlacementId([[300, 250]], 'banner', 'dfp-ad--inline2'),
+		).toBe('1500001025');
 	});
 
 	test('should return correct placementID for hangtime ads in inline2 in US', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
-		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline2')).toBe(
-			'1500001025',
-		);
+		expect(
+			getOzonePlacementId([[300, 250]], 'banner', 'dfp-ad--inline2'),
+		).toBe('1500001025');
 	});
 
 	test('should return correct placementID for hangtime ads in inline2 in AUZ or NZ', () => {
 		isInAuOrNz.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
-		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline2')).toBe(
-			'1500001025',
-		);
+		expect(
+			getOzonePlacementId([[300, 250]], 'banner', 'dfp-ad--inline2'),
+		).toBe('1500001025');
 	});
 
 	test('should NOT return hangtime for non-inline2 mobile MPU slots', () => {
@@ -1118,24 +1113,24 @@ describe('getOzonePlacementId', () => {
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
 		containsMobileSticky.mockReturnValue(false);
-		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline3')).toBe(
-			'1500001036',
-		);
+		expect(
+			getOzonePlacementId([[300, 250]], 'banner', 'dfp-ad--inline3'),
+		).toBe('1500001036');
 	});
 
 	test('should NOT return hangtime for desktop inline2 slots', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('D');
 		containsMpuOrDmpu.mockReturnValue(true);
-		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline2')).toBe(
-			'3500010911',
-		); // ← Should get desktop MPU, not hangtime
+		expect(
+			getOzonePlacementId([[300, 250]], 'banner', 'dfp-ad--inline2'),
+		).toBe('3500010911'); // ← Should get desktop MPU, not hangtime
 	});
 
 	test('should return correct placementID if none of the conditions are met', () => {
 		isInUk.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('T');
 		containsMpu.mockReturnValue(true);
-		expect(getOzonePlacementId([[300, 250]])).toBe('0420420500');
+		expect(getOzonePlacementId([[300, 250]], 'banner')).toBe('0420420500');
 	});
 });

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -355,9 +355,9 @@ describe('bids', () => {
 			.mockReturnValueOnce(false) // triplelift
 			.mockReturnValueOnce(false) // and
 			.mockReturnValueOnce(false) // xhb
+			.mockReturnValueOnce(false) // pubmatic
 			.mockReturnValueOnce(false) // ozone - banner
 			.mockReturnValueOnce(false) // ozone - video
-			.mockReturnValueOnce(false) // pubmatic
 			.mockReturnValueOnce(false) // oxd
 			.mockReturnValueOnce(false) // kargo
 			.mockReturnValueOnce(true); // teads
@@ -375,9 +375,9 @@ describe('bids', () => {
 			.mockReturnValueOnce(false) // triplelift
 			.mockReturnValueOnce(false) // and
 			.mockReturnValueOnce(false) // xhb
+			.mockReturnValueOnce(false) // pubmatic
 			.mockReturnValueOnce(false) // ozone - banner
 			.mockReturnValueOnce(false) // ozone - video
-			.mockReturnValueOnce(false) // pubmatic
 			.mockReturnValueOnce(false) // oxd
 			.mockReturnValueOnce(false) // kargo
 			.mockReturnValueOnce(false) // teads

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -374,6 +374,10 @@ const getOzonePlacementId = (
 	slotId?: string,
 	pageTargeting?: PageTargeting,
 ) => {
+	if (slotId === 'dfp-ad--inline1') {
+		return '1500001169';
+	}
+
 	if (isInUsa()) {
 		if (getBreakpointKey() === 'D') {
 			if (containsBillboard(sizes)) {

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -380,6 +380,10 @@ const getOzonePlacementId = (
 		'variant',
 	);
 
+	/**
+	 * We'd like to use this placement ID for outstream only, but AFAICT there's no way to link a Placement ID
+	 * to a media type. Therefore, the placement ID has to be associated with the slot/sizes instead.
+	 */
 	if (isInOzoneAbTest && slotId === 'dfp-ad--inline1') {
 		return '1500001169';
 	}

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -43,6 +43,7 @@ import {
 	containsPortraitInterstitial,
 	containsWS,
 	getBreakpointKey,
+	isOutstream,
 	shouldIncludeBidder,
 	stripDfpAdPrefixFrom,
 	stripMobileSuffix,
@@ -370,21 +371,14 @@ const getTeadsParams = (
 
 	return undefined;
 };
+
 const getOzonePlacementId = (
 	sizes: Size[],
+	mediaType: 'banner' | 'video',
 	slotId?: string,
 	pageTargeting?: PageTargeting,
 ) => {
-	const isInOzoneAbTest = isUserInTestGroup(
-		'commercial-ozone-outstream',
-		'variant',
-	);
-
-	/**
-	 * We'd like to use this placement ID for outstream only, but AFAICT there's no way to link a Placement ID
-	 * to a media type. Therefore, the placement ID has to be associated with the slot/sizes instead.
-	 */
-	if (isInOzoneAbTest && slotId === 'dfp-ad--inline1') {
+	if (mediaType === 'video') {
 		return '1500001169';
 	}
 
@@ -442,35 +436,59 @@ const teadsBidder: PrebidBidder = {
 	},
 };
 
-const ozoneBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
+/**
+ * Ozone has a separate bidder for each supported mediaType: banner and video
+ */
+const ozoneBidders: (
+	slotSizes: Size[],
 	pageTargeting: PageTargeting,
-) => ({
-	name: 'ozone',
-	switchName: 'prebidOzone',
-	bidParams: (_slotId: string, sizes: Size[]): PrebidOzoneParams => {
-		const advert = dfpEnv.adverts.get(_slotId);
-		const testgroup = advert?.testgroup
-			? { testgroup: advert.testgroup }
-			: {};
+) => PrebidBidder[] = (slotSizes: Size[], pageTargeting: PageTargeting) => {
+	const isInOzoneAbTest = isUserInTestGroup(
+		'commercial-ozone-outstream',
+		'variant',
+	);
 
-		return {
-			publisherId: 'OZONEGMG0001',
-			siteId: '4204204209',
-			placementId: getOzonePlacementId(sizes, _slotId, pageTargeting),
-			customData: [
-				{
-					settings: {},
-					targeting: {
-						// Assigns a random integer between 0 and 99
-						...testgroup,
-						...buildAppNexusTargetingObject(pageTargeting),
+	const bidders: Array<'banner' | 'video'> = ['banner'];
+
+	const isVideoSlotSizes =
+		slotSizes.filter((size) => isOutstream(size)).length > 0;
+	if (isInOzoneAbTest && isVideoSlotSizes) {
+		bidders.push('video');
+	}
+
+	return bidders.map((mediaType) => ({
+		name: 'ozone',
+		switchName: 'prebidOzone',
+		bidParams: (_slotId: string, sizes: Size[]): PrebidOzoneParams => {
+			const advert = dfpEnv.adverts.get(_slotId);
+			const testgroup = advert?.testgroup
+				? { testgroup: advert.testgroup }
+				: {};
+
+			return {
+				publisherId: 'OZONEGMG0001',
+				siteId: '4204204209',
+				placementId: getOzonePlacementId(
+					sizes,
+					mediaType,
+					_slotId,
+					pageTargeting,
+				),
+				customData: [
+					{
+						settings: {},
+						targeting: {
+							// Assigns a random integer between 0 and 99
+							...testgroup,
+							...buildAppNexusTargetingObject(pageTargeting),
+						},
 					},
-				},
-			],
-			ozoneData: {}, // TODO: confirm if we need to send any
-		};
-	},
-});
+				],
+				ozoneData: {}, // TODO: confirm if we need to send any
+			};
+		},
+	}));
+};
 
 const getPubmaticPublisherId = (): string => {
 	if (isInUsOrCa()) {
@@ -607,7 +625,7 @@ const kargoBidder: PrebidBidder = {
 };
 
 const magniteBidder: PrebidBidder = {
-	//Rubicon is the old name for Magnite but it is still used for the integration
+	// Rubicon is the old name for Magnite but it is still used for the integration
 	name: 'rubicon',
 	switchName: 'prebidMagnite',
 	bidParams: (slotId: string, sizes: Size[]): PrebidMagniteParams => ({
@@ -658,6 +676,10 @@ const currentBidders = (
 		? indexExchangeBidders(slotSizes)
 		: [];
 
+	const ozoneBids = shouldInclude('ozone')
+		? ozoneBidders(slotSizes, pageTargeting)
+		: [];
+
 	const biddersToCheck: Array<[boolean, PrebidBidder]> = [
 		[shouldInclude('criteo'), criteoBidder(slotSizes)],
 		[shouldInclude('trustx'), trustXBidder],
@@ -665,7 +687,6 @@ const currentBidders = (
 		[shouldInclude('and'), appNexusBidder(pageTargeting)],
 		[shouldInclude('xhb'), xaxisBidder],
 		[shouldInclude('pubmatic'), pubmaticBidder(slotSizes)],
-		[shouldInclude('ozone'), ozoneBidder(pageTargeting)],
 		[shouldInclude('oxd'), openxBidder(pageTargeting)],
 		[shouldInclude('kargo'), kargoBidder],
 		[shouldInclude('teads'), teadsBidder],
@@ -677,7 +698,7 @@ const currentBidders = (
 		.filter(([shouldInclude]) => inPbTestOr(shouldInclude))
 		.map(([, bidder]) => bidder);
 
-	const allBidders = [...ixBidders, ...otherBidders];
+	const allBidders = [...ixBidders, ...ozoneBids, ...otherBidders];
 
 	return isPbTestOn() ? biddersBeingTested(allBidders) : allBidders;
 };

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -386,11 +386,11 @@ const getOzonePlacementId = (
 
 	if (isInUsa()) {
 		if (getBreakpointKey() === 'D') {
-			if (containsBillboard(sizes)) {
+			if (containsLeaderboardOrBillboard(sizes)) {
 				return '3500010912';
 			}
 
-			if (containsMpu(sizes)) {
+			if (containsMpuOrDmpu(sizes)) {
 				return '3500010911';
 			}
 		}

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -375,12 +375,12 @@ const getOzonePlacementId = (
 	slotId?: string,
 	pageTargeting?: PageTargeting,
 ) => {
-	const isInTeadsTest = isUserInTestGroup(
+	const isInOzoneAbTest = isUserInTestGroup(
 		'commercial-ozone-outstream',
 		'variant',
 	);
 
-	if (isInTeadsTest && slotId === 'dfp-ad--inline1') {
+	if (isInOzoneAbTest && slotId === 'dfp-ad--inline1') {
 		return '1500001169';
 	}
 

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -10,6 +10,7 @@ import type { ConsentState } from '@guardian/consent-manager';
 import { log } from '@guardian/libs';
 import type { AdUnitBidDefinition } from 'prebid.js/dist/src/adUnits';
 import type { Size } from 'prebid.js/dist/src/types/common';
+import { isUserInTestGroup } from '../../../../ab-testing';
 import type { PrebidIndexSite } from '../../../../types/global';
 import { dfpEnv } from '../../../dfp/dfp-env';
 import { buildAppNexusTargetingObject } from '../../../page-targeting';
@@ -374,7 +375,12 @@ const getOzonePlacementId = (
 	slotId?: string,
 	pageTargeting?: PageTargeting,
 ) => {
-	if (slotId === 'dfp-ad--inline1') {
+	const isInTeadsTest = isUserInTestGroup(
+		'commercial-ozone-outstream',
+		'variant',
+	);
+
+	if (isInTeadsTest && slotId === 'dfp-ad--inline1') {
 		return '1500001169';
 	}
 

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -374,11 +374,11 @@ const getTeadsParams = (
 
 const getOzonePlacementId = (
 	sizes: Size[],
-	mediaType: 'banner' | 'video',
+	bidderType: 'banner' | 'video',
 	slotId?: string,
 	pageTargeting?: PageTargeting,
 ) => {
-	if (mediaType === 'video') {
+	if (bidderType === 'video') {
 		return '1500001169';
 	}
 
@@ -437,57 +437,64 @@ const teadsBidder: PrebidBidder = {
 };
 
 /**
- * Ozone has a separate bidder for each supported mediaType: banner and video
+ * Ozone has a separate bidder for each supported PrebidAdUnit mediaType: banner and video
  */
-const ozoneBidders: (
-	slotSizes: Size[],
+const ozoneBidder: (
 	pageTargeting: PageTargeting,
-) => PrebidBidder[] = (slotSizes: Size[], pageTargeting: PageTargeting) => {
+	bidderType: 'banner' | 'video',
+) => PrebidBidder = (
+	pageTargeting: PageTargeting,
+	bidderType: 'banner' | 'video',
+) => ({
+	name: 'ozone',
+	switchName: 'prebidOzone',
+	bidParams: (_slotId: string, sizes: Size[]): PrebidOzoneParams => {
+		const advert = dfpEnv.adverts.get(_slotId);
+		const testgroup = advert?.testgroup
+			? { testgroup: advert.testgroup }
+			: {};
+
+		return {
+			publisherId: 'OZONEGMG0001',
+			siteId: '4204204209',
+			placementId: getOzonePlacementId(
+				sizes,
+				bidderType,
+				_slotId,
+				pageTargeting,
+			),
+			customData: [
+				{
+					settings: {},
+					targeting: {
+						// Assigns a random integer between 0 and 99
+						...testgroup,
+						...buildAppNexusTargetingObject(pageTargeting),
+					},
+				},
+			],
+			ozoneData: {}, // TODO: confirm if we need to send any
+		};
+	},
+});
+
+const ozoneBannerBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
+	pageTargeting: PageTargeting,
+) => ozoneBidder(pageTargeting, 'banner');
+
+const ozoneVideoBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
+	pageTargeting: PageTargeting,
+) => ozoneBidder(pageTargeting, 'video');
+
+const shouldIncludeOzoneVideoBidder = (slotSizes: Size[]): boolean => {
 	const isInOzoneAbTest = isUserInTestGroup(
 		'commercial-ozone-outstream',
 		'variant',
 	);
 
-	const bidders: Array<'banner' | 'video'> = ['banner'];
+	const isVideoSlotSizes = slotSizes.some(isOutstream);
 
-	const isVideoSlotSizes =
-		slotSizes.filter((size) => isOutstream(size)).length > 0;
-	if (isInOzoneAbTest && isVideoSlotSizes) {
-		bidders.push('video');
-	}
-
-	return bidders.map((mediaType) => ({
-		name: 'ozone',
-		switchName: 'prebidOzone',
-		bidParams: (_slotId: string, sizes: Size[]): PrebidOzoneParams => {
-			const advert = dfpEnv.adverts.get(_slotId);
-			const testgroup = advert?.testgroup
-				? { testgroup: advert.testgroup }
-				: {};
-
-			return {
-				publisherId: 'OZONEGMG0001',
-				siteId: '4204204209',
-				placementId: getOzonePlacementId(
-					sizes,
-					mediaType,
-					_slotId,
-					pageTargeting,
-				),
-				customData: [
-					{
-						settings: {},
-						targeting: {
-							// Assigns a random integer between 0 and 99
-							...testgroup,
-							...buildAppNexusTargetingObject(pageTargeting),
-						},
-					},
-				],
-				ozoneData: {}, // TODO: confirm if we need to send any
-			};
-		},
-	}));
+	return isInOzoneAbTest && isVideoSlotSizes;
 };
 
 const getPubmaticPublisherId = (): string => {
@@ -676,10 +683,6 @@ const currentBidders = (
 		? indexExchangeBidders(slotSizes)
 		: [];
 
-	const ozoneBids = shouldInclude('ozone')
-		? ozoneBidders(slotSizes, pageTargeting)
-		: [];
-
 	const biddersToCheck: Array<[boolean, PrebidBidder]> = [
 		[shouldInclude('criteo'), criteoBidder(slotSizes)],
 		[shouldInclude('trustx'), trustXBidder],
@@ -687,6 +690,11 @@ const currentBidders = (
 		[shouldInclude('and'), appNexusBidder(pageTargeting)],
 		[shouldInclude('xhb'), xaxisBidder],
 		[shouldInclude('pubmatic'), pubmaticBidder(slotSizes)],
+		[shouldInclude('ozone'), ozoneBannerBidder(pageTargeting)],
+		[
+			shouldInclude('ozone') && shouldIncludeOzoneVideoBidder(slotSizes),
+			ozoneVideoBidder(pageTargeting),
+		],
 		[shouldInclude('oxd'), openxBidder(pageTargeting)],
 		[shouldInclude('kargo'), kargoBidder],
 		[shouldInclude('teads'), teadsBidder],
@@ -698,7 +706,7 @@ const currentBidders = (
 		.filter(([shouldInclude]) => inPbTestOr(shouldInclude))
 		.map(([, bidder]) => bidder);
 
-	const allBidders = [...ixBidders, ...ozoneBids, ...otherBidders];
+	const allBidders = [...ixBidders, ...otherBidders];
 
 	return isPbTestOn() ? biddersBeingTested(allBidders) : allBidders;
 };

--- a/bundle/src/lib/header-bidding/prebid/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.ts
@@ -119,7 +119,6 @@ const initialise = async (
 	};
 
 	// configure analytics
-
 	const analytics: Array<AnalyticsConfig<string>> = [];
 	const guAnalytics = getGUAnalyticsConfig();
 	if (guAnalytics) {
@@ -243,6 +242,7 @@ const requestBids = async (
 				});
 			}),
 	);
+
 	return requestQueue;
 };
 

--- a/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.spec.ts
@@ -91,7 +91,8 @@ describe('PrebidAdUnit', () => {
 			sizes: [
 				[300, 250],
 				[620, 350],
-				[550, 310],
+				[300, 197],
+				[640, 360],
 			],
 		};
 
@@ -104,12 +105,13 @@ describe('PrebidAdUnit', () => {
 
 		expect(adUnit.mediaTypes).toEqual({
 			banner: {
-				sizes: slot.sizes,
+				sizes: [[300, 250]],
 			},
 			video: {
 				playerSize: [
 					[620, 350],
-					[550, 310],
+					[300, 197],
+					[640, 360],
 				],
 				context: 'outstream',
 				placement: 3,
@@ -158,6 +160,43 @@ describe('PrebidAdUnit', () => {
 		expect(adUnit.mediaTypes).toEqual({
 			banner: {
 				sizes: slot.sizes,
+			},
+		});
+	});
+
+	test('uses outstream video sizes only in video media type when in AB test', () => {
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
+		const advert = buildAdvert('dfp-ad--inline1');
+		const slot: HeaderBiddingSlot = {
+			key: 'inline1',
+			sizes: [
+				[300, 250],
+				[620, 350],
+				[300, 197],
+				[640, 360],
+			],
+		};
+
+		const adUnit = new PrebidAdUnit(
+			advert,
+			slot,
+			mockPageTargeting,
+			mockConsentState,
+		);
+
+		expect(adUnit.mediaTypes).toEqual({
+			banner: {
+				sizes: [[300, 250]],
+			},
+			video: {
+				playerSize: [
+					[620, 350],
+					[300, 197],
+					[640, 360],
+				],
+				context: 'outstream',
+				placement: 3,
+				plcmt: 4,
 			},
 		});
 	});

--- a/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.spec.ts
@@ -1,6 +1,7 @@
 import type { PageTargeting } from '@guardian/commercial-core/targeting/build-page-targeting';
 import type { ConsentState } from '@guardian/consent-manager';
 import type { Size } from 'prebid.js/dist/src/types/common';
+import { isUserInTestGroup } from '../../../ab-testing';
 import type { Advert } from '../../../define/Advert';
 import type { HeaderBiddingSlot } from '../prebid-types';
 import { bids } from './bidders/config';
@@ -15,6 +16,10 @@ function buildDummyBid() {
 
 jest.mock('./bidders/config', () => ({
 	bids: jest.fn().mockReturnValue([buildDummyBid()]),
+}));
+
+jest.mock('../../../ab-testing', () => ({
+	isUserInTestGroup: jest.fn(),
 }));
 
 const mockedBids = bids as jest.MockedFunction<typeof bids>;
@@ -51,6 +56,7 @@ describe('PrebidAdUnit', () => {
 	});
 
 	test('adds the video media type for inline1 with only outstream-compatible sizes', () => {
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
 		const advert = buildAdvert('dfp-ad--inline1');
 		const slot: HeaderBiddingSlot = {
 			key: 'inline1',
@@ -87,6 +93,30 @@ describe('PrebidAdUnit', () => {
 	});
 
 	test('does not add the video media type for non-inline1 slots', () => {
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
+		const advert = buildAdvert('dfp-ad--top-above-nav');
+		const slot: HeaderBiddingSlot = {
+			key: 'top-above-nav',
+			sizes: [size(728, 90)],
+		};
+
+		const adUnit = new PrebidAdUnit(
+			advert,
+			slot,
+			mockPageTargeting,
+			mockConsentState,
+		);
+
+		expect(adUnit.mediaTypes).toEqual({
+			banner: {
+				sizes: slot.sizes,
+			},
+		});
+		expect(adUnit.bids).toEqual([buildDummyBid()]);
+	});
+
+	test('does not add the video media type when NOT in AB test', () => {
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
 		const advert = buildAdvert('dfp-ad--top-above-nav');
 		const slot: HeaderBiddingSlot = {
 			key: 'top-above-nav',

--- a/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.spec.ts
@@ -1,0 +1,110 @@
+import type { PageTargeting } from '@guardian/commercial-core/targeting/build-page-targeting';
+import type { ConsentState } from '@guardian/consent-manager';
+import type { Size } from 'prebid.js/dist/src/types/common';
+import type { Advert } from '../../../define/Advert';
+import type { HeaderBiddingSlot } from '../prebid-types';
+import { bids } from './bidders/config';
+import { PrebidAdUnit } from './prebid-ad-unit';
+
+function buildDummyBid() {
+	return {
+		bidder: 'dummy-bidder',
+		params: { placementId: 'dummy-placement-id' },
+	};
+}
+
+jest.mock('./bidders/config', () => ({
+	bids: jest.fn().mockReturnValue([buildDummyBid()]),
+}));
+
+const mockedBids = bids as jest.MockedFunction<typeof bids>;
+
+const mockPageTargeting = {} as PageTargeting;
+
+const mockConsentState = {
+	tcfv2: {
+		consents: { 1: false },
+		eventStatus: 'tcloaded',
+		vendorConsents: { abc: false },
+		addtlConsent: 'xyz',
+		gdprApplies: true,
+		tcString: 'YAAA',
+	},
+	gpcSignal: true,
+	canTarget: true,
+	framework: 'tcfv2',
+} satisfies ConsentState;
+
+const buildAdvert = (id: string) =>
+	({
+		id,
+		gpid: 'test-gpid',
+		headerBiddingSizes: null,
+	}) as unknown as Advert;
+
+const size = (width: number, height: number): Size => [width, height];
+
+describe('PrebidAdUnit', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockedBids.mockReturnValue([buildDummyBid()]);
+	});
+
+	test('adds the video media type for inline1 with only outstream-compatible sizes', () => {
+		const advert = buildAdvert('dfp-ad--inline1');
+		const slot: HeaderBiddingSlot = {
+			key: 'inline1',
+			sizes: [size(300, 250), size(620, 350), size(550, 310)],
+		};
+
+		const adUnit = new PrebidAdUnit(
+			advert,
+			slot,
+			mockPageTargeting,
+			mockConsentState,
+		);
+
+		expect(adUnit.mediaTypes).toEqual({
+			banner: {
+				sizes: slot.sizes,
+			},
+			video: {
+				playerSize: [size(620, 350), size(550, 310)],
+				context: 'outstream',
+				placement: 3,
+				plcmt: 4,
+			},
+		});
+		expect(adUnit.bids).toEqual([buildDummyBid()]);
+		expect(mockedBids).toHaveBeenCalledWith(
+			advert.id,
+			slot.sizes,
+			mockPageTargeting,
+			advert.gpid,
+			mockConsentState,
+		);
+		expect(advert.headerBiddingSizes).toEqual(slot.sizes);
+	});
+
+	test('does not add the video media type for non-inline1 slots', () => {
+		const advert = buildAdvert('dfp-ad--top-above-nav');
+		const slot: HeaderBiddingSlot = {
+			key: 'top-above-nav',
+			sizes: [size(728, 90)],
+		};
+
+		const adUnit = new PrebidAdUnit(
+			advert,
+			slot,
+			mockPageTargeting,
+			mockConsentState,
+		);
+
+		expect(adUnit.mediaTypes).toEqual({
+			banner: {
+				sizes: slot.sizes,
+			},
+		});
+		expect(adUnit.bids).toEqual([buildDummyBid()]);
+	});
+});

--- a/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.spec.ts
@@ -1,6 +1,5 @@
 import type { PageTargeting } from '@guardian/commercial-core/targeting/build-page-targeting';
 import type { ConsentState } from '@guardian/consent-manager';
-import type { Size } from 'prebid.js/dist/src/types/common';
 import { isUserInTestGroup } from '../../../ab-testing';
 import type { Advert } from '../../../define/Advert';
 import type { HeaderBiddingSlot } from '../prebid-types';
@@ -47,20 +46,53 @@ const buildAdvert = (id: string) =>
 		headerBiddingSizes: null,
 	}) as unknown as Advert;
 
-const size = (width: number, height: number): Size => [width, height];
-
 describe('PrebidAdUnit', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		mockedBids.mockReturnValue([buildDummyBid()]);
 	});
 
-	test('adds the video media type for inline1 with only outstream-compatible sizes', () => {
+	test('returns the correct bids and sizes for slot', () => {
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
+		const advert = buildAdvert('dfp-ad--top-above-nav');
+		const slot: HeaderBiddingSlot = {
+			key: 'top-above-nav',
+			sizes: [[728, 90]],
+		};
+
+		const adUnit = new PrebidAdUnit(
+			advert,
+			slot,
+			mockPageTargeting,
+			mockConsentState,
+		);
+
+		expect(adUnit.mediaTypes).toEqual({
+			banner: {
+				sizes: slot.sizes,
+			},
+		});
+		expect(adUnit.bids).toEqual([buildDummyBid()]);
+		expect(mockedBids).toHaveBeenCalledWith(
+			advert.id,
+			slot.sizes,
+			mockPageTargeting,
+			advert.gpid,
+			mockConsentState,
+		);
+		expect(advert.headerBiddingSizes).toEqual(slot.sizes);
+	});
+
+	test('adds the video media type for non-inline1 slots', () => {
 		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
 		const advert = buildAdvert('dfp-ad--inline1');
 		const slot: HeaderBiddingSlot = {
 			key: 'inline1',
-			sizes: [size(300, 250), size(620, 350), size(550, 310)],
+			sizes: [
+				[300, 250],
+				[620, 350],
+				[550, 310],
+			],
 		};
 
 		const adUnit = new PrebidAdUnit(
@@ -75,21 +107,15 @@ describe('PrebidAdUnit', () => {
 				sizes: slot.sizes,
 			},
 			video: {
-				playerSize: [size(620, 350), size(550, 310)],
+				playerSize: [
+					[620, 350],
+					[550, 310],
+				],
 				context: 'outstream',
 				placement: 3,
 				plcmt: 4,
 			},
 		});
-		expect(adUnit.bids).toEqual([buildDummyBid()]);
-		expect(mockedBids).toHaveBeenCalledWith(
-			advert.id,
-			slot.sizes,
-			mockPageTargeting,
-			advert.gpid,
-			mockConsentState,
-		);
-		expect(advert.headerBiddingSizes).toEqual(slot.sizes);
 	});
 
 	test('does not add the video media type for non-inline1 slots', () => {
@@ -97,7 +123,7 @@ describe('PrebidAdUnit', () => {
 		const advert = buildAdvert('dfp-ad--top-above-nav');
 		const slot: HeaderBiddingSlot = {
 			key: 'top-above-nav',
-			sizes: [size(728, 90)],
+			sizes: [[728, 90]],
 		};
 
 		const adUnit = new PrebidAdUnit(
@@ -112,15 +138,14 @@ describe('PrebidAdUnit', () => {
 				sizes: slot.sizes,
 			},
 		});
-		expect(adUnit.bids).toEqual([buildDummyBid()]);
 	});
 
 	test('does not add the video media type when NOT in AB test', () => {
 		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
-		const advert = buildAdvert('dfp-ad--top-above-nav');
+		const advert = buildAdvert('dfp-ad--inline1');
 		const slot: HeaderBiddingSlot = {
-			key: 'top-above-nav',
-			sizes: [size(728, 90)],
+			key: 'inline1',
+			sizes: [[728, 90]],
 		};
 
 		const adUnit = new PrebidAdUnit(
@@ -135,6 +160,5 @@ describe('PrebidAdUnit', () => {
 				sizes: slot.sizes,
 			},
 		});
-		expect(adUnit.bids).toEqual([buildDummyBid()]);
 	});
 });

--- a/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
@@ -1,5 +1,3 @@
-import type { AdSizeString } from '@guardian/commercial-core/ad-sizes';
-import { outstreamSizes } from '@guardian/commercial-core/ad-sizes';
 import type { PageTargeting } from '@guardian/commercial-core/targeting/build-page-targeting';
 import type { ConsentState } from '@guardian/consent-manager';
 import { log } from '@guardian/libs';
@@ -8,20 +6,12 @@ import type {
 	AdUnitDefinition,
 } from 'prebid.js/dist/src/adUnits';
 import type { MediaTypes } from 'prebid.js/dist/src/mediaTypes';
-import type { Size } from 'prebid.js/dist/src/types/common';
 import type { VideoMediaType } from 'prebid.js/dist/src/video';
 import { isUserInTestGroup } from '../../../ab-testing';
 import type { Advert } from '../../../define/Advert';
 import type { HeaderBiddingSlot } from '../prebid-types';
+import { isOutstream } from '../utils';
 import { bids } from './bidders/config';
-
-/**
- * Outstream ad sizes are only compatible with the mediaTypes.video property of PrebidAdUnit
- */
-const isOutstream = (size: Size) =>
-	Object.values(outstreamSizes)
-		.map((outstreamSize) => outstreamSize.toString())
-		.includes(size.toString() as AdSizeString);
 
 export class PrebidAdUnit implements AdUnitDefinition {
 	code: string;
@@ -48,17 +38,21 @@ export class PrebidAdUnit implements AdUnitDefinition {
 			'variant',
 		);
 
+		/**
+		 * Outstream ad sizes are only compatible with the mediaTypes.video property of PrebidAdUnit
+		 */
+		const bannerSizes = slot.sizes.filter((size) => !isOutstream(size));
+		const videoSizes = slot.sizes.filter((size) => isOutstream(size));
+
 		this.code = advert.id;
 		this.mediaTypes = {
 			banner: {
-				sizes: slot.sizes.filter((size) => !isOutstream(size)),
+				sizes: bannerSizes,
 			},
 			...(isInOzoneAbTest && slot.key === 'inline1'
 				? {
 						video: {
-							playerSize: slot.sizes.filter((size) =>
-								isOutstream(size),
-							),
+							playerSize: videoSizes,
 							context: 'outstream',
 							placement: 3, // in-article
 							plcmt: 4, // outstream

--- a/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
@@ -52,8 +52,8 @@ export class PrebidAdUnit implements AdUnitDefinition {
 			...(isInOzoneAbTest && slot.key === 'inline1'
 				? {
 						video: {
-							playerSize: videoSizes,
 							context: 'outstream',
+							playerSize: videoSizes,
 							placement: 3, // in-article
 							plcmt: 4, // outstream
 						} as VideoMediaType,
@@ -80,6 +80,11 @@ export class PrebidAdUnit implements AdUnitDefinition {
 
 		advert.headerBiddingSizes = slot.sizes;
 
-		log('commercial', `PrebidAdUnit ${this.code}`, this.bids);
+		log(
+			'commercial',
+			`PrebidAdUnit ${this.code}`,
+			this.mediaTypes,
+			this.bids,
+		);
 	}
 }

--- a/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
@@ -10,6 +10,7 @@ import type {
 import type { MediaTypes } from 'prebid.js/dist/src/mediaTypes';
 import type { Size } from 'prebid.js/dist/src/types/common';
 import type { VideoMediaType } from 'prebid.js/dist/src/video';
+import { isUserInTestGroup } from '../../../ab-testing';
 import type { Advert } from '../../../define/Advert';
 import type { HeaderBiddingSlot } from '../prebid-types';
 import { bids } from './bidders/config';
@@ -48,12 +49,17 @@ export class PrebidAdUnit implements AdUnitDefinition {
 		pageTargeting: PageTargeting,
 		consentState: ConsentState,
 	) {
+		const isInTeadsTest = isUserInTestGroup(
+			'commercial-ozone-outstream',
+			'variant',
+		);
+
 		this.code = advert.id;
 		this.mediaTypes = {
 			banner: {
 				sizes: slot.sizes,
 			},
-			...(slot.key === 'inline1'
+			...(isInTeadsTest && slot.key === 'inline1'
 				? {
 						video: {
 							playerSize: filterSizesForVideoMediaType(

--- a/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
@@ -49,7 +49,7 @@ export class PrebidAdUnit implements AdUnitDefinition {
 		pageTargeting: PageTargeting,
 		consentState: ConsentState,
 	) {
-		const isInTeadsTest = isUserInTestGroup(
+		const isInOzoneAbTest = isUserInTestGroup(
 			'commercial-ozone-outstream',
 			'variant',
 		);
@@ -59,7 +59,7 @@ export class PrebidAdUnit implements AdUnitDefinition {
 			banner: {
 				sizes: slot.sizes,
 			},
-			...(isInTeadsTest && slot.key === 'inline1'
+			...(isInOzoneAbTest && slot.key === 'inline1'
 				? {
 						video: {
 							playerSize: filterSizesForVideoMediaType(

--- a/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
@@ -1,4 +1,4 @@
-import type { AdSize } from '@guardian/commercial-core/ad-sizes';
+import type { AdSizeString } from '@guardian/commercial-core/ad-sizes';
 import { outstreamSizes } from '@guardian/commercial-core/ad-sizes';
 import type { PageTargeting } from '@guardian/commercial-core/targeting/build-page-targeting';
 import type { ConsentState } from '@guardian/consent-manager';
@@ -16,18 +16,12 @@ import type { HeaderBiddingSlot } from '../prebid-types';
 import { bids } from './bidders/config';
 
 /**
- * The ad sizes that are compatible for use with the mediaTypes.video property of PrebidAdUnit.
- * https://docs.prebid.org/dev-docs/adunit-reference.html#adUnit.mediaTypes
+ * Outstream ad sizes are only compatible with the mediaTypes.video property of PrebidAdUnit
  */
-const allowedVideoMediaTypeSizes: AdSize[] = Object.values(outstreamSizes);
-
-const filterSizesForVideoMediaType = (sizes: Size[]) =>
-	sizes.filter((size) =>
-		allowedVideoMediaTypeSizes.some(
-			(allowedSize) =>
-				allowedSize[0] === size[0] && allowedSize[1] === size[1],
-		),
-	);
+const isOutstream = (size: Size) =>
+	Object.values(outstreamSizes)
+		.map((outstreamSize) => outstreamSize.toString())
+		.includes(size.toString() as AdSizeString);
 
 export class PrebidAdUnit implements AdUnitDefinition {
 	code: string;
@@ -57,13 +51,13 @@ export class PrebidAdUnit implements AdUnitDefinition {
 		this.code = advert.id;
 		this.mediaTypes = {
 			banner: {
-				sizes: slot.sizes,
+				sizes: slot.sizes.filter((size) => !isOutstream(size)),
 			},
 			...(isInOzoneAbTest && slot.key === 'inline1'
 				? {
 						video: {
-							playerSize: filterSizesForVideoMediaType(
-								slot.sizes,
+							playerSize: slot.sizes.filter((size) =>
+								isOutstream(size),
 							),
 							context: 'outstream',
 							placement: 3, // in-article

--- a/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
@@ -1,3 +1,5 @@
+import type { AdSize } from '@guardian/commercial-core/ad-sizes';
+import { outstreamSizes } from '@guardian/commercial-core/ad-sizes';
 import type { PageTargeting } from '@guardian/commercial-core/targeting/build-page-targeting';
 import type { ConsentState } from '@guardian/consent-manager';
 import { log } from '@guardian/libs';
@@ -6,9 +8,25 @@ import type {
 	AdUnitDefinition,
 } from 'prebid.js/dist/src/adUnits';
 import type { MediaTypes } from 'prebid.js/dist/src/mediaTypes';
+import type { Size } from 'prebid.js/dist/src/types/common';
+import type { VideoMediaType } from 'prebid.js/dist/src/video';
 import type { Advert } from '../../../define/Advert';
 import type { HeaderBiddingSlot } from '../prebid-types';
 import { bids } from './bidders/config';
+
+/**
+ * The ad sizes that are compatible for use with the mediaTypes.video property of PrebidAdUnit.
+ * https://docs.prebid.org/dev-docs/adunit-reference.html#adUnit.mediaTypes
+ */
+const allowedVideoMediaTypeSizes: AdSize[] = Object.values(outstreamSizes);
+
+const filterSizesForVideoMediaType = (sizes: Size[]) =>
+	sizes.filter((size) =>
+		allowedVideoMediaTypeSizes.some(
+			(allowedSize) =>
+				allowedSize[0] === size[0] && allowedSize[1] === size[1],
+		),
+	);
 
 export class PrebidAdUnit implements AdUnitDefinition {
 	code: string;
@@ -31,7 +49,23 @@ export class PrebidAdUnit implements AdUnitDefinition {
 		consentState: ConsentState,
 	) {
 		this.code = advert.id;
-		this.mediaTypes = { banner: { sizes: slot.sizes } };
+		this.mediaTypes = {
+			banner: {
+				sizes: slot.sizes,
+			},
+			...(slot.key === 'inline1'
+				? {
+						video: {
+							playerSize: filterSizesForVideoMediaType(
+								slot.sizes,
+							),
+							context: 'outstream',
+							placement: 3, // in-article
+							plcmt: 4, // outstream
+						} as VideoMediaType,
+					}
+				: {}),
+		};
 		this.gpid = advert.gpid ?? '';
 		this.ortb2Imp = {
 			ext: {
@@ -51,6 +85,7 @@ export class PrebidAdUnit implements AdUnitDefinition {
 		);
 
 		advert.headerBiddingSizes = slot.sizes;
+
 		log('commercial', `PrebidAdUnit ${this.code}`, this.bids);
 	}
 }

--- a/bundle/src/lib/header-bidding/prebid/price-config.ts
+++ b/bundle/src/lib/header-bidding/prebid/price-config.ts
@@ -70,7 +70,8 @@ export const ozonePriceGranularity = (
 		sizeString === adSizes.billboard.toString() ||
 		sizeString === adSizes.mpu.toString() ||
 		sizeString === adSizes.outstreamDesktop.toString() ||
-		sizeString === adSizes.outstreamMobile.toString()
+		sizeString === adSizes.outstreamMobile.toString() ||
+		sizeString === adSizes.outstreamOzone.toString()
 	) {
 		return {
 			buckets: [

--- a/bundle/src/lib/header-bidding/slot-config.spec.ts
+++ b/bundle/src/lib/header-bidding/slot-config.spec.ts
@@ -2,8 +2,8 @@ import type { SizeMapping } from '@guardian/commercial-core/ad-sizes';
 import { adSizes, createAdSize } from '@guardian/commercial-core/ad-sizes';
 import { Advert } from '../../define/Advert';
 import { getHeaderBiddingAdSlots } from './slot-config';
-import { getBreakpointKey, shouldIncludeMobileSticky } from './utils';
 import type * as Utils from './utils';
+import { getBreakpointKey, shouldIncludeMobileSticky } from './utils';
 
 jest.mock('./utils', () => {
 	const original: typeof Utils = jest.requireActual('./utils');
@@ -127,6 +127,7 @@ describe('getPrebidAdSlots', () => {
 		expect(hbSlots[0]?.sizes).toEqual([
 			createAdSize(300, 250),
 			createAdSize(620, 350),
+			createAdSize(640, 360),
 		]);
 	});
 
@@ -138,6 +139,7 @@ describe('getPrebidAdSlots', () => {
 		expect(hbSlots).toHaveLength(1);
 		expect(hbSlots[0]?.sizes).toEqual([
 			createAdSize(300, 197),
+			createAdSize(640, 360),
 			createAdSize(300, 250),
 			createAdSize(320, 480),
 		]);

--- a/bundle/src/lib/header-bidding/slot-config.spec.ts
+++ b/bundle/src/lib/header-bidding/slot-config.spec.ts
@@ -1,5 +1,6 @@
 import type { SizeMapping } from '@guardian/commercial-core/ad-sizes';
 import { adSizes, createAdSize } from '@guardian/commercial-core/ad-sizes';
+import { isUserInTestGroup } from '../../ab-testing';
 import { Advert } from '../../define/Advert';
 import { getHeaderBiddingAdSlots } from './slot-config';
 import type * as Utils from './utils';
@@ -20,6 +21,10 @@ jest.mock('define/init-slot-ias', () => ({
 
 jest.mock('@guardian/commercial-core/targeting/teads-eligibility', () => ({
 	isEligibleForTeads: jest.fn(),
+}));
+
+jest.mock('../../ab-testing', () => ({
+	isUserInTestGroup: jest.fn(),
 }));
 
 const slotPrototype = {
@@ -118,8 +123,9 @@ describe('getPrebidAdSlots', () => {
 		]);
 	});
 
-	test('should return the correct inline1 slot at breakpoint D with no additional size mappings', () => {
+	test('should return the correct inline1 slot at breakpoint D with no additional size mappings and in test group', () => {
 		(getBreakpointKey as jest.Mock).mockReturnValue('D');
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
 		window.guardian.config.page.contentType = 'Article';
 
 		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline1'));
@@ -131,8 +137,22 @@ describe('getPrebidAdSlots', () => {
 		]);
 	});
 
-	test('should return the correct inline1 slot at breakpoint M with no additional size mappings', () => {
+	test('should return the correct inline1 slot at breakpoint D with no additional size mappings and NOT in test group', () => {
+		(getBreakpointKey as jest.Mock).mockReturnValue('D');
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
+		window.guardian.config.page.contentType = 'Article';
+
+		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline1'));
+		expect(hbSlots).toHaveLength(1);
+		expect(hbSlots[0]?.sizes).toEqual([
+			createAdSize(300, 250),
+			createAdSize(620, 350),
+		]);
+	});
+
+	test('should return the correct inline1 slot at breakpoint M with no additional size mappings and in test group', () => {
 		(getBreakpointKey as jest.Mock).mockReturnValue('M');
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
 		window.guardian.config.page.contentType = 'Article';
 
 		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline1'));
@@ -140,6 +160,19 @@ describe('getPrebidAdSlots', () => {
 		expect(hbSlots[0]?.sizes).toEqual([
 			createAdSize(300, 197),
 			createAdSize(640, 360),
+			createAdSize(300, 250),
+			createAdSize(320, 480),
+		]);
+	});
+	test('should return the correct inline1 slot at breakpoint M with no additional size mappings and NOT in test group', () => {
+		(getBreakpointKey as jest.Mock).mockReturnValue('M');
+		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
+		window.guardian.config.page.contentType = 'Article';
+
+		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline1'));
+		expect(hbSlots).toHaveLength(1);
+		expect(hbSlots[0]?.sizes).toEqual([
+			createAdSize(300, 197),
 			createAdSize(300, 250),
 			createAdSize(320, 480),
 		]);

--- a/bundle/src/lib/header-bidding/slot-config.ts
+++ b/bundle/src/lib/header-bidding/slot-config.ts
@@ -118,7 +118,7 @@ const getSlotSizeMapping = (): HeaderBiddingSizeMapping => {
 	const isArticle = contentType === 'Article';
 	const hasExtendedMostPop =
 		isArticle && window.guardian.config.switches.extendedMostPopular;
-	const isInTeadsTest = isUserInTestGroup(
+	const isInOzoneAbTest = isUserInTestGroup(
 		'commercial-ozone-outstream',
 		'variant',
 	);
@@ -159,20 +159,26 @@ const getSlotSizeMapping = (): HeaderBiddingSizeMapping => {
 				? [
 						getAdSize('mpu'),
 						getAdSize('outstreamDesktop'),
-						...(isInTeadsTest ? [getAdSize('outstreamOzone')] : []),
+						...(isInOzoneAbTest
+							? [getAdSize('outstreamOzone')]
+							: []),
 					]
 				: [getAdSize('mpu')],
 			tablet: isArticle
 				? [
 						getAdSize('mpu'),
 						getAdSize('outstreamDesktop'),
-						...(isInTeadsTest ? [getAdSize('outstreamOzone')] : []),
+						...(isInOzoneAbTest
+							? [getAdSize('outstreamOzone')]
+							: []),
 					]
 				: [getAdSize('mpu')],
 			mobile: isArticle
 				? [
 						getAdSize('outstreamMobile'),
-						...(isInTeadsTest ? [getAdSize('outstreamOzone')] : []),
+						...(isInOzoneAbTest
+							? [getAdSize('outstreamOzone')]
+							: []),
 						getAdSize('mpu'),
 						getAdSize('portraitInterstitial'),
 					]

--- a/bundle/src/lib/header-bidding/slot-config.ts
+++ b/bundle/src/lib/header-bidding/slot-config.ts
@@ -112,7 +112,7 @@ const getAdSize = (name: keyof typeof adSizes): Size => [
 	adSizes[name][1],
 ];
 
-const getSlots = (): HeaderBiddingSizeMapping => {
+const getSlotSizeMapping = (): HeaderBiddingSizeMapping => {
 	const { contentType, hasShowcaseMainElement } = window.guardian.config.page;
 	const isArticle = contentType === 'Article';
 	const hasExtendedMostPop =
@@ -151,14 +151,23 @@ const getSlots = (): HeaderBiddingSizeMapping => {
 		},
 		inline1: {
 			desktop: isArticle
-				? [getAdSize('mpu'), getAdSize('outstreamDesktop')]
+				? [
+						getAdSize('mpu'),
+						getAdSize('outstreamDesktop'),
+						getAdSize('outstreamOzone'),
+					]
 				: [getAdSize('mpu')],
 			tablet: isArticle
-				? [getAdSize('mpu'), getAdSize('outstreamDesktop')]
+				? [
+						getAdSize('mpu'),
+						getAdSize('outstreamDesktop'),
+						getAdSize('outstreamOzone'),
+					]
 				: [getAdSize('mpu')],
 			mobile: isArticle
 				? [
 						getAdSize('outstreamMobile'),
+						getAdSize('outstreamOzone'),
 						getAdSize('mpu'),
 						getAdSize('portraitInterstitial'),
 					]
@@ -256,7 +265,8 @@ export const getHeaderBiddingAdSlots = (
 	slotFlatMap: SlotFlatMap = (s) => [s],
 ): HeaderBiddingSlot[] => {
 	const breakpoint = getHbBreakpoint();
-	const headerBiddingSlots = filterByAdvert(ad, breakpoint, getSlots());
+	const slotSizeMapping = getSlotSizeMapping();
+	const headerBiddingSlots = filterByAdvert(ad, breakpoint, slotSizeMapping);
 
 	return headerBiddingSlots
 		.map(filterBySizeMapping(ad.sizes[breakpoint]))

--- a/bundle/src/lib/header-bidding/slot-config.ts
+++ b/bundle/src/lib/header-bidding/slot-config.ts
@@ -2,6 +2,7 @@ import type { AdSize } from '@guardian/commercial-core/ad-sizes';
 import { adSizes } from '@guardian/commercial-core/ad-sizes';
 import { isInUk } from '@guardian/commercial-core/geo/geo-utils';
 import type { Size } from 'prebid.js/dist/src/types/common';
+import { isUserInTestGroup } from '../../ab-testing';
 import type { Advert } from '../../define/Advert';
 import type {
 	HeaderBiddingSizeKey,
@@ -117,6 +118,10 @@ const getSlotSizeMapping = (): HeaderBiddingSizeMapping => {
 	const isArticle = contentType === 'Article';
 	const hasExtendedMostPop =
 		isArticle && window.guardian.config.switches.extendedMostPopular;
+	const isInTeadsTest = isUserInTestGroup(
+		'commercial-ozone-outstream',
+		'variant',
+	);
 
 	return {
 		right: {
@@ -154,20 +159,20 @@ const getSlotSizeMapping = (): HeaderBiddingSizeMapping => {
 				? [
 						getAdSize('mpu'),
 						getAdSize('outstreamDesktop'),
-						getAdSize('outstreamOzone'),
+						...(isInTeadsTest ? [getAdSize('outstreamOzone')] : []),
 					]
 				: [getAdSize('mpu')],
 			tablet: isArticle
 				? [
 						getAdSize('mpu'),
 						getAdSize('outstreamDesktop'),
-						getAdSize('outstreamOzone'),
+						...(isInTeadsTest ? [getAdSize('outstreamOzone')] : []),
 					]
 				: [getAdSize('mpu')],
 			mobile: isArticle
 				? [
 						getAdSize('outstreamMobile'),
-						getAdSize('outstreamOzone'),
+						...(isInTeadsTest ? [getAdSize('outstreamOzone')] : []),
 						getAdSize('mpu'),
 						getAdSize('portraitInterstitial'),
 					]

--- a/bundle/src/lib/header-bidding/utils.ts
+++ b/bundle/src/lib/header-bidding/utils.ts
@@ -1,4 +1,8 @@
 import {
+	type AdSizeString,
+	outstreamSizes,
+} from '@guardian/commercial-core/ad-sizes';
+import {
 	isInAuOrNz,
 	isInCanada,
 	isInRow,
@@ -6,8 +10,7 @@ import {
 	isInUsa,
 	isInUsOrCa,
 } from '@guardian/commercial-core/geo/geo-utils';
-import { type ConsentState } from '@guardian/consent-manager';
-import { getConsentFor } from '@guardian/consent-manager';
+import { type ConsentState, getConsentFor } from '@guardian/consent-manager';
 import { isString } from '@guardian/libs';
 import { once } from 'lodash-es';
 import type { Size } from 'prebid.js/dist/src/types/common';
@@ -109,6 +112,11 @@ export const containsLeaderboardOrBillboard = (sizes: Size[]): boolean =>
 
 export const containsPortraitInterstitial = (sizes: Size[]): boolean =>
 	contains(sizes, [320, 480]);
+
+export const isOutstream = (size: Size) =>
+	Object.values(outstreamSizes)
+		.map((outstreamSize) => outstreamSize.toString())
+		.includes(size.toString() as AdSizeString);
 
 export const getLargestSize = (sizes: Size[]): Size | null => {
 	const reducer = (previous: Size, current: Size) => {

--- a/core/src/ad-sizes.ts
+++ b/core/src/ad-sizes.ts
@@ -1,5 +1,5 @@
-import { breakpoints, isBreakpoint } from './breakpoint';
 import type { Breakpoint } from './breakpoint';
+import { breakpoints, isBreakpoint } from './breakpoint';
 import type { Indices } from './types';
 
 type AdSizeString = 'fluid' | `${number},${number}`;
@@ -88,6 +88,7 @@ type SizeKeys =
 	| 'outstreamDesktop'
 	| 'outstreamGoogleDesktop'
 	| 'outstreamMobile'
+	| 'outstreamOzone'
 	| 'portrait'
 	| 'portraitInterstitial'
 	| 'pubmaticInterscroller'
@@ -148,6 +149,7 @@ const outstreamSizes = {
 	outstreamDesktop: createAdSize(620, 350),
 	outstreamGoogleDesktop: createAdSize(550, 310),
 	outstreamMobile: createAdSize(300, 197),
+	outstreamOzone: createAdSize(640, 360), // Uses the same size for both desktop and mobile
 };
 
 /**
@@ -473,15 +475,15 @@ const findAppliedSizesForBreakpoint = (
 // Export for testing
 export const _ = { createAdSize };
 
-export type { AdSizeString, SizeKeys, SizeMapping, SlotSizeMappings, SlotName };
+export type { AdSizeString, SizeKeys, SizeMapping, SlotName, SlotSizeMappings };
 
 export {
 	AdSize,
 	adSizes,
-	standardAdSizes,
-	outstreamSizes,
-	getAdSize,
-	slotSizeMappings,
 	createAdSize,
 	findAppliedSizesForBreakpoint,
+	getAdSize,
+	outstreamSizes,
+	slotSizeMappings,
+	standardAdSizes,
 };


### PR DESCRIPTION
AB test PR: https://github.com/guardian/dotcom-rendering/pull/16330

## What does this change?

- Introduces new Ozone Outstream video ad size (640x360)
- Adds `video` mediaType in Prebid requests for inline1 slot across all devices for outstream video sizes
- Uses outstream sizes as playerSize for this new media type

Encapsulates the new code in an AB test, so that this change can be tested before going live.

## Why?

We would like to improve our Ozone Outstream integration.

Tested locally and on CODE

## How to test?

- Go to an article with the AB test suffix appended to the URL: ?ab-commercial-ozone-outstream=variant
- Subscribe to the Commercial logger and check the PrebidAdUnit. There should be two ozone bidders: one of which should use the new inline1 placementId 1500001169. This is the video mediaType.
- Check that this is not true when not in the AB test.