### PR TITLE
allows all non-UK Liveblog articles on mobile to show moble-sticky

### DIFF
--- a/bundle/src/lib/header-bidding/utils.spec.ts
+++ b/bundle/src/lib/header-bidding/utils.spec.ts
@@ -423,13 +423,16 @@ describe('Utils', () => {
 				expect(shouldIncludeMobileSticky()).toBe(expected);
 			},
 		);
-
-		test('should be true for US LiveBlog on mobile', () => {
-			window.guardian.config.page.contentType = 'LiveBlog';
-			getLocale.mockReturnValue('US');
-			matchesBreakpoints.mockReturnValue(true);
-			expect(shouldIncludeMobileSticky()).toBe(true);
-		});
+		
+		test.each(regionsTestCases)(
+			`should be $expected if geolocation is $region and content is LiveBlog on mobiles`,
+			({ region, expected }) => {
+				window.guardian.config.page.contentType = 'LiveBlog';
+				getLocale.mockReturnValue(region);
+				matchesBreakpoints.mockReturnValue(true);
+				expect(shouldIncludeMobileSticky()).toBe(expected);
+			},
+		);
 
 		test('should be false if all conditions true except pageId or content type ', () => {
 			window.guardian.config.page.contentType = 'Network Front';

--- a/bundle/src/lib/header-bidding/utils.spec.ts
+++ b/bundle/src/lib/header-bidding/utils.spec.ts
@@ -423,7 +423,7 @@ describe('Utils', () => {
 				expect(shouldIncludeMobileSticky()).toBe(expected);
 			},
 		);
-		
+
 		test.each(regionsTestCases)(
 			`should be $expected if geolocation is $region and content is LiveBlog on mobiles`,
 			({ region, expected }) => {

--- a/bundle/src/lib/header-bidding/utils.ts
+++ b/bundle/src/lib/header-bidding/utils.ts
@@ -250,8 +250,7 @@ export const shouldIncludeMobileSticky = once(
 		}) &&
 			!isInUk() &&
 			(isValidPageForMobileSticky() ||
-				(window.guardian.config.page.contentType === 'LiveBlog' &&
-					isInUsa())) &&
+				(window.guardian.config.page.contentType === 'LiveBlog')) &&
 			!window.guardian.config.page.isHosted),
 );
 

--- a/bundle/src/lib/header-bidding/utils.ts
+++ b/bundle/src/lib/header-bidding/utils.ts
@@ -48,6 +48,7 @@ const isValidPageForMobileSticky = (): boolean => {
 	return (
 		contentType === 'Article' ||
 		contentType === 'Interactive' ||
+		contentType === 'LiveBlog' ||
 		pageId.startsWith('football/')
 	);
 };
@@ -249,8 +250,7 @@ export const shouldIncludeMobileSticky = once(
 			max: 'mobileLandscape',
 		}) &&
 			!isInUk() &&
-			(isValidPageForMobileSticky() ||
-				(window.guardian.config.page.contentType === 'LiveBlog')) &&
+			isValidPageForMobileSticky() &&
 			!window.guardian.config.page.isHosted),
 );
 


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Renders mobile-sticky ads on all LiveBlog articles in eligible non-UK regions.

## Why?
After initial rollout of mobile-sticky to LiveBlog articles in US with positive test results, we have approval to expand the feature to all other non-UK regions.


## Testing

Tested locally: http://localhost:3030/Article/https://www.theguardian.com/sport/live/2026/aug/07/tour-de-france-femmes-2026-stage-seven-mont-ventoux-finish-live
VPN : France

https://github.com/user-attachments/assets/87074077-20bf-4c60-8bba-19f54b281865


