### PR TITLE
Reduce noise from prebid unit tests

### DIFF
--- a/bundle/src/lib/header-bidding/prebid/index.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.spec.ts
@@ -80,6 +80,8 @@ const resetPrebid = () => {
 
 describe('initialise', () => {
 	beforeEach(() => {
+		/** jsdom mock for video play operation */
+		window.HTMLMediaElement.prototype.play = () => Promise.resolve();
 		resetPrebid();
 		window.guardian.config.switches.consentManagement = true;
 		window.guardian.config.switches.prebidUserSync = true;

--- a/core/package.json
+++ b/core/package.json
@@ -56,7 +56,7 @@
 		"@types/jest": "30.0.0",
 		"@types/node": "26.1.2",
 		"jest": "30.3.0",
-		"jest-environment-jsdom": "30.3.0",
+		"jest-environment-jsdom": "30.4.1",
 		"jest-environment-jsdom-global": "4.0.0",
 		"ts-jest": "29.4.9",
 		"tsc-alias": "1.8.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,11 +232,11 @@ importers:
         specifier: 30.3.0
         version: 30.3.0(@types/node@26.1.2)
       jest-environment-jsdom:
-        specifier: 30.3.0
-        version: 30.3.0
+        specifier: 30.4.1
+        version: 30.4.1
       jest-environment-jsdom-global:
         specifier: 4.0.0
-        version: 4.0.0(jest-environment-jsdom@30.3.0)
+        version: 4.0.0(jest-environment-jsdom@30.4.1)
       ts-jest:
         specifier: 29.4.9
         version: 29.4.9(@babel/core@7.29.7)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.3.0(@types/node@26.1.2))(typescript@5.9.3)
@@ -1272,16 +1272,6 @@ packages:
   '@jest/diff-sequences@30.3.0':
     resolution: {integrity: sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/environment-jsdom-abstract@30.3.0':
-    resolution: {integrity: sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-    peerDependencies:
-      canvas: ^3.0.0
-      jsdom: '*'
-    peerDependenciesMeta:
-      canvas:
-        optional: true
 
   '@jest/environment-jsdom-abstract@30.4.1':
     resolution: {integrity: sha512-dSlKrqug3siYNHVnjwIldShY12wAH3spwRltO/+8VOjg0X+xEq7vOs3DbBs4LRKsu7OH+NUb9kuZUNBF9Ho3TA==}
@@ -3970,15 +3960,6 @@ packages:
     engines: {node: '>= 14'}
     peerDependencies:
       jest-environment-jsdom: 22.x || 23.x || 24.x || 25.x || 26.x || 27.x || 28.x || 29.x
-
-  jest-environment-jsdom@30.3.0:
-    resolution: {integrity: sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-    peerDependencies:
-      canvas: ^3.0.0
-    peerDependenciesMeta:
-      canvas:
-        optional: true
 
   jest-environment-jsdom@30.4.1:
     resolution: {integrity: sha512-o3nfaN4zej7qgk2X0j8Jhq/S9nAVKs2xK3QeQxeHVvpkEPxaA1yxDGydR+iVI7zPy7Cp62Aq2h3Ja46QvfWHGA==}
@@ -7254,17 +7235,6 @@ snapshots:
 
   '@jest/diff-sequences@30.3.0': {}
 
-  '@jest/environment-jsdom-abstract@30.3.0(jsdom@26.1.0(patch_hash=dc6f2601e97346e56a984ec48c0fe20ba3472340aab70c7ac6f9782c3bdb8d59))':
-    dependencies:
-      '@jest/environment': 30.3.0
-      '@jest/fake-timers': 30.3.0
-      '@jest/types': 30.3.0
-      '@types/jsdom': 21.1.7
-      '@types/node': 26.1.2
-      jest-mock: 30.3.0
-      jest-util: 30.3.0
-      jsdom: 26.1.0(patch_hash=dc6f2601e97346e56a984ec48c0fe20ba3472340aab70c7ac6f9782c3bdb8d59)
-
   '@jest/environment-jsdom-abstract@30.4.1(jsdom@26.1.0(patch_hash=dc6f2601e97346e56a984ec48c0fe20ba3472340aab70c7ac6f9782c3bdb8d59))':
     dependencies:
       '@jest/environment': 30.4.1
@@ -10398,23 +10368,9 @@ snapshots:
       jest-util: 30.3.0
       pretty-format: 30.3.0
 
-  jest-environment-jsdom-global@4.0.0(jest-environment-jsdom@30.3.0):
-    dependencies:
-      jest-environment-jsdom: 30.3.0
-
   jest-environment-jsdom-global@4.0.0(jest-environment-jsdom@30.4.1):
     dependencies:
       jest-environment-jsdom: 30.4.1
-
-  jest-environment-jsdom@30.3.0:
-    dependencies:
-      '@jest/environment': 30.3.0
-      '@jest/environment-jsdom-abstract': 30.3.0(jsdom@26.1.0(patch_hash=dc6f2601e97346e56a984ec48c0fe20ba3472340aab70c7ac6f9782c3bdb8d59))
-      jsdom: 26.1.0(patch_hash=dc6f2601e97346e56a984ec48c0fe20ba3472340aab70c7ac6f9782c3bdb8d59)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
 
   jest-environment-jsdom@30.4.1:
     dependencies:


### PR DESCRIPTION
## What does this change?

- Adds a stub for video playback for prebid test
- Bumps `jest-environment-jsdom` in `core` package. This must have been missed accidentally since this was updated already in `bundle`

## Why?

Ever since adding `teadsBidAdapter` the tests have resulted in error blocks which don't result in the test failing but do add a huge amount of noise and console output to the tests.

We don't need to test this functionality so let's stub it to silence the noisy output