### PR TITLE
Remove tablet breakpoint from mostpop e2e test

### DIFF
--- a/bundle/playwright/tests/mostpop.spec.ts
+++ b/bundle/playwright/tests/mostpop.spec.ts
@@ -14,7 +14,7 @@ test.describe('mostpop slot', () => {
 		 * Since the introduction of non-house advertising in the merchandising slot,
 		 * we now hide the most pop slot until the tablet breakpoint
 		 */
-		testAtBreakpoints(['tablet', 'desktop', 'wide']).forEach(
+		testAtBreakpoints(['desktop', 'wide']).forEach(
 			({ breakpoint, width, height }) => {
 				test(`Test page ${index} has slot and iframe at breakpoint ${breakpoint}`, async ({
 					page,


### PR DESCRIPTION
## What does this change?

Removes the tablet breakpoint from the most pop end to end test

## Why?

We removed the most pop slot from tablet in https://github.com/guardian/dotcom-rendering/pull/16525 and the commercial bundle playwright tests were failing
See https://github.com/guardian/commercial/actions/runs/31501735138