### PR TITLE
Reinstate old Ozone sizes

### DIFF
--- a/bundle/src/init/consented/static-ad-slots.ts
+++ b/bundle/src/init/consented/static-ad-slots.ts
@@ -28,16 +28,24 @@ const decideAdditionalSizes = (adSlot: HTMLElement): SizeMapping => {
 					mobile: [adSizes.outstreamOzone],
 					phablet: [
 						adSizes.outstreamOzone,
+						adSizes.outstreamDesktop,
 						adSizes.outstreamGoogleDesktop,
 					],
 					desktop: [
 						adSizes.outstreamOzone,
+						adSizes.outstreamDesktop,
 						adSizes.outstreamGoogleDesktop,
 					],
 				}
 			: {
-					phablet: [adSizes.outstreamGoogleDesktop],
-					desktop: [adSizes.outstreamGoogleDesktop],
+					phablet: [
+						adSizes.outstreamDesktop,
+						adSizes.outstreamGoogleDesktop,
+					],
+					desktop: [
+						adSizes.outstreamDesktop,
+						adSizes.outstreamGoogleDesktop,
+					],
 				};
 	}
 

--- a/bundle/src/insert/spacefinder/article.ts
+++ b/bundle/src/insert/spacefinder/article.ts
@@ -105,8 +105,16 @@ const addDesktopInline1 = (fillSlot: FillAdSlot): Promise<boolean> => {
 	// these are added here and not in size mappings because the inline[i] name
 	// is also used on fronts, where we don't want outstream or tall ads
 	const additionalSizes = {
-		phablet: [adSizes.outstreamOzone, adSizes.outstreamGoogleDesktop],
-		desktop: [adSizes.outstreamOzone, adSizes.outstreamGoogleDesktop],
+		phablet: [
+			adSizes.outstreamOzone,
+			adSizes.outstreamDesktop,
+			adSizes.outstreamGoogleDesktop,
+		],
+		desktop: [
+			adSizes.outstreamOzone,
+			adSizes.outstreamDesktop,
+			adSizes.outstreamGoogleDesktop,
+		],
 	};
 
 	const insertAd: SpacefinderWriter = async (paras) => {

--- a/bundle/src/insert/spacefinder/liveblog-adverts.ts
+++ b/bundle/src/insert/spacefinder/liveblog-adverts.ts
@@ -56,16 +56,24 @@ const insertAdAtPara = (para: Node) => {
 			? {
 					phablet: [
 						adSizes.outstreamOzone,
+						adSizes.outstreamDesktop,
 						adSizes.outstreamGoogleDesktop,
 					],
 					desktop: [
 						adSizes.outstreamOzone,
+						adSizes.outstreamDesktop,
 						adSizes.outstreamGoogleDesktop,
 					],
 				}
 			: {
-					phablet: [adSizes.outstreamGoogleDesktop],
-					desktop: [adSizes.outstreamGoogleDesktop],
+					phablet: [
+						adSizes.outstreamDesktop,
+						adSizes.outstreamGoogleDesktop,
+					],
+					desktop: [
+						adSizes.outstreamDesktop,
+						adSizes.outstreamGoogleDesktop,
+					],
 				};
 
 	return fastdom

--- a/bundle/src/lib/header-bidding/slot-config.spec.ts
+++ b/bundle/src/lib/header-bidding/slot-config.spec.ts
@@ -126,6 +126,7 @@ describe('getPrebidAdSlots', () => {
 		expect(hbSlots).toHaveLength(1);
 		expect(hbSlots[0]?.sizes).toEqual([
 			createAdSize(300, 250),
+			createAdSize(620, 350),
 			createAdSize(640, 360),
 			createAdSize(1, 1),
 		]);
@@ -139,6 +140,7 @@ describe('getPrebidAdSlots', () => {
 		expect(hbSlots).toHaveLength(1);
 		expect(hbSlots[0]?.sizes).toEqual([
 			createAdSize(300, 250),
+			createAdSize(300, 197),
 			createAdSize(640, 360),
 			createAdSize(320, 480),
 			createAdSize(1, 1),

--- a/bundle/src/lib/header-bidding/slot-config.ts
+++ b/bundle/src/lib/header-bidding/slot-config.ts
@@ -153,16 +153,22 @@ const getSlotSizeMapping = (): HeaderBiddingSizeMapping => {
 			desktop: isArticle
 				? [
 						getAdSize('mpu'),
+						getAdSize('outstreamDesktop'),
 						getAdSize('outstreamOzone'),
 						getAdSize('outOfPage'),
 					]
 				: [getAdSize('mpu')],
 			tablet: isArticle
-				? [getAdSize('mpu'), getAdSize('outstreamOzone')]
+				? [
+						getAdSize('mpu'),
+						getAdSize('outstreamDesktop'),
+						getAdSize('outstreamOzone'),
+					]
 				: [getAdSize('mpu')],
 			mobile: isArticle
 				? [
 						getAdSize('mpu'),
+						getAdSize('outstreamMobile'),
 						getAdSize('outstreamOzone'),
 						getAdSize('portraitInterstitial'),
 						getAdSize('outOfPage'),

--- a/bundle/src/lib/messenger/passback.ts
+++ b/bundle/src/lib/messenger/passback.ts
@@ -26,19 +26,33 @@ type PassbackMessagePayload = { source: string };
  */
 const mpu: [number, number] = [adSizes.mpu.width, adSizes.mpu.height];
 
+const outstreamDesktop: [number, number] = [
+	adSizes.outstreamDesktop.width,
+	adSizes.outstreamDesktop.height,
+];
+const outstreamMobile: [number, number] = [
+	adSizes.outstreamMobile.width,
+	adSizes.outstreamMobile.height,
+];
 const outstreamOzone: [number, number] = [
 	adSizes.outstreamOzone.width,
 	adSizes.outstreamOzone.height,
 ];
 
+const outstreamSizes = [outstreamDesktop, outstreamMobile, outstreamOzone];
+
+const outstreamHeightDesktop = Math.max(
+	...outstreamSizes.map((size) => size[1]),
+);
+
 const oustreamSizeMappings = [
 	[
 		[breakpoints.phablet, 0],
-		[mpu, outstreamOzone],
+		[mpu, outstreamDesktop, outstreamOzone],
 	],
 	[
 		[breakpoints.mobile, 0],
-		[mpu, outstreamOzone],
+		[mpu, outstreamMobile, outstreamOzone],
 	],
 ] satisfies googletag.SizeMappingArray;
 
@@ -60,7 +74,7 @@ const defaultSizeMappings = [
 const decideSizes = (source: string) => {
 	if (source === 'teads') {
 		return {
-			sizes: [mpu, outstreamOzone],
+			sizes: [mpu, ...outstreamSizes],
 			sizeMappings: oustreamSizeMappings,
 		};
 	}
@@ -299,8 +313,7 @@ const initPassbackMessage = (register: RegisterListener): void => {
 										const slotHeight = `${
 											(getCurrentBreakpoint() === 'mobile'
 												? adHeight
-												: adSizes.outstreamOzone
-														.height) +
+												: outstreamHeightDesktop) +
 											AD_LABEL_HEIGHT
 										}px`;
 										log(


### PR DESCRIPTION
## What does this change?

Reinstates the usage of the following outstream sizes, where they were removed in [this PR](https://github.com/guardian/commercial/pull/2641):
- 620x350
- 300x197

## Why?

It was thought that these sizes were no longer used. However, they are still used by some vendors.