### PR TITLE
update pageId and placementId values for Teads bidders in inline1 slot

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -522,8 +522,8 @@ describe('bids', () => {
 		).find((bid) => bid.bidder === 'teads');
 
 		expect(teadsBid?.params).toEqual({
-			pageId: 265029,
-			placementId: 248133,
+			pageId: 248133,
+			placementId: 265029,
 		});
 	});
 
@@ -838,8 +838,8 @@ describe('getTeadsParams', () => {
 			expect(
 				getTeadsParams([[300, 250]], 'dfp-ad--inline1'),
 			).toStrictEqual({
-				pageId: 265029,
-				placementId: 248133,
+				pageId: 248133,
+				placementId: 265029,
 			});
 		});
 	});
@@ -896,8 +896,8 @@ describe('getTeadsParams', () => {
 			expect(
 				getTeadsParams([[300, 250]], 'dfp-ad--inline1'),
 			).toStrictEqual({
-				pageId: 265030,
-				placementId: 248134,
+				pageId: 248134,
+				placementId: 265030,
 			});
 		});
 	});

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -278,7 +278,7 @@ const getTeadsParams = (
 	if (isInUk()) {
 		if (isDesktop) {
 			if (slotId === 'dfp-ad--inline1' && containsMpu(sizes)) {
-				return { pageId: 265029, placementId: 248133 };
+				return { pageId: 248133, placementId: 265029 };
 			}
 			if (
 				containsMpu(sizes) ||
@@ -299,7 +299,7 @@ const getTeadsParams = (
 	if (isInRow()) {
 		if (isDesktop) {
 			if (slotId === 'dfp-ad--inline1' && containsMpu(sizes)) {
-				return { pageId: 265030, placementId: 248134 };
+				return { pageId: 248134, placementId: 265030 };
 			}
 			if (
 				containsMpu(sizes) ||


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
This updates the pageId and placement Id for inline1 slots in UK and Rest of World regions.
## Why?
This is part of the broader work with integrating Teads within Prebid and a small update needed  to ensure the correct ID values are passed. 
Teads gave us an erroneous mapping for page IDs and Placement IDs where they were swapped in the initial request.