### PR TITLE
Remove the outstream ozone AB test

### DIFF
--- a/bundle/src/init/consented/static-ad-slots.ts
+++ b/bundle/src/init/consented/static-ad-slots.ts
@@ -2,7 +2,6 @@ import type { SizeMapping } from '@guardian/commercial-core/ad-sizes';
 import { adSizes, createAdSize } from '@guardian/commercial-core/ad-sizes';
 import { isInUsa } from '@guardian/commercial-core/geo/geo-utils';
 import { isNonNullable, log } from '@guardian/libs';
-import { isUserInTestGroup } from '../../ab-testing';
 import { createAdvert } from '../../define/create-advert';
 import { displayAds } from '../../display/display-ads';
 import { displayLazyAds } from '../../display/display-lazy-ads';
@@ -23,26 +22,11 @@ const decideAdditionalSizes = (adSlot: HTMLElement): SizeMapping => {
 		};
 	}
 
-	const isInOzoneAbTest = isUserInTestGroup(
-		'commercial-ozone-outstream',
-		'variant',
-	);
-
 	if (contentType === 'LiveBlog' && name?.includes('inline')) {
 		return {
-			...(isInOzoneAbTest && { mobile: [adSizes.outstreamOzone] }),
-			phablet: [
-				isInOzoneAbTest
-					? adSizes.outstreamOzone
-					: adSizes.outstreamDesktop,
-				adSizes.outstreamGoogleDesktop,
-			],
-			desktop: [
-				isInOzoneAbTest
-					? adSizes.outstreamOzone
-					: adSizes.outstreamDesktop,
-				adSizes.outstreamGoogleDesktop,
-			],
+			mobile: [adSizes.outstreamOzone],
+			phablet: [adSizes.outstreamOzone, adSizes.outstreamGoogleDesktop],
+			desktop: [adSizes.outstreamOzone, adSizes.outstreamGoogleDesktop],
 		};
 	}
 

--- a/bundle/src/init/consented/static-ad-slots.ts
+++ b/bundle/src/init/consented/static-ad-slots.ts
@@ -23,11 +23,22 @@ const decideAdditionalSizes = (adSlot: HTMLElement): SizeMapping => {
 	}
 
 	if (contentType === 'LiveBlog' && name?.includes('inline')) {
-		return {
-			mobile: [adSizes.outstreamOzone],
-			phablet: [adSizes.outstreamOzone, adSizes.outstreamGoogleDesktop],
-			desktop: [adSizes.outstreamOzone, adSizes.outstreamGoogleDesktop],
-		};
+		return name === 'inline1'
+			? {
+					mobile: [adSizes.outstreamOzone],
+					phablet: [
+						adSizes.outstreamOzone,
+						adSizes.outstreamGoogleDesktop,
+					],
+					desktop: [
+						adSizes.outstreamOzone,
+						adSizes.outstreamGoogleDesktop,
+					],
+				}
+			: {
+					phablet: [adSizes.outstreamGoogleDesktop],
+					desktop: [adSizes.outstreamGoogleDesktop],
+				};
 	}
 
 	if (name === 'article-end' && isInUsa()) {

--- a/bundle/src/insert/spacefinder/article.spec.ts
+++ b/bundle/src/insert/spacefinder/article.spec.ts
@@ -1,5 +1,6 @@
+import { adSizes } from '@guardian/commercial-core';
 import { allowArticleBodyAdverts } from '../../lib/article-body-adverts';
-import { init } from './article';
+import { additionalMobileAndTabletInlineSizes, init } from './article';
 import { spaceFiller } from './space-filler';
 
 jest.mock('lib/header-bidding/prebid', () => ({
@@ -77,5 +78,29 @@ describe('Article Body Adverts', () => {
 				'mobile-inlines',
 			);
 		});
+	});
+});
+
+describe('additionalMobileAndTabletInlineSizes', () => {
+	it('should return the correct sizes for inline1', () => {
+		const sizes = additionalMobileAndTabletInlineSizes(1);
+		expect(sizes).toEqual({
+			mobile: [adSizes.portraitInterstitial, adSizes.outstreamOzone],
+		});
+	});
+
+	it('should return the correct sizes for inline2', () => {
+		const sizes = additionalMobileAndTabletInlineSizes(2);
+		expect(sizes).toEqual({
+			mobile: [
+				adSizes.portraitInterstitial,
+				adSizes.pubmaticInterscroller,
+			],
+		});
+	});
+
+	it('should return an empty object for other indices', () => {
+		const sizes = additionalMobileAndTabletInlineSizes(0);
+		expect(sizes).toEqual(undefined);
 	});
 });

--- a/bundle/src/insert/spacefinder/article.ts
+++ b/bundle/src/insert/spacefinder/article.ts
@@ -211,11 +211,11 @@ const addDesktopRightRailAds = ({
 
 const additionalMobileAndTabletInlineSizes = (index: number) => {
 	switch (index) {
-		case 1:
+		case 1: // inline1
 			return {
 				mobile: [adSizes.portraitInterstitial, adSizes.outstreamOzone],
 			};
-		case 2:
+		case 2: // inline2
 			return {
 				mobile: [
 					adSizes.portraitInterstitial,

--- a/bundle/src/insert/spacefinder/article.ts
+++ b/bundle/src/insert/spacefinder/article.ts
@@ -1,6 +1,5 @@
 import type { AdSize, SizeMapping } from '@guardian/commercial-core/ad-sizes';
 import { adSizes } from '@guardian/commercial-core/ad-sizes';
-import { isUserInTestGroup } from '../../ab-testing';
 import { allowArticleBodyAdverts } from '../../lib/article-body-adverts';
 import type { ContainerOptions } from '../../lib/create-ad-slot';
 import {
@@ -103,22 +102,11 @@ const decideAdditionalSizes = async (
 };
 
 const addDesktopInline1 = (fillSlot: FillAdSlot): Promise<boolean> => {
-	const isInOzoneAbTest = isUserInTestGroup(
-		'commercial-ozone-outstream',
-		'variant',
-	);
-
 	// these are added here and not in size mappings because the inline[i] name
 	// is also used on fronts, where we don't want outstream or tall ads
 	const additionalSizes = {
-		phablet: [
-			isInOzoneAbTest ? adSizes.outstreamOzone : adSizes.outstreamDesktop,
-			adSizes.outstreamGoogleDesktop,
-		],
-		desktop: [
-			isInOzoneAbTest ? adSizes.outstreamOzone : adSizes.outstreamDesktop,
-			adSizes.outstreamGoogleDesktop,
-		],
+		phablet: [adSizes.outstreamOzone, adSizes.outstreamGoogleDesktop],
+		desktop: [adSizes.outstreamOzone, adSizes.outstreamGoogleDesktop],
 	};
 
 	const insertAd: SpacefinderWriter = async (paras) => {
@@ -222,27 +210,21 @@ const addDesktopRightRailAds = ({
 };
 
 const additionalMobileAndTabletInlineSizes = (index: number) => {
-	const isInOzoneAbTest = isUserInTestGroup(
-		'commercial-ozone-outstream',
-		'variant',
-	);
-
-	if (index === 1) {
-		return {
-			mobile: isInOzoneAbTest
-				? [adSizes.portraitInterstitial, adSizes.outstreamOzone]
-				: [adSizes.portraitInterstitial],
-		};
-	} else if (index === 2) {
-		return {
-			mobile: [
-				adSizes.portraitInterstitial,
-				adSizes.pubmaticInterscroller,
-			],
-		};
+	switch (index) {
+		case 1:
+			return {
+				mobile: [adSizes.portraitInterstitial, adSizes.outstreamOzone],
+			};
+		case 2:
+			return {
+				mobile: [
+					adSizes.portraitInterstitial,
+					adSizes.pubmaticInterscroller,
+				],
+			};
+		default:
+			return undefined;
 	}
-
-	return undefined;
 };
 
 /**

--- a/bundle/src/insert/spacefinder/article.ts
+++ b/bundle/src/insert/spacefinder/article.ts
@@ -327,4 +327,9 @@ const init = async (fillAdSlot: FillAdSlot): Promise<void> => {
 	await addInlineAds(fillAdSlot, false);
 };
 
-export { addInlineAds, init, type FillAdSlot };
+export {
+	addInlineAds,
+	additionalMobileAndTabletInlineSizes,
+	init,
+	type FillAdSlot,
+};

--- a/bundle/src/insert/spacefinder/liveblog-adverts.ts
+++ b/bundle/src/insert/spacefinder/liveblog-adverts.ts
@@ -1,6 +1,5 @@
 import { adSizes } from '@guardian/commercial-core/ad-sizes';
 import { log } from '@guardian/libs';
-import { isUserInTestGroup } from '../../ab-testing';
 import { isAdFree } from '../../lib/ad-free';
 import { createAdSlot } from '../../lib/create-ad-slot';
 import { getCurrentBreakpoint } from '../../lib/detect/detect-breakpoint';
@@ -50,11 +49,6 @@ const insertAdAtPara = (para: Node) => {
 
 	container.appendChild(ad);
 
-	const isInOzoneAbTest = isUserInTestGroup(
-		'commercial-ozone-outstream',
-		'variant',
-	);
-
 	return fastdom
 		.mutate(() => {
 			if (para.parentNode) {
@@ -65,15 +59,11 @@ const insertAdAtPara = (para: Node) => {
 		.then(async () =>
 			fillDynamicAdSlot(ad, false, {
 				phablet: [
-					isInOzoneAbTest
-						? adSizes.outstreamOzone
-						: adSizes.outstreamDesktop,
+					adSizes.outstreamOzone,
 					adSizes.outstreamGoogleDesktop,
 				],
 				desktop: [
-					isInOzoneAbTest
-						? adSizes.outstreamOzone
-						: adSizes.outstreamDesktop,
+					adSizes.outstreamOzone,
 					adSizes.outstreamGoogleDesktop,
 				],
 			}),

--- a/bundle/src/insert/spacefinder/liveblog-adverts.ts
+++ b/bundle/src/insert/spacefinder/liveblog-adverts.ts
@@ -42,12 +42,31 @@ const insertAdAtPara = (para: Node) => {
 		isMobile ? 'mobile' : 'desktop'
 	}`;
 
+	const slotName = getSlotName(isMobile, AD_COUNTER);
+
 	const ad = createAdSlot('inline', {
-		name: getSlotName(isMobile, AD_COUNTER),
+		name: slotName,
 		classes: `liveblog-inline${isMobile ? '--mobile' : ''}`,
 	});
 
 	container.appendChild(ad);
+
+	const additionalSizes =
+		slotName === 'inline1'
+			? {
+					phablet: [
+						adSizes.outstreamOzone,
+						adSizes.outstreamGoogleDesktop,
+					],
+					desktop: [
+						adSizes.outstreamOzone,
+						adSizes.outstreamGoogleDesktop,
+					],
+				}
+			: {
+					phablet: [adSizes.outstreamGoogleDesktop],
+					desktop: [adSizes.outstreamGoogleDesktop],
+				};
 
 	return fastdom
 		.mutate(() => {
@@ -56,18 +75,7 @@ const insertAdAtPara = (para: Node) => {
 				para.parentNode.insertBefore(container, para.nextSibling);
 			}
 		})
-		.then(async () =>
-			fillDynamicAdSlot(ad, false, {
-				phablet: [
-					adSizes.outstreamOzone,
-					adSizes.outstreamGoogleDesktop,
-				],
-				desktop: [
-					adSizes.outstreamOzone,
-					adSizes.outstreamGoogleDesktop,
-				],
-			}),
-		);
+		.then(async () => fillDynamicAdSlot(ad, false, additionalSizes));
 };
 
 const insertAds: SpacefinderWriter = async (paras) => {

--- a/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.spec.ts
@@ -1,6 +1,5 @@
 import type { PageTargeting } from '@guardian/commercial-core/targeting/build-page-targeting';
 import type { ConsentState } from '@guardian/consent-manager';
-import { isUserInTestGroup } from '../../../ab-testing';
 import type { Advert } from '../../../define/Advert';
 import type { HeaderBiddingSlot } from '../prebid-types';
 import { bids } from './bidders/config';
@@ -15,10 +14,6 @@ function buildDummyBid() {
 
 jest.mock('./bidders/config', () => ({
 	bids: jest.fn().mockReturnValue([buildDummyBid()]),
-}));
-
-jest.mock('../../../ab-testing', () => ({
-	isUserInTestGroup: jest.fn(),
 }));
 
 const mockedBids = bids as jest.MockedFunction<typeof bids>;
@@ -53,7 +48,6 @@ describe('PrebidAdUnit', () => {
 	});
 
 	test('returns the correct bids and sizes for slot', () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
 		const advert = buildAdvert('dfp-ad--top-above-nav');
 		const slot: HeaderBiddingSlot = {
 			key: 'top-above-nav',
@@ -83,15 +77,12 @@ describe('PrebidAdUnit', () => {
 		expect(advert.headerBiddingSizes).toEqual(slot.sizes);
 	});
 
-	test('adds the video media type for non-inline1 slots', () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
+	test('adds the video media type for inline1 slots', () => {
 		const advert = buildAdvert('dfp-ad--inline1');
 		const slot: HeaderBiddingSlot = {
 			key: 'inline1',
 			sizes: [
 				[300, 250],
-				[620, 350],
-				[300, 197],
 				[640, 360],
 			],
 		};
@@ -108,11 +99,7 @@ describe('PrebidAdUnit', () => {
 				sizes: [[300, 250]],
 			},
 			video: {
-				playerSize: [
-					[620, 350],
-					[300, 197],
-					[640, 360],
-				],
+				playerSize: [[640, 360]],
 				context: 'outstream',
 				placement: 3,
 				plcmt: 4,
@@ -121,11 +108,13 @@ describe('PrebidAdUnit', () => {
 	});
 
 	test('does not add the video media type for non-inline1 slots', () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
 		const advert = buildAdvert('dfp-ad--top-above-nav');
 		const slot: HeaderBiddingSlot = {
 			key: 'top-above-nav',
-			sizes: [[728, 90]],
+			sizes: [
+				[300, 250],
+				[640, 360],
+			],
 		};
 
 		const adUnit = new PrebidAdUnit(
@@ -137,17 +126,19 @@ describe('PrebidAdUnit', () => {
 
 		expect(adUnit.mediaTypes).toEqual({
 			banner: {
-				sizes: slot.sizes,
+				sizes: [[300, 250]],
 			},
 		});
 	});
 
-	test('does not add the video media type when NOT in AB test', () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
+	test('does not add the video media type when there are no video sizes', () => {
 		const advert = buildAdvert('dfp-ad--inline1');
 		const slot: HeaderBiddingSlot = {
 			key: 'inline1',
-			sizes: [[728, 90]],
+			sizes: [
+				[970, 350],
+				[728, 90],
+			],
 		};
 
 		const adUnit = new PrebidAdUnit(
@@ -164,15 +155,12 @@ describe('PrebidAdUnit', () => {
 		});
 	});
 
-	test('uses outstream video sizes only in video media type when in AB test', () => {
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
+	test('uses outstream video sizes only in video media type', () => {
 		const advert = buildAdvert('dfp-ad--inline1');
 		const slot: HeaderBiddingSlot = {
 			key: 'inline1',
 			sizes: [
 				[300, 250],
-				[620, 350],
-				[300, 197],
 				[640, 360],
 			],
 		};
@@ -189,11 +177,7 @@ describe('PrebidAdUnit', () => {
 				sizes: [[300, 250]],
 			},
 			video: {
-				playerSize: [
-					[620, 350],
-					[300, 197],
-					[640, 360],
-				],
+				playerSize: [[640, 360]],
 				context: 'outstream',
 				placement: 3,
 				plcmt: 4,

--- a/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
@@ -7,7 +7,6 @@ import type {
 } from 'prebid.js/dist/src/adUnits';
 import type { MediaTypes } from 'prebid.js/dist/src/mediaTypes';
 import type { VideoMediaType } from 'prebid.js/dist/src/video';
-import { isUserInTestGroup } from '../../../ab-testing';
 import type { Advert } from '../../../define/Advert';
 import type { HeaderBiddingSlot } from '../prebid-types';
 import { isOutstream } from '../utils';
@@ -33,23 +32,20 @@ export class PrebidAdUnit implements AdUnitDefinition {
 		pageTargeting: PageTargeting,
 		consentState: ConsentState,
 	) {
-		const isInOzoneAbTest = isUserInTestGroup(
-			'commercial-ozone-outstream',
-			'variant',
-		);
-
 		/**
 		 * Outstream ad sizes are only compatible with the mediaTypes.video property of PrebidAdUnit
 		 */
 		const bannerSizes = slot.sizes.filter((size) => !isOutstream(size));
 		const videoSizes = slot.sizes.filter((size) => isOutstream(size));
+		const isOutstreamVideoAllowed =
+			slot.key === 'inline1' && videoSizes.length > 0;
 
 		this.code = advert.id;
 		this.mediaTypes = {
 			banner: {
 				sizes: bannerSizes,
 			},
-			...(isInOzoneAbTest && slot.key === 'inline1'
+			...(isOutstreamVideoAllowed
 				? {
 						video: {
 							context: 'outstream',

--- a/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
@@ -37,7 +37,7 @@ export class PrebidAdUnit implements AdUnitDefinition {
 		 */
 		const bannerSizes = slot.sizes.filter((size) => !isOutstream(size));
 		const videoSizes = slot.sizes.filter((size) => isOutstream(size));
-		const isOutstreamVideoAllowed =
+		const useOutstreamVideo =
 			slot.key === 'inline1' && videoSizes.length > 0;
 
 		this.code = advert.id;
@@ -45,7 +45,7 @@ export class PrebidAdUnit implements AdUnitDefinition {
 			banner: {
 				sizes: bannerSizes,
 			},
-			...(isOutstreamVideoAllowed
+			...(useOutstreamVideo
 				? {
 						video: {
 							context: 'outstream',

--- a/bundle/src/lib/header-bidding/slot-config.spec.ts
+++ b/bundle/src/lib/header-bidding/slot-config.spec.ts
@@ -1,6 +1,5 @@
 import type { SizeMapping } from '@guardian/commercial-core/ad-sizes';
 import { adSizes, createAdSize } from '@guardian/commercial-core/ad-sizes';
-import { isUserInTestGroup } from '../../ab-testing';
 import { Advert } from '../../define/Advert';
 import { getHeaderBiddingAdSlots } from './slot-config';
 import type * as Utils from './utils';
@@ -21,10 +20,6 @@ jest.mock('define/init-slot-ias', () => ({
 
 jest.mock('@guardian/commercial-core/targeting/teads-eligibility', () => ({
 	isEligibleForTeads: jest.fn(),
-}));
-
-jest.mock('../../ab-testing', () => ({
-	isUserInTestGroup: jest.fn(),
 }));
 
 const slotPrototype = {
@@ -123,9 +118,8 @@ describe('getPrebidAdSlots', () => {
 		]);
 	});
 
-	test('should return the correct inline1 slot at breakpoint D with no additional size mappings and in test group', () => {
+	test('should return the correct inline1 slot at breakpoint D with no additional size mappings', () => {
 		(getBreakpointKey as jest.Mock).mockReturnValue('D');
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
 		window.guardian.config.page.contentType = 'Article';
 
 		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline1'));
@@ -133,46 +127,19 @@ describe('getPrebidAdSlots', () => {
 		expect(hbSlots[0]?.sizes).toEqual([
 			createAdSize(300, 250),
 			createAdSize(640, 360),
-		]);
-	});
-
-	test('should return the correct inline1 slot at breakpoint D with no additional size mappings and NOT in test group', () => {
-		(getBreakpointKey as jest.Mock).mockReturnValue('D');
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
-		window.guardian.config.page.contentType = 'Article';
-
-		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline1'));
-		expect(hbSlots).toHaveLength(1);
-		expect(hbSlots[0]?.sizes).toEqual([
-			createAdSize(300, 250),
-			createAdSize(620, 350),
 			createAdSize(1, 1),
 		]);
 	});
 
-	test('should return the correct inline1 slot at breakpoint M with no additional size mappings and in test group', () => {
+	test('should return the correct inline1 slot at breakpoint M with no additional size mappings', () => {
 		(getBreakpointKey as jest.Mock).mockReturnValue('M');
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
 		window.guardian.config.page.contentType = 'Article';
 
 		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline1'));
 		expect(hbSlots).toHaveLength(1);
 		expect(hbSlots[0]?.sizes).toEqual([
+			createAdSize(300, 250),
 			createAdSize(640, 360),
-			createAdSize(300, 250),
-			createAdSize(320, 480),
-		]);
-	});
-	test('should return the correct inline1 slot at breakpoint M with no additional size mappings and NOT in test group', () => {
-		(getBreakpointKey as jest.Mock).mockReturnValue('M');
-		jest.mocked(isUserInTestGroup).mockReturnValueOnce(false);
-		window.guardian.config.page.contentType = 'Article';
-
-		const hbSlots = getHeaderBiddingAdSlots(buildAdvert('inline1'));
-		expect(hbSlots).toHaveLength(1);
-		expect(hbSlots[0]?.sizes).toEqual([
-			createAdSize(300, 197),
-			createAdSize(300, 250),
 			createAdSize(320, 480),
 			createAdSize(1, 1),
 		]);

--- a/bundle/src/lib/header-bidding/slot-config.ts
+++ b/bundle/src/lib/header-bidding/slot-config.ts
@@ -2,7 +2,6 @@ import type { AdSize } from '@guardian/commercial-core/ad-sizes';
 import { adSizes } from '@guardian/commercial-core/ad-sizes';
 import { isInUk } from '@guardian/commercial-core/geo/geo-utils';
 import type { Size } from 'prebid.js/dist/src/types/common';
-import { isUserInTestGroup } from '../../ab-testing';
 import type { Advert } from '../../define/Advert';
 import type {
 	HeaderBiddingSizeKey,
@@ -118,10 +117,6 @@ const getSlotSizeMapping = (): HeaderBiddingSizeMapping => {
 	const isArticle = contentType === 'Article';
 	const hasExtendedMostPop =
 		isArticle && window.guardian.config.switches.extendedMostPopular;
-	const isInOzoneAbTest = isUserInTestGroup(
-		'commercial-ozone-outstream',
-		'variant',
-	);
 
 	return {
 		right: {
@@ -158,30 +153,19 @@ const getSlotSizeMapping = (): HeaderBiddingSizeMapping => {
 			desktop: isArticle
 				? [
 						getAdSize('mpu'),
-						...(isInOzoneAbTest
-							? [getAdSize('outstreamOzone')]
-							: [
-									getAdSize('outstreamDesktop'),
-									getAdSize('outOfPage'),
-								]),
+						getAdSize('outstreamOzone'),
+						getAdSize('outOfPage'),
 					]
 				: [getAdSize('mpu')],
 			tablet: isArticle
-				? [
-						getAdSize('mpu'),
-						...(isInOzoneAbTest
-							? [getAdSize('outstreamOzone')]
-							: [getAdSize('outstreamDesktop')]),
-					]
+				? [getAdSize('mpu'), getAdSize('outstreamOzone')]
 				: [getAdSize('mpu')],
 			mobile: isArticle
 				? [
-						...(isInOzoneAbTest
-							? [getAdSize('outstreamOzone')]
-							: [getAdSize('outstreamMobile')]),
 						getAdSize('mpu'),
+						getAdSize('outstreamOzone'),
 						getAdSize('portraitInterstitial'),
-						...(isInOzoneAbTest ? [] : [getAdSize('outOfPage')]),
+						getAdSize('outOfPage'),
 					]
 				: [getAdSize('mpu')],
 		},

--- a/bundle/src/lib/messenger/passback.ts
+++ b/bundle/src/lib/messenger/passback.ts
@@ -2,7 +2,6 @@ import { adSizes } from '@guardian/commercial-core/ad-sizes';
 import { AD_LABEL_HEIGHT } from '@guardian/commercial-core/constants/ad-label-height';
 import { log } from '@guardian/libs';
 import { breakpoints } from '@guardian/source/foundations';
-import { isUserInTestGroup } from '../../ab-testing';
 import { getCurrentBreakpoint } from '../detect/detect-breakpoint';
 import { adSlotIdPrefix } from '../dfp/dfp-env-globals';
 import { getAdvertById } from '../dfp/get-advert-by-id';
@@ -27,40 +26,19 @@ type PassbackMessagePayload = { source: string };
  */
 const mpu: [number, number] = [adSizes.mpu.width, adSizes.mpu.height];
 
-const isInOzoneAbTest = isUserInTestGroup(
-	'commercial-ozone-outstream',
-	'variant',
-);
-
-const outstreamDesktop: [number, number] = [
-	adSizes.outstreamDesktop.width,
-	adSizes.outstreamDesktop.height,
-];
-const outstreamMobile: [number, number] = [
-	adSizes.outstreamMobile.width,
-	adSizes.outstreamMobile.height,
-];
 const outstreamOzone: [number, number] = [
 	adSizes.outstreamOzone.width,
 	adSizes.outstreamOzone.height,
 ];
 
-const outstreamHeightDesktop = isInOzoneAbTest
-	? adSizes.outstreamOzone.height
-	: adSizes.outstreamDesktop.height;
-
-const outstreamSizes = isInOzoneAbTest
-	? [outstreamOzone]
-	: [outstreamDesktop, outstreamMobile];
-
 const oustreamSizeMappings = [
 	[
 		[breakpoints.phablet, 0],
-		[mpu, isInOzoneAbTest ? outstreamOzone : outstreamDesktop],
+		[mpu, outstreamOzone],
 	],
 	[
 		[breakpoints.mobile, 0],
-		[mpu, isInOzoneAbTest ? outstreamOzone : outstreamMobile],
+		[mpu, outstreamOzone],
 	],
 ] satisfies googletag.SizeMappingArray;
 
@@ -82,7 +60,7 @@ const defaultSizeMappings = [
 const decideSizes = (source: string) => {
 	if (source === 'teads') {
 		return {
-			sizes: [mpu, ...outstreamSizes],
+			sizes: [mpu, outstreamOzone],
 			sizeMappings: oustreamSizeMappings,
 		};
 	}
@@ -321,7 +299,8 @@ const initPassbackMessage = (register: RegisterListener): void => {
 										const slotHeight = `${
 											(getCurrentBreakpoint() === 'mobile'
 												? adHeight
-												: outstreamHeightDesktop) +
+												: adSizes.outstreamOzone
+														.height) +
 											AD_LABEL_HEIGHT
 										}px`;
 										log(


### PR DESCRIPTION
## What does this change?

Removes the Ozone outstream AB test. The new outstream size has been verified and will replace the two old outstream sizes. 

The Teads 1x1 size `outOfPage` is retained in slots in which it was used outside the variant of this AB test.

## Why?

The testing of this new size is complete. An AB test is not required to gradually increase the number of users exposed to this new size.

The Teads size was applied to all users before this PR and will be following its removal. There is no change here.