### PR TITLE
Remove tall ad sizes from comments ad slot

### DIFF
--- a/bundle/src/lib/header-bidding/slot-config.ts
+++ b/bundle/src/lib/header-bidding/slot-config.ts
@@ -207,11 +207,7 @@ const getSlotSizeMapping = (): HeaderBiddingSizeMapping => {
 			mobile: [getAdSize('mpu')],
 		},
 		comments: {
-			desktop: [
-				getAdSize('skyscraper'),
-				getAdSize('mpu'),
-				getAdSize('halfPage'),
-			],
+			desktop: [getAdSize('mpu')],
 		},
 		'comments-expanded': {
 			desktop: [


### PR DESCRIPTION
## What does this change?

Removes the following ad sizes from the **header bidding** config in the Comments ad slot:
- 160x600 (skyscraper)
- 300x600 (halfPage)

These sizes were removed from the regular ad sizes config in #770.

## Why?

Header bidding ad size config was overlooked in https://github.com/guardian/commercial/pull/770.

The height of the content is too small to display a tall ad in this slot. As a general rule for UI purposes, ads should not create extra whitespace as a result of their insertion.

## Screenshots

| Before | After |
| - | - |
| ![before-1] | ![after-1] |
| ![before-2] | ![after-2] |

[before-1]: https://github.com/user-attachments/assets/176c43f3-d94b-4a20-aff5-9cae03fabb02
[before-2]: https://github.com/user-attachments/assets/833cf26d-a26d-4568-827f-a03aaab26417
[after-1]: https://github.com/user-attachments/assets/986322fb-dbae-49ee-aa55-e2d556fe758f
[after-2]: https://github.com/user-attachments/assets/fdb71d0f-ffd8-4886-9712-f5ed5805cf70
