### PR TITLE
Fix flakiness of mobile-sticky Playwright test

### DIFF
--- a/bundle/playwright/tests/mobile-sticky-slot.spec.ts
+++ b/bundle/playwright/tests/mobile-sticky-slot.spec.ts
@@ -86,7 +86,7 @@ test.describe('mobile-sticky', () => {
 			};
 			await loadPage({ page, path, region: 'US', queryParams });
 			await cmpAcceptAll(page);
-			await page.reload();
+			await page.reload({ waitUntil: 'networkidle' });
 
 			// Dismiss banner
 			// TODO: These text selectors are fragile - consider adding data-testid
@@ -99,7 +99,7 @@ test.describe('mobile-sticky', () => {
 				.getByRole('alert')
 				.getByRole('button', { name: 'Close' });
 
-			expect(twoStepBanner.or(oneStepBanner)).toBeVisible;
+			expect(twoStepBanner.or(oneStepBanner)).toBeVisible();
 
 			if (await twoStepBanner.isVisible()) {
 				await twoStepBanner.click();


### PR DESCRIPTION
## What does this change?

Add wait condition to reload step during mobile sticky test

## Why?

The mobile-sticky Playwright test is quite flakey at the moment as it doesn't correctly distinguish between a two step reader revenue banner and a single step one
