### PR TITLE
adds new items to high value sections list for spacefinder

### DIFF
--- a/bundle/src/insert/spacefinder/rules.ts
+++ b/bundle/src/insert/spacefinder/rules.ts
@@ -6,12 +6,12 @@ import type { OpponentSelectorRules, SpacefinderRules } from './spacefinder';
 const bodySelector = '.article-body-commercial-selector';
 const adSlotContainerSelector = `.${adSlotContainerClass}`;
 
-const shouldIncludeLifeAndStyle = isUserInTestGroup(
+const shouldIncludeExpandedSections = isUserInTestGroup(
 	'commercial-spacefinder-highvalue-section',
 	'variant',
 );
 
-const highValueSections = [
+const originalHighValueSections = [
 	'business',
 	'environment',
 	'music',
@@ -22,7 +22,13 @@ const highValueSections = [
 	'travel',
 	'wellness',
 	'games',
-	...(shouldIncludeLifeAndStyle ? ['lifeandstyle'] : []),
+];
+
+const highValueSections = [
+	...originalHighValueSections,
+	...(shouldIncludeExpandedSections
+		? ['commentisfree', 'football', 'lifeandstyle', 'politics', 'sport']
+		: []),
 ];
 
 const isInHighValueSection = highValueSections.includes(

--- a/bundle/src/insert/spacefinder/rules.ts
+++ b/bundle/src/insert/spacefinder/rules.ts
@@ -1,9 +1,15 @@
 import { adSizes } from '@guardian/commercial-core/ad-sizes';
+import { isUserInTestGroup } from '../../ab-testing';
 import { adSlotContainerClass } from '../../lib/create-ad-slot';
 import type { OpponentSelectorRules, SpacefinderRules } from './spacefinder';
 
 const bodySelector = '.article-body-commercial-selector';
 const adSlotContainerSelector = `.${adSlotContainerClass}`;
+
+const shouldIncludeLifeAndStyle = isUserInTestGroup(
+	'commercial-spacefinder-highvalue-section',
+	'variant',
+);
 
 const highValueSections = [
 	'business',
@@ -16,6 +22,7 @@ const highValueSections = [
 	'travel',
 	'wellness',
 	'games',
+	...(shouldIncludeLifeAndStyle ? ['lifeandstyle'] : []),
 ];
 
 const isInHighValueSection = highValueSections.includes(


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Expands highValueSections in rules.ts to include commentisfree, football, lifeandstyle, politics, and sport, gated behind a 0% AB test variant.

Also introduces isInOriginalHighValueSection to keep desktop heading margins tied to the original 10 sections, so the variant doesn't inadvertently affect those.

## Why?
`highValueSections` reduces the minimum distance between inline ads on mobile from 750px to 500px. This has been running across 10 sections for ~2 years.

We're expanding it to 5 higher-traffic sections, starting at 0% to validate before rollout — given variables like regional ad vendor differences (e.g. Kargo in the US). The heading margin logic is kept separate to avoid unintended side effects from the test.


## Testing

### Mobile:

**Control**: `http://localhost:3030/Article/https://www.theguardian.com/lifeandstyle/2026/aug/05/journalist-taking-on-tech-fascists-silicon-valley?ab-commercial-spacefinder-highvalue-section=control&sfdebug=true`

https://github.com/user-attachments/assets/08e1af43-08ee-41c2-900e-88bbd5e4b461


**Variant**: `http://localhost:3030/Article/https://www.theguardian.com/lifeandstyle/2026/aug/05/journalist-taking-on-tech-fascists-silicon-valley?ab-commercial-spacefinder-highvalue-section=variant&sfdebug=true`


https://github.com/user-attachments/assets/cc4348e1-f17e-421a-9721-7242114184f0


### Desktop
Desktop control and variant are intentionally identical — isInOriginalHighValueSection ensures the test has no effect on desktop.

**Control**: `http://localhost:3030/Article/https://www.theguardian.com/lifeandstyle/2026/aug/05/journalist-taking-on-tech-fascists-silicon-valley?ab-commercial-spacefinder-highvalue-section=control&sfdebug=true`

https://github.com/user-attachments/assets/95555ca7-9958-4829-b028-201f891d4550


**Variant**: `http://localhost:3030/Article/https://www.theguardian.com/lifeandstyle/2026/aug/05/journalist-taking-on-tech-fascists-silicon-valley?ab-commercial-spacefinder-highvalue-section=variant&sfdebug=true`


https://github.com/user-attachments/assets/924167a7-3478-4566-bff7-6a5428d0cfd2



