### PR TITLE
Ozone outstream AB test: add sizes to slot size array

### DIFF
--- a/bundle/src/init/consented/static-ad-slots.ts
+++ b/bundle/src/init/consented/static-ad-slots.ts
@@ -2,6 +2,7 @@ import type { SizeMapping } from '@guardian/commercial-core/ad-sizes';
 import { adSizes, createAdSize } from '@guardian/commercial-core/ad-sizes';
 import { isInUsa } from '@guardian/commercial-core/geo/geo-utils';
 import { isNonNullable, log } from '@guardian/libs';
+import { isUserInTestGroup } from '../../ab-testing';
 import { createAdvert } from '../../define/create-advert';
 import { displayAds } from '../../display/display-ads';
 import { displayLazyAds } from '../../display/display-lazy-ads';
@@ -22,10 +23,26 @@ const decideAdditionalSizes = (adSlot: HTMLElement): SizeMapping => {
 		};
 	}
 
+	const isInOzoneAbTest = isUserInTestGroup(
+		'commercial-ozone-outstream',
+		'variant',
+	);
+
 	if (contentType === 'LiveBlog' && name?.includes('inline')) {
 		return {
-			phablet: [adSizes.outstreamDesktop, adSizes.outstreamGoogleDesktop],
-			desktop: [adSizes.outstreamDesktop, adSizes.outstreamGoogleDesktop],
+			...(isInOzoneAbTest && { mobile: [adSizes.outstreamOzone] }),
+			phablet: [
+				isInOzoneAbTest
+					? adSizes.outstreamOzone
+					: adSizes.outstreamDesktop,
+				adSizes.outstreamGoogleDesktop,
+			],
+			desktop: [
+				isInOzoneAbTest
+					? adSizes.outstreamOzone
+					: adSizes.outstreamDesktop,
+				adSizes.outstreamGoogleDesktop,
+			],
 		};
 	}
 

--- a/bundle/src/insert/spacefinder/article.ts
+++ b/bundle/src/insert/spacefinder/article.ts
@@ -1,5 +1,6 @@
 import type { AdSize, SizeMapping } from '@guardian/commercial-core/ad-sizes';
 import { adSizes } from '@guardian/commercial-core/ad-sizes';
+import { isUserInTestGroup } from '../../ab-testing';
 import { allowArticleBodyAdverts } from '../../lib/article-body-adverts';
 import type { ContainerOptions } from '../../lib/create-ad-slot';
 import {
@@ -102,11 +103,22 @@ const decideAdditionalSizes = async (
 };
 
 const addDesktopInline1 = (fillSlot: FillAdSlot): Promise<boolean> => {
+	const isInOzoneAbTest = isUserInTestGroup(
+		'commercial-ozone-outstream',
+		'variant',
+	);
+
 	// these are added here and not in size mappings because the inline[i] name
 	// is also used on fronts, where we don't want outstream or tall ads
 	const additionalSizes = {
-		phablet: [adSizes.outstreamDesktop, adSizes.outstreamGoogleDesktop],
-		desktop: [adSizes.outstreamDesktop, adSizes.outstreamGoogleDesktop],
+		phablet: [
+			isInOzoneAbTest ? adSizes.outstreamOzone : adSizes.outstreamDesktop,
+			adSizes.outstreamGoogleDesktop,
+		],
+		desktop: [
+			isInOzoneAbTest ? adSizes.outstreamOzone : adSizes.outstreamDesktop,
+			adSizes.outstreamGoogleDesktop,
+		],
 	};
 
 	const insertAd: SpacefinderWriter = async (paras) => {
@@ -210,8 +222,17 @@ const addDesktopRightRailAds = ({
 };
 
 const additionalMobileAndTabletInlineSizes = (index: number) => {
+	const isInOzoneAbTest = isUserInTestGroup(
+		'commercial-ozone-outstream',
+		'variant',
+	);
+
 	if (index === 1) {
-		return { mobile: [adSizes.portraitInterstitial] };
+		return {
+			mobile: isInOzoneAbTest
+				? [adSizes.portraitInterstitial, adSizes.outstreamOzone]
+				: [adSizes.portraitInterstitial],
+		};
 	} else if (index === 2) {
 		return {
 			mobile: [
@@ -220,6 +241,7 @@ const additionalMobileAndTabletInlineSizes = (index: number) => {
 			],
 		};
 	}
+
 	return undefined;
 };
 
@@ -311,4 +333,4 @@ const init = async (fillAdSlot: FillAdSlot): Promise<void> => {
 	await addInlineAds(fillAdSlot, false);
 };
 
-export { init, addInlineAds, type FillAdSlot };
+export { addInlineAds, init, type FillAdSlot };

--- a/bundle/src/insert/spacefinder/article.ts
+++ b/bundle/src/insert/spacefinder/article.ts
@@ -245,32 +245,44 @@ const additionalMobileAndTabletInlineSizes = (index: number) => {
 	return undefined;
 };
 
+/**
+ * On mobile, the first inline ad is `top-above-nav`, followed by `inline1`, `inline2`, and so on.
+ * On tablet, the first inline ad is `inline1`.
+ */
+const getSlotName = (isMobile: boolean, index: number): string => {
+	if (isMobile) {
+		return index === 0 ? 'top-above-nav' : `inline${index}`;
+	}
+
+	return `inline${index + 1}`;
+};
+
 const addMobileAndTabletInlineAds = (
 	fillSlot: FillAdSlot,
-	currentBreakpoint: ReturnType<typeof getCurrentBreakpoint>,
+	currentBreakpoint: Extract<
+		ReturnType<typeof getCurrentBreakpoint>,
+		'mobile' | 'tablet'
+	>,
 ): Promise<boolean> => {
 	const insertAds: SpacefinderWriter = async (paras) => {
 		const slots = paras.map(async (para, i) => {
-			//Mobile top-above-nav is the first ad in the body and the inline1 is the second ad in the body.
-			//Tablet top-above-nav is above the website's navigation and the inline1 is the first ad in the body.
-			const name =
-				currentBreakpoint === 'mobile' && i === 0
-					? 'top-above-nav'
-					: currentBreakpoint === 'tablet'
-						? `inline${i + 1}`
-						: `inline${i}`;
+			const isMobile = currentBreakpoint === 'mobile';
+			const name = getSlotName(isMobile, i);
 
-			const type =
-				currentBreakpoint === 'mobile' && i === 0
-					? 'top-above-nav'
-					: 'inline';
-			const slot = await insertSlotAtPara(para, name, type, 'inline');
+			const slot = await insertSlotAtPara(
+				para,
+				name,
+				isMobile && i === 0 ? 'top-above-nav' : 'inline',
+				'inline',
+			);
+
 			return fillSlot(
 				name,
 				slot,
 				additionalMobileAndTabletInlineSizes(i),
 			);
 		});
+
 		await Promise.all(slots);
 	};
 
@@ -291,7 +303,7 @@ const addInlineAds = async (
 	isConsentless: boolean,
 ): Promise<boolean> => {
 	const currentBreakpoint = getCurrentBreakpoint();
-	if (['mobile', 'tablet'].includes(currentBreakpoint)) {
+	if (currentBreakpoint === 'mobile' || currentBreakpoint === 'tablet') {
 		return addMobileAndTabletInlineAds(fillSlot, currentBreakpoint);
 	}
 

--- a/bundle/src/insert/spacefinder/liveblog-adverts.ts
+++ b/bundle/src/insert/spacefinder/liveblog-adverts.ts
@@ -1,5 +1,6 @@
 import { adSizes } from '@guardian/commercial-core/ad-sizes';
 import { log } from '@guardian/libs';
+import { isUserInTestGroup } from '../../ab-testing';
 import { isAdFree } from '../../lib/ad-free';
 import { createAdSlot } from '../../lib/create-ad-slot';
 import { getCurrentBreakpoint } from '../../lib/detect/detect-breakpoint';
@@ -49,21 +50,30 @@ const insertAdAtPara = (para: Node) => {
 
 	container.appendChild(ad);
 
+	const isInOzoneAbTest = isUserInTestGroup(
+		'commercial-ozone-outstream',
+		'variant',
+	);
+
 	return fastdom
 		.mutate(() => {
 			if (para.parentNode) {
-				/* ads are inserted after the block on liveblogs */
+				// Ads are inserted after the block on liveblogs
 				para.parentNode.insertBefore(container, para.nextSibling);
 			}
 		})
 		.then(async () =>
 			fillDynamicAdSlot(ad, false, {
 				phablet: [
-					adSizes.outstreamDesktop,
+					isInOzoneAbTest
+						? adSizes.outstreamOzone
+						: adSizes.outstreamDesktop,
 					adSizes.outstreamGoogleDesktop,
 				],
 				desktop: [
-					adSizes.outstreamDesktop,
+					isInOzoneAbTest
+						? adSizes.outstreamOzone
+						: adSizes.outstreamDesktop,
 					adSizes.outstreamGoogleDesktop,
 				],
 			}),
@@ -238,15 +248,13 @@ const onUpdate = (): void => {
 	void lookForSpacesForAdSlots();
 };
 
-/**
- * Inserts inline ad slots between new content
- * blocks when they are pushed to the page.
- */
-
 const isLiveBlog = window.guardian.config.page.isLiveBlog ?? false;
 const adsEnabled = shouldLoadAds();
 const adFree = isAdFree();
 
+/**
+ * Inserts inline ad slots between new content blocks when they are pushed to the page.
+ */
 export const init = (): Promise<void> => {
 	if (!!isLiveBlog && adsEnabled && !adFree) {
 		void startListening();

--- a/bundle/src/lib/messenger/passback.ts
+++ b/bundle/src/lib/messenger/passback.ts
@@ -2,6 +2,7 @@ import { adSizes } from '@guardian/commercial-core/ad-sizes';
 import { AD_LABEL_HEIGHT } from '@guardian/commercial-core/constants/ad-label-height';
 import { log } from '@guardian/libs';
 import { breakpoints } from '@guardian/source/foundations';
+import { isUserInTestGroup } from '../../ab-testing';
 import { getCurrentBreakpoint } from '../detect/detect-breakpoint';
 import { adSlotIdPrefix } from '../dfp/dfp-env-globals';
 import { getAdvertById } from '../dfp/get-advert-by-id';
@@ -26,6 +27,11 @@ type PassbackMessagePayload = { source: string };
  */
 const mpu: [number, number] = [adSizes.mpu.width, adSizes.mpu.height];
 
+const isInOzoneAbTest = isUserInTestGroup(
+	'commercial-ozone-outstream',
+	'variant',
+);
+
 const outstreamDesktop: [number, number] = [
 	adSizes.outstreamDesktop.width,
 	adSizes.outstreamDesktop.height,
@@ -34,17 +40,27 @@ const outstreamMobile: [number, number] = [
 	adSizes.outstreamMobile.width,
 	adSizes.outstreamMobile.height,
 ];
+const outstreamOzone: [number, number] = [
+	adSizes.outstreamOzone.width,
+	adSizes.outstreamOzone.height,
+];
 
-const outstreamSizes = [mpu, outstreamMobile, outstreamDesktop];
+const outstreamHeightDesktop = isInOzoneAbTest
+	? adSizes.outstreamOzone.height
+	: adSizes.outstreamDesktop.height;
+
+const outstreamSizes = isInOzoneAbTest
+	? [outstreamOzone]
+	: [outstreamDesktop, outstreamMobile];
 
 const oustreamSizeMappings = [
 	[
 		[breakpoints.phablet, 0],
-		[mpu, outstreamDesktop],
+		[mpu, isInOzoneAbTest ? outstreamOzone : outstreamDesktop],
 	],
 	[
 		[breakpoints.mobile, 0],
-		[mpu, outstreamMobile],
+		[mpu, isInOzoneAbTest ? outstreamOzone : outstreamMobile],
 	],
 ] satisfies googletag.SizeMappingArray;
 
@@ -66,7 +82,7 @@ const defaultSizeMappings = [
 const decideSizes = (source: string) => {
 	if (source === 'teads') {
 		return {
-			sizes: outstreamSizes,
+			sizes: [mpu, ...outstreamSizes],
 			sizeMappings: oustreamSizeMappings,
 		};
 	}
@@ -305,8 +321,7 @@ const initPassbackMessage = (register: RegisterListener): void => {
 										const slotHeight = `${
 											(getCurrentBreakpoint() === 'mobile'
 												? adHeight
-												: adSizes.outstreamDesktop
-														.height) +
+												: outstreamHeightDesktop) +
 											AD_LABEL_HEIGHT
 										}px`;
 										log(


### PR DESCRIPTION
## What does this change?

Add new Ozone Outstream sizes to slot size array when appropriate.

## Why?

We have a 0% AB test to check the implementation of Ozone Outstream. This was missed during the initial setup of the AB test: https://github.com/guardian/commercial/pull/2611

## Screenshots

The new outstream size: 640x360 can be seen in both content types and screen sizes

| <img width=100/> | Article | Liveblog |
| - | - | - |
| mobile | ![mobile-article] | ![mobile-liveblog] |
| desktop | ![desktop-article] | ![desktop-liveblog] |

[mobile-article]: https://github.com/user-attachments/assets/ee1c0ab6-ae85-4287-b6ff-22d60805f474
[desktop-article]: https://github.com/user-attachments/assets/11c5ae87-bf91-4beb-97c5-2ac6039ce394
[mobile-liveblog]: https://github.com/user-attachments/assets/8f52ca04-387a-42ca-ba1b-2adaa2c81ea6
[desktop-liveblog]: https://github.com/user-attachments/assets/19f4411f-82fb-4445-8c3c-382402714d54

## Testing

The new outstream size has been checked that it appears in the examples above. When in the control of the test, these new sizes do no appear. This has been checked locally.