### PR TITLE
remove inline1-halfpage test gate logic

### DIFF
--- a/bundle/src/insert/spacefinder/article.ts
+++ b/bundle/src/insert/spacefinder/article.ts
@@ -1,6 +1,5 @@
 import type { AdSize, SizeMapping } from '@guardian/commercial-core/ad-sizes';
 import { adSizes } from '@guardian/commercial-core/ad-sizes';
-import { isUserInTestGroup } from '../../ab-testing';
 import { allowArticleBodyAdverts } from '../../lib/article-body-adverts';
 import type { ContainerOptions } from '../../lib/create-ad-slot';
 import {
@@ -212,12 +211,7 @@ const addDesktopRightRailAds = ({
 
 const additionalMobileAndTabletInlineSizes = (index: number) => {
 	if (index === 1) {
-		return isUserInTestGroup(
-			'commercial-mobile-inline1-halfpage',
-			'variant',
-		)
-			? { mobile: [adSizes.portraitInterstitial, adSizes.halfPage] }
-			: { mobile: [adSizes.portraitInterstitial] };
+		return { mobile: [adSizes.portraitInterstitial] };
 	} else if (index === 2) {
 		return {
 			mobile: [


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Removes the test gate for `commercial-mobile-inline1-halfpage` 
## Why?
This test gate is now redundant since we are no longer collecting data and have removed the test configuriaton in DCR: https://github.com/guardian/dotcom-rendering/pull/16398