### PR TITLE
removes test gate for mobile-sticky-liveblog-us and related tests

### DIFF
--- a/bundle/src/lib/header-bidding/utils.spec.ts
+++ b/bundle/src/lib/header-bidding/utils.spec.ts
@@ -5,7 +5,6 @@ import {
 	getConsentFor as getConsentFor_,
 } from '@guardian/consent-manager';
 import type { CountryCode } from '@guardian/libs';
-import { isUserInTestGroup } from '../../ab-testing';
 import type { SourceBreakpoint } from '../detect/detect-breakpoint';
 import {
 	getCurrentTweakpoint as getCurrentTweakpoint_,
@@ -66,10 +65,6 @@ jest.mock('@guardian/commercial-core/geo/get-locale', () => ({
 jest.mock('lib/detect/detect-breakpoint', () => ({
 	getCurrentTweakpoint: jest.fn(() => 'mobile'),
 	matchesBreakpoints: jest.fn(),
-}));
-
-jest.mock('../../ab-testing', () => ({
-	isUserInTestGroup: jest.fn(),
 }));
 
 const resetConfig = () => {
@@ -429,20 +424,11 @@ describe('Utils', () => {
 			},
 		);
 
-		test('should be true for US LiveBlog on mobile when user is not in holdback', () => {
+		test('should be true for US LiveBlog on mobile', () => {
 			window.guardian.config.page.contentType = 'LiveBlog';
 			getLocale.mockReturnValue('US');
 			matchesBreakpoints.mockReturnValue(true);
-			jest.mocked(isUserInTestGroup).mockReturnValue(false);
 			expect(shouldIncludeMobileSticky()).toBe(true);
-		});
-
-		test('should be false for US LiveBlog on mobile when user is in holdback', () => {
-			window.guardian.config.page.contentType = 'LiveBlog';
-			getLocale.mockReturnValue('US');
-			matchesBreakpoints.mockReturnValue(true);
-			jest.mocked(isUserInTestGroup).mockReturnValue(true);
-			expect(shouldIncludeMobileSticky()).toBe(false);
 		});
 
 		test('should be false if all conditions true except pageId or content type ', () => {

--- a/bundle/src/lib/header-bidding/utils.ts
+++ b/bundle/src/lib/header-bidding/utils.ts
@@ -14,7 +14,6 @@ import { type ConsentState, getConsentFor } from '@guardian/consent-manager';
 import { isString } from '@guardian/libs';
 import { once } from 'lodash-es';
 import type { Size } from 'prebid.js/dist/src/types/common';
-import { isUserInTestGroup } from '../../ab-testing';
 import {
 	getCurrentTweakpoint,
 	matchesBreakpoints,
@@ -251,13 +250,7 @@ export const shouldIncludeMobileSticky = once(
 		}) &&
 			!isInUk() &&
 			(isValidPageForMobileSticky() ||
-				// We intentionally use variant as the holdback arm for this test.
-				// Only users not in variant are eligible for this LiveBlog US mobile-sticky path.
-				(!isUserInTestGroup(
-					'commercial-mobile-sticky-liveblog-us',
-					'variant',
-				) &&
-					window.guardian.config.page.contentType === 'LiveBlog' &&
+				(window.guardian.config.page.contentType === 'LiveBlog' &&
 					isInUsa())) &&
 			!window.guardian.config.page.isHosted),
 );


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Removes the AB test gate logic for `commercial-mobile-sticky-liveblog-us` and exposes the feature to all users.

## Why?
We have collected enough data to be confident to release after a holdback test.