### PR TITLE
remove prebid-price-floor-holdback test gate

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/index.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.spec.ts
@@ -2,7 +2,6 @@
 
 import { hashEmailForClient } from '@guardian/commercial-core/email-hash';
 import { type ConsentState, getConsentFor } from '@guardian/consent-manager';
-import { isUserInTestGroup } from '../../../ab-testing';
 import { pubmatic } from '../../__vendor/pubmatic';
 import { getAdvertById as getAdvertById_ } from '../../dfp/get-advert-by-id';
 import { getEmail } from '../../identity/api';
@@ -44,10 +43,6 @@ jest.mock('../../identity/api', () => ({
 
 jest.mock('@guardian/commercial-core/email-hash', () => ({
 	hashEmailForClient: jest.fn(),
-}));
-
-jest.mock('../../../ab-testing', () => ({
-	isUserInTestGroup: jest.fn(),
 }));
 
 const mockGetConsentForID5 = (hasConsent: boolean) =>
@@ -602,11 +597,9 @@ describe('Prebid.js bidWon Events', () => {
 		},
 	);
 });
-describe('isInPrebidFloorPriceTest', () => {
+describe('prebid price floors', () => {
 	/* eslint-disable @typescript-eslint/no-unsafe-assignment -- Jest matchers return any */
-	test('when user can use price floors and is not in the variant holdback group, pbjs.setConfig is called with floor price values', async () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
-
+	test('pbjs.setConfig is called with floor price values for all users', async () => {
 		const setConfigSpy = jest.spyOn(window.pbjs, 'setConfig');
 		await prebid.initialise(window, mockConsentState);
 
@@ -615,26 +608,12 @@ describe('isInPrebidFloorPriceTest', () => {
 				floors: expect.objectContaining({
 					enabled: true,
 					data: expect.objectContaining({
+						/* eslint-enable @typescript-eslint/no-unsafe-assignment */
 						schema: { fields: ['mediaType'] },
 						values: { '*': 0.1 },
 						default: 0.1,
 					}),
 				}),
-			}),
-		);
-	});
-	/* eslint-enable @typescript-eslint/no-unsafe-assignment */
-	test('when user is in the variant holdback group, pbjs.setConfig is called without floor price values', async () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
-
-		const setConfigSpy = jest.spyOn(window.pbjs, 'setConfig');
-
-		await prebid.initialise(window, mockConsentState);
-
-		expect(setConfigSpy).toHaveBeenCalledWith(
-			expect.not.objectContaining({
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest matchers return any
-				floors: expect.anything(),
 			}),
 		);
 	});

--- a/bundle/src/lib/header-bidding/prebid/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.ts
@@ -9,7 +9,6 @@ import { flatten } from 'lodash-es';
 import type { AnalyticsConfig } from 'prebid.js/dist/libraries/analyticsAdapter/AnalyticsAdapter';
 import type { AdUnitDefinition } from 'prebid.js/dist/src/adUnits';
 import type { UserSyncConfig } from 'prebid.js/dist/src/userSync';
-import { isUserInTestGroup } from '../../../ab-testing';
 import type { Advert } from '../../../define/Advert';
 import { getAdvertById } from '../../dfp/get-advert-by-id';
 import { isUserLoggedIn } from '../../identity/api';
@@ -47,12 +46,6 @@ const initialise = async (
 
 	const userSync: UserSyncConfig = await getUserSyncSettings(consentState);
 
-	// We're holding back 5% of users, who will not get any price floors applied
-	const canUsePriceFloors = !isUserInTestGroup(
-		'commercial-prebid-price-floor-holdback',
-		'holdback',
-	);
-
 	window.pbjs.setConfig({
 		/**
 		 * The amount of time reserved for the auction
@@ -61,18 +54,14 @@ const initialise = async (
 		/**
 		 * Applying one global floor price of £0.10 for all bids.
 		 */
-		...(canUsePriceFloors
-			? {
-					floors: {
-						enabled: true,
-						data: {
-							schema: { fields: ['mediaType'] },
-							values: { '*': 0.1 },
-							default: 0.1,
-						},
-					},
-				}
-			: {}),
+		floors: {
+			enabled: true,
+			data: {
+				schema: { fields: ['mediaType'] },
+				values: { '*': 0.1 },
+				default: 0.1,
+			},
+		},
 		priceGranularity: 'custom',
 		customPriceBucket: priceGranularity,
 		userSync,


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Removes the A/B test gate for `commercial-prebid-price-floor-holdback`
## Why?
This test gate is now redundant since we have completed the holdback experiment and are applying the price floors are now enabled for 100% of users.


Related Test config PR in DCR: https://github.com/guardian/dotcom-rendering/pull/16399