### PR TITLE
Remove the second ozone bidder. Use one placementId for inline1 everywhere

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -356,8 +356,7 @@ describe('bids', () => {
 			.mockReturnValueOnce(false) // and
 			.mockReturnValueOnce(false) // xhb
 			.mockReturnValueOnce(false) // pubmatic
-			.mockReturnValueOnce(false) // ozone - banner
-			.mockReturnValueOnce(false) // ozone - video
+			.mockReturnValueOnce(false) // ozone
 			.mockReturnValueOnce(false) // oxd
 			.mockReturnValueOnce(false) // kargo
 			.mockReturnValueOnce(true); // teads
@@ -376,8 +375,7 @@ describe('bids', () => {
 			.mockReturnValueOnce(false) // and
 			.mockReturnValueOnce(false) // xhb
 			.mockReturnValueOnce(false) // pubmatic
-			.mockReturnValueOnce(false) // ozone - banner
-			.mockReturnValueOnce(false) // ozone - video
+			.mockReturnValueOnce(false) // ozone
 			.mockReturnValueOnce(false) // oxd
 			.mockReturnValueOnce(false) // kargo
 			.mockReturnValueOnce(false) // teads
@@ -1024,49 +1022,49 @@ describe('getOzonePlacementId', () => {
 		jest.resetAllMocks();
 	});
 
-	test('should return inline1 placementID for video media type', () => {
+	test('should return inline1 placementID for inline1 slot', () => {
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
 		containsMobileSticky.mockReturnValue(false);
 		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
-		expect(
-			getOzonePlacementId([[300, 250]], 'video', 'dfp-ad--inline1'),
-		).toBe('1500001169');
+		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline1')).toBe(
+			'1500001169',
+		);
 	});
 
 	test('should return correct placementID for billboard in US when it is in desktop', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('D');
 		containsLeaderboardOrBillboard.mockReturnValue(true);
-		expect(getOzonePlacementId([[970, 250]], 'banner')).toBe('3500010912');
+		expect(getOzonePlacementId([[970, 250]])).toBe('3500010912');
 	});
 
 	test('should return correct placementID for mpu in US when it is in desktop', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('D');
 		containsMpuOrDmpu.mockReturnValue(true);
-		expect(getOzonePlacementId([[300, 250]], 'banner')).toBe('3500010911');
+		expect(getOzonePlacementId([[300, 250]])).toBe('3500010911');
 	});
 
 	test('should return correct placementID for mpu in US when it is in mobile', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
-		expect(getOzonePlacementId([[300, 250]], 'banner')).toBe('1500001036');
+		expect(getOzonePlacementId([[300, 250]])).toBe('1500001036');
 	});
 
 	test('should return correct placementID for mobile-sticky in US', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMobileSticky.mockReturnValue(true);
-		expect(getOzonePlacementId([[320, 50]], 'banner')).toBe('3500014217');
+		expect(getOzonePlacementId([[320, 50]])).toBe('3500014217');
 	});
 
 	test('should return correct placementID for mobile-sticky in ROW', () => {
 		isInRow.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMobileSticky.mockReturnValue(true);
-		expect(getOzonePlacementId([[320, 50]], 'banner')).toBe('1500000260');
+		expect(getOzonePlacementId([[320, 50]])).toBe('1500000260');
 	});
 
 	// "Hangtime" - see the comment on getOzonePlacementId in config.ts for what this term means.
@@ -1074,36 +1072,36 @@ describe('getOzonePlacementId', () => {
 		isInUk.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
-		expect(
-			getOzonePlacementId([[300, 250]], 'banner', 'dfp-ad--inline2'),
-		).toBe('1500001025');
+		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline2')).toBe(
+			'1500001025',
+		);
 	});
 
 	test('should return correct placementID for hangtime ads in inline2 in ROW', () => {
 		isInRow.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
-		expect(
-			getOzonePlacementId([[300, 250]], 'banner', 'dfp-ad--inline2'),
-		).toBe('1500001025');
+		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline2')).toBe(
+			'1500001025',
+		);
 	});
 
 	test('should return correct placementID for hangtime ads in inline2 in US', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
-		expect(
-			getOzonePlacementId([[300, 250]], 'banner', 'dfp-ad--inline2'),
-		).toBe('1500001025');
+		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline2')).toBe(
+			'1500001025',
+		);
 	});
 
 	test('should return correct placementID for hangtime ads in inline2 in AUZ or NZ', () => {
 		isInAuOrNz.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
-		expect(
-			getOzonePlacementId([[300, 250]], 'banner', 'dfp-ad--inline2'),
-		).toBe('1500001025');
+		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline2')).toBe(
+			'1500001025',
+		);
 	});
 
 	test('should NOT return hangtime for non-inline2 mobile MPU slots', () => {
@@ -1111,24 +1109,24 @@ describe('getOzonePlacementId', () => {
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
 		containsMobileSticky.mockReturnValue(false);
-		expect(
-			getOzonePlacementId([[300, 250]], 'banner', 'dfp-ad--inline3'),
-		).toBe('1500001036');
+		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline3')).toBe(
+			'1500001036',
+		);
 	});
 
 	test('should NOT return hangtime for desktop inline2 slots', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('D');
 		containsMpuOrDmpu.mockReturnValue(true);
-		expect(
-			getOzonePlacementId([[300, 250]], 'banner', 'dfp-ad--inline2'),
-		).toBe('3500010911'); // ← Should get desktop MPU, not hangtime
+		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline2')).toBe(
+			'3500010911',
+		); // ← Should get desktop MPU, not hangtime
 	});
 
 	test('should return correct placementID if none of the conditions are met', () => {
 		isInUk.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('T');
 		containsMpu.mockReturnValue(true);
-		expect(getOzonePlacementId([[300, 250]], 'banner')).toBe('0420420500');
+		expect(getOzonePlacementId([[300, 250]])).toBe('0420420500');
 	});
 });

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -10,7 +10,6 @@ import type { ConsentState } from '@guardian/consent-manager';
 import { log } from '@guardian/libs';
 import type { AdUnitBidDefinition } from 'prebid.js/dist/src/adUnits';
 import type { Size } from 'prebid.js/dist/src/types/common';
-import { isUserInTestGroup } from '../../../../ab-testing';
 import type { PrebidIndexSite } from '../../../../types/global';
 import { dfpEnv } from '../../../dfp/dfp-env';
 import { buildAppNexusTargetingObject } from '../../../page-targeting';
@@ -43,7 +42,6 @@ import {
 	containsPortraitInterstitial,
 	containsWS,
 	getBreakpointKey,
-	isOutstream,
 	shouldIncludeBidder,
 	stripDfpAdPrefixFrom,
 	stripMobileSuffix,
@@ -374,11 +372,10 @@ const getTeadsParams = (
 
 const getOzonePlacementId = (
 	sizes: Size[],
-	bidderType: 'banner' | 'video',
 	slotId?: string,
 	pageTargeting?: PageTargeting,
 ) => {
-	if (bidderType === 'video') {
+	if (slotId === 'dfp-ad--inline1') {
 		return '1500001169';
 	}
 
@@ -442,15 +439,8 @@ const teadsBidder: PrebidBidder = {
 	},
 };
 
-/**
- * Ozone has a separate bidder for each supported PrebidAdUnit mediaType: banner and video
- */
-const ozoneBidder: (
+const ozoneBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
 	pageTargeting: PageTargeting,
-	bidderType: 'banner' | 'video',
-) => PrebidBidder = (
-	pageTargeting: PageTargeting,
-	bidderType: 'banner' | 'video',
 ) => ({
 	name: 'ozone',
 	switchName: 'prebidOzone',
@@ -463,12 +453,7 @@ const ozoneBidder: (
 		return {
 			publisherId: 'OZONEGMG0001',
 			siteId: '4204204209',
-			placementId: getOzonePlacementId(
-				sizes,
-				bidderType,
-				_slotId,
-				pageTargeting,
-			),
+			placementId: getOzonePlacementId(sizes, _slotId, pageTargeting),
 			customData: [
 				{
 					settings: {},
@@ -483,25 +468,6 @@ const ozoneBidder: (
 		};
 	},
 });
-
-const ozoneBannerBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
-	pageTargeting: PageTargeting,
-) => ozoneBidder(pageTargeting, 'banner');
-
-const ozoneVideoBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
-	pageTargeting: PageTargeting,
-) => ozoneBidder(pageTargeting, 'video');
-
-const shouldIncludeOzoneVideoBidder = (slotSizes: Size[]): boolean => {
-	const isInOzoneAbTest = isUserInTestGroup(
-		'commercial-ozone-outstream',
-		'variant',
-	);
-
-	const isVideoSlotSizes = slotSizes.some(isOutstream);
-
-	return isInOzoneAbTest && isVideoSlotSizes;
-};
 
 const getPubmaticPublisherId = (): string => {
 	if (isInUsOrCa()) {
@@ -696,11 +662,7 @@ const currentBidders = (
 		[shouldInclude('and'), appNexusBidder(pageTargeting)],
 		[shouldInclude('xhb'), xaxisBidder],
 		[shouldInclude('pubmatic'), pubmaticBidder(slotSizes)],
-		[shouldInclude('ozone'), ozoneBannerBidder(pageTargeting)],
-		[
-			shouldInclude('ozone') && shouldIncludeOzoneVideoBidder(slotSizes),
-			ozoneVideoBidder(pageTargeting),
-		],
+		[shouldInclude('ozone'), ozoneBidder(pageTargeting)],
 		[shouldInclude('oxd'), openxBidder(pageTargeting)],
 		[shouldInclude('kargo'), kargoBidder],
 		[shouldInclude('teads'), teadsBidder],


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

- Use the same Placement ID for all inline1 slots.
- Only use 1 Ozone bidder.

## Why?

Request from Ozone. The initial understanding was that Ozone wanted a separate Placement ID for the video Media Type. Since bids cannot be linked to media types, we created a separate bidder for Ozone with a different Placement ID. However, Ozone now only want one Placement ID per slot, for performance reasons, we remove the second Ozone bidder.