### PR TITLE
Remove unnecessary code from "MPU when no epic" 

### DIFF
--- a/bundle/src/lib/header-bidding/prebid-types.ts
+++ b/bundle/src/lib/header-bidding/prebid-types.ts
@@ -12,7 +12,6 @@ type HeaderBiddingSlotName =
 	| 'top-above-nav'
 	| 'merchandising'
 	| 'merchandising-high'
-	| 'article-end'
 	| `fronts-banner-${number}`
 	| `inline${number}`;
 

--- a/bundle/src/lib/header-bidding/slot-config.ts
+++ b/bundle/src/lib/header-bidding/slot-config.ts
@@ -251,11 +251,6 @@ const getSlotSizeMapping = (): HeaderBiddingSizeMapping => {
 			mobile: [getAdSize('mpu')],
 			desktop: [getAdSize('billboard')],
 		},
-		'article-end': {
-			mobile: isInUk() ? [getAdSize('mpu')] : [],
-			tablet: isInUk() ? [getAdSize('mpu')] : [],
-			desktop: isInUk() ? [getAdSize('mpu')] : [],
-		},
 	};
 };
 

--- a/bundle/src/lib/header-bidding/slot-config.ts
+++ b/bundle/src/lib/header-bidding/slot-config.ts
@@ -1,6 +1,5 @@
 import type { AdSize } from '@guardian/commercial-core/ad-sizes';
 import { adSizes } from '@guardian/commercial-core/ad-sizes';
-import { isInUk } from '@guardian/commercial-core/geo/geo-utils';
 import type { Size } from 'prebid.js/dist/src/types/common';
 import type { Advert } from '../../define/Advert';
 import type {


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

This PR removes the code left from the clean up of the the AB test `mpuWhenNoEpic` as it's the only part of the code that hasn't been removed. The code removal in previous PRs https://github.com/guardian/commercial/pull/2074 and https://github.com/guardian/dotcom-rendering/pull/14195

## Why?

That code was part of an AB test that we decided to not release and it was the only bit of code left to be removed. 
