### PR TITLE
Prevent AB test variant from being truncated

### DIFF
--- a/core/src/targeting/build-page-targeting.spec.ts
+++ b/core/src/targeting/build-page-targeting.spec.ts
@@ -417,7 +417,7 @@ describe('Build Page Targeting', () => {
 				consentState: emptyConsent,
 				isSignedIn: true,
 			}).ab,
-		).toEqual(['someTest-variantName']);
+		).toEqual(['variantName-someTest']);
 	});
 
 	it('should set Observer flag for Observer content', () => {

--- a/core/src/targeting/session.spec.ts
+++ b/core/src/targeting/session.spec.ts
@@ -34,7 +34,7 @@ describe('Session targeting', () => {
 		};
 
 		const expected: SessionTargeting = {
-			ab: ['ab-new-ad-targeting-variant', 'ab-some-other-test-control'],
+			ab: ['variant-ab-new-ad-targeting', 'control-ab-some-other-test'],
 			at: null,
 			cc: 'GB',
 			lh: '12',

--- a/core/src/targeting/session.ts
+++ b/core/src/targeting/session.ts
@@ -143,8 +143,8 @@ const abTestingTargeting = (
 	const testToParams = (testName: string, variant: string): string | null => {
 		if (variant === 'notintest') return null;
 
-		// GAM key-value pairs accept value strings up to 40 characters long
-		return `${testName}-${variant}`.substring(0, 40);
+		// GAM key-value pairs accept value strings up to 40 characters long, put variant first so it isn't truncated
+		return `${variant}-${testName}`.substring(0, 40);
 	};
 
 	const abTests = Object.entries(abTestParticipations)


### PR DESCRIPTION
## What does this change?

The ab targeting value is capped at 40 chars for GAM, and with `${testName}-${variant}` the variant (e.g. control/variant) could get truncated off the end for longer test names, making it impossible to tell which variant a session was in. Swapped the order to `${variant}-${testName}` so the variant always survives, any truncation now trims the (usually more verbose, still identifiable) test name instead.

Updated the two existing unit tests asserting the old value order.
> [!NOTE]
> This changes the format of an established GAM custom key, we should flag to anyone with downstream reports/queries that parse this value assuming testName-variant order.

## Why?
 Resolves https://app.asana.com/1/1210045093164357/project/1213489522854406/task/1215679158890872?focus=true