### PR TITLE
Don't use old Ozone Outstream sizes when in AB test

### DIFF
--- a/bundle/src/lib/header-bidding/slot-config.spec.ts
+++ b/bundle/src/lib/header-bidding/slot-config.spec.ts
@@ -132,7 +132,6 @@ describe('getPrebidAdSlots', () => {
 		expect(hbSlots).toHaveLength(1);
 		expect(hbSlots[0]?.sizes).toEqual([
 			createAdSize(300, 250),
-			createAdSize(620, 350),
 			createAdSize(640, 360),
 		]);
 	});
@@ -158,7 +157,6 @@ describe('getPrebidAdSlots', () => {
 		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline1'));
 		expect(hbSlots).toHaveLength(1);
 		expect(hbSlots[0]?.sizes).toEqual([
-			createAdSize(300, 197),
 			createAdSize(640, 360),
 			createAdSize(300, 250),
 			createAdSize(320, 480),

--- a/bundle/src/lib/header-bidding/slot-config.ts
+++ b/bundle/src/lib/header-bidding/slot-config.ts
@@ -158,27 +158,24 @@ const getSlotSizeMapping = (): HeaderBiddingSizeMapping => {
 			desktop: isArticle
 				? [
 						getAdSize('mpu'),
-						getAdSize('outstreamDesktop'),
 						...(isInOzoneAbTest
 							? [getAdSize('outstreamOzone')]
-							: []),
+							: [getAdSize('outstreamDesktop')]),
 					]
 				: [getAdSize('mpu')],
 			tablet: isArticle
 				? [
 						getAdSize('mpu'),
-						getAdSize('outstreamDesktop'),
 						...(isInOzoneAbTest
 							? [getAdSize('outstreamOzone')]
-							: []),
+							: [getAdSize('outstreamDesktop')]),
 					]
 				: [getAdSize('mpu')],
 			mobile: isArticle
 				? [
-						getAdSize('outstreamMobile'),
 						...(isInOzoneAbTest
 							? [getAdSize('outstreamOzone')]
-							: []),
+							: [getAdSize('outstreamMobile')]),
 						getAdSize('mpu'),
 						getAdSize('portraitInterstitial'),
 					]


### PR DESCRIPTION
## What does this change?

When in the Ozone outstream AB test, no longer use the old Outstream sizes.

This is a fix for the implementation of Outstream Ozone https://github.com/guardian/commercial/pull/2611, which is behind this AB test: https://github.com/guardian/dotcom-rendering/pull/16330

## Why?

Following testing, it was found that we were not sending the correct size when both outstream sizes, old and new, were included.

## Screenshots

Taken from the inline1 `auction` network request

| Before | After |
| - | - |
| ![desktop-before] | ![desktop-after] |

[desktop-before]: https://github.com/user-attachments/assets/188bb86e-bf8a-4479-96f7-c1a60f45bb94
[desktop-after]: https://github.com/user-attachments/assets/d00ac676-7002-446d-ac38-6611e5f69d88
