### PR TITLE
Add `reset-height` message handler to support super billboard ads

### DIFF
--- a/bundle/src/init/consented/messenger.ts
+++ b/bundle/src/init/consented/messenger.ts
@@ -8,6 +8,7 @@ import { initGetStylesMessage } from '../../lib/messenger/get-stylesheet';
 import { initMeasureAdLoadMessage } from '../../lib/messenger/measure-ad-load';
 import { initPassbackMessage } from '../../lib/messenger/passback';
 import { initPassbackRefreshMessage } from '../../lib/messenger/passback-refresh';
+import { initResetHeightMessage } from '../../lib/messenger/reset-height';
 import { initResizeMessage } from '../../lib/messenger/resize';
 import { initScrollMessage } from '../../lib/messenger/scroll';
 import { initTypeMessage } from '../../lib/messenger/type';
@@ -26,6 +27,7 @@ export const initMessenger = (): void => {
 			initMeasureAdLoadMessage,
 			initPassbackMessage,
 			initPassbackRefreshMessage,
+			initResetHeightMessage,
 			initResizeMessage,
 			initScrollMessage,
 			initTypeMessage,

--- a/bundle/src/lib/messenger.ts
+++ b/bundle/src/lib/messenger.ts
@@ -14,13 +14,15 @@ type MessageType =
 	| 'measure-ad-load'
 	| 'passback'
 	| 'resize'
+	| 'full-height'
 	| 'full-width'
 	| 'set-ad-height'
 	| 'scroll'
 	| 'type'
 	| 'viewport'
 	| 'passback-refresh'
-	| 'video-progress';
+	| 'video-progress'
+	| 'reset-height';
 
 /**
  * A message that is sent from an iframe following a standard format

--- a/bundle/src/lib/messenger.ts
+++ b/bundle/src/lib/messenger.ts
@@ -8,21 +8,20 @@ type MessageType =
 	| 'background'
 	| 'click'
 	| 'disable-refresh'
+	| 'full-width'
 	| 'get-page-targeting'
 	| 'get-page-url'
 	| 'get-styles'
 	| 'measure-ad-load'
 	| 'passback'
+	| 'passback-refresh'
+	| 'reset-height'
 	| 'resize'
-	| 'full-height'
-	| 'full-width'
 	| 'set-ad-height'
 	| 'scroll'
 	| 'type'
 	| 'viewport'
-	| 'passback-refresh'
-	| 'video-progress'
-	| 'reset-height';
+	| 'video-progress';
 
 /**
  * A message that is sent from an iframe following a standard format

--- a/bundle/src/lib/messenger/reset-height.spec.ts
+++ b/bundle/src/lib/messenger/reset-height.spec.ts
@@ -1,0 +1,55 @@
+import { _ } from './reset-height';
+
+const { toggleResetHeight } = _;
+
+describe('Cross-frame messenger: reset-height', () => {
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('should add the reset-height class to the slot', () => {
+		document.body.innerHTML = `
+			<div class="ad-slot-container">
+              <div id="slot01" class="js-ad-slot" style="width: 7px; height: 14px;" >
+                <div id="container01">
+                    <iframe id="iframe01" class="iframe" data-unit="ch"></iframe>
+                </div>
+              </div>
+			</div>`;
+
+		const fakeAdSlot = document.querySelector('.js-ad-slot') as HTMLElement;
+
+		expect(fakeAdSlot).not.toBeUndefined();
+
+		const fakeSpecs = true;
+
+		toggleResetHeight(fakeSpecs, fakeAdSlot);
+
+		expect(fakeAdSlot.classList.contains('ad-slot--reset-height')).toBe(
+			true,
+		);
+	});
+
+	it('should remove the reset-height class from the slot', () => {
+		document.body.innerHTML = `
+			<div class="ad-slot-container">
+			  <div id="slot01" class="js-ad-slot ad-slot--reset-height" style="width: 7px; height: 14px;" >
+				<div id="container01">
+					<iframe id="iframe01" class="iframe" data-unit="ch"></iframe>
+				</div>
+			  </div>
+			</div>`;
+
+		const fakeAdSlot = document.querySelector('.js-ad-slot') as HTMLElement;
+
+		expect(fakeAdSlot).not.toBeUndefined();
+
+		const fakeSpecs = false;
+
+		toggleResetHeight(fakeSpecs, fakeAdSlot);
+
+		expect(fakeAdSlot.classList.contains('ad-slot--reset-height')).toBe(
+			false,
+		);
+	});
+});

--- a/bundle/src/lib/messenger/reset-height.ts
+++ b/bundle/src/lib/messenger/reset-height.ts
@@ -1,0 +1,37 @@
+import { isBoolean } from '@guardian/libs';
+import fastdom from 'fastdom';
+import type { RegisterListener } from '../messenger';
+
+const toggleResetHeight = (fullHeight: boolean, slot: HTMLElement) =>
+	fastdom.mutate(() => {
+		if (fullHeight) {
+			slot.classList.add('ad-slot--reset-height');
+		} else {
+			slot.classList.remove('ad-slot--reset-height');
+		}
+	});
+
+const initResetHeightMessage = (register: RegisterListener): void => {
+	register('reset-height', (specs, ret, iframe) => {
+		if (iframe && specs) {
+			if (!isBoolean(specs)) {
+				return;
+			}
+
+			const adSlot =
+				iframe.closest<HTMLElement>('.js-ad-slot') ?? undefined;
+
+			// only allow for fluid ads as these are the ones with a min-height set initially
+			const isFluidAd = adSlot?.classList.contains('ad-slot--fluid');
+			if (!isFluidAd || !adSlot) {
+				return;
+			}
+
+			return toggleResetHeight(specs, adSlot);
+		}
+	});
+};
+
+export const _ = { toggleResetHeight };
+
+export { initResetHeightMessage };

--- a/bundle/src/lib/messenger/reset-height.ts
+++ b/bundle/src/lib/messenger/reset-height.ts
@@ -1,12 +1,20 @@
-import { isBoolean } from '@guardian/libs';
+import { isBoolean, log } from '@guardian/libs';
 import fastdom from 'fastdom';
 import type { RegisterListener } from '../messenger';
 
-const toggleResetHeight = (fullHeight: boolean, slot: HTMLElement) =>
+const toggleResetHeight = (reset: boolean, slot: HTMLElement) =>
 	fastdom.mutate(() => {
-		if (fullHeight) {
+		if (reset) {
+			log(
+				'commercial',
+				`[reset-height] resetting the height for slot: ${slot.dataset.name}`,
+			);
 			slot.classList.add('ad-slot--reset-height');
 		} else {
+			log(
+				'commercial',
+				`[reset-height] removing the height reset for slot: ${slot.dataset.name}`,
+			);
 			slot.classList.remove('ad-slot--reset-height');
 		}
 	});
@@ -15,6 +23,10 @@ const initResetHeightMessage = (register: RegisterListener): void => {
 	register('reset-height', (specs, ret, iframe) => {
 		if (iframe && specs) {
 			if (!isBoolean(specs)) {
+				log(
+					'commercial',
+					'[reset-height] incorrect message payload: expected a boolean',
+				);
 				return;
 			}
 
@@ -24,6 +36,10 @@ const initResetHeightMessage = (register: RegisterListener): void => {
 			// only allow for fluid ads as these are the ones with a min-height set initially
 			const isFluidAd = adSlot?.classList.contains('ad-slot--fluid');
 			if (!isFluidAd || !adSlot) {
+				log(
+					'commercial',
+					'[reset-height] cannot reset height: no ad slot identified or not a fluid ad',
+				);
 				return;
 			}
 


### PR DESCRIPTION
## What does this change?

Adds a `postMessage` handler for a `reset-height` message and a unit test to demonstrate usage

Usage is similar to the `full-width` message, where the value provided is a boolean to control whether it is on or off.

**Demo of how this works (without the postMessage handler):**

https://github.com/user-attachments/assets/9fadc414-d6be-44e1-9700-8b076e401935

Notice how when the ad collapses, the ad slot does not resize properly until the class has been added. When the class is removed it reverts back to the original behaviour.

- The part in the commercial repo is responsible for handling the postMessage and adding the class name 
- The part in the dotcom-rendering repo is responsible for adding the ad slot styling (the CSS which corresponds to the class being present)

## Why?

There's a new type of "super billboard" ad we want to support which allows expanding and collapsing the ad within the space. This is being created as a fabric custom ad which uses the "fluid" size. Fluid ads have a minimum height set on them in the code.
This, along with [the companion PR in dotcom-rendering](https://github.com/guardian/dotcom-rendering/pull/16564), allow a fabric custom advert to be created which posts a message to the top layer asking for the slot to resize according to the dimensions of the ad it contains, rather than setting a minimum height as a constant.