### PR TITLE
Add a failsafe timeout to Prebid

### DIFF
--- a/.changeset/cold-shoes-play.md
+++ b/.changeset/cold-shoes-play.md
@@ -1,0 +1,5 @@
+---
+"@guardian/commercial-core": major
+---
+
+Renames PREBID_TIMEOUT constant to PREBID_AUCTION_TIMEOUT. Adds PREBID_FAILSAFE_TIMEOUT constant. The file is renamed to prebid-timeouts.ts

--- a/bundle/src/init/consented/prepare-prebid.spec.ts
+++ b/bundle/src/init/consented/prepare-prebid.spec.ts
@@ -347,7 +347,7 @@ describe('init', () => {
 		expect(log).toHaveBeenCalledWith(
 			'commercial',
 			expect.stringContaining('Failed to execute prebid'),
-			expect.stringContaining('Unknown framework'),
+			expect.stringContaining('Unknown consent framework'),
 		);
 
 		expect(prebid.initialise).not.toHaveBeenCalled();

--- a/bundle/src/init/consented/prepare-prebid.ts
+++ b/bundle/src/init/consented/prepare-prebid.ts
@@ -37,7 +37,7 @@ const throwIfUnconsented = (hasConsentForPrebid: boolean): void => {
 	}
 };
 
-const setupPrebidIfAllowed = async (): Promise<void> => {
+const setupPrebid = async (): Promise<void> => {
 	if (!shouldLoadPrebid()) {
 		return;
 	}
@@ -67,7 +67,7 @@ const setupPrebidIfAllowed = async (): Promise<void> => {
 	}
 };
 
-export const setupPrebidOnce: () => Promise<void> = once(setupPrebidIfAllowed);
+export const setupPrebidOnce: () => Promise<void> = once(setupPrebid);
 
 /**
  * Initialise prebid - header bidding for display and video ads
@@ -79,5 +79,5 @@ export const preparePrebid = (): Promise<void> => {
 };
 
 export const _ = {
-	setupPrebid: setupPrebidIfAllowed,
+	setupPrebid,
 };

--- a/bundle/src/init/consented/prepare-prebid.ts
+++ b/bundle/src/init/consented/prepare-prebid.ts
@@ -19,11 +19,6 @@ const shouldLoadPrebid = () =>
 	!isInCanada();
 
 const loadPrebid = async (consentState: ConsentState): Promise<void> => {
-	// double check that we should load prebid
-	if (!shouldLoadPrebid()) {
-		return;
-	}
-
 	await import(
 		/* webpackChunkName: "Prebid.js" */
 		'../../lib/header-bidding/prebid/modules'
@@ -42,12 +37,15 @@ const throwIfUnconsented = (hasConsentForPrebid: boolean): void => {
 	}
 };
 
-const setupPrebid = async (): Promise<void> => {
+const setupPrebidIfAllowed = async (): Promise<void> => {
+	if (!shouldLoadPrebid()) {
+		return;
+	}
+
 	try {
 		const consentState = await onConsent();
-
 		if (!consentState.framework) {
-			throw new Error('Unknown framework');
+			throw new Error('Unknown consent framework');
 		}
 
 		switch (consentState.framework) {
@@ -61,6 +59,7 @@ const setupPrebid = async (): Promise<void> => {
 				// We do per-vendor checks for this framework, no requirement for a top-level check for Prebid
 				break;
 		}
+
 		return loadPrebid(consentState);
 	} catch (err: unknown) {
 		const error = err as Error;
@@ -68,7 +67,7 @@ const setupPrebid = async (): Promise<void> => {
 	}
 };
 
-export const setupPrebidOnce: () => Promise<void> = once(setupPrebid);
+export const setupPrebidOnce: () => Promise<void> = once(setupPrebidIfAllowed);
 
 /**
  * Initialise prebid - header bidding for display and video ads
@@ -80,5 +79,5 @@ export const preparePrebid = (): Promise<void> => {
 };
 
 export const _ = {
-	setupPrebid,
+	setupPrebid: setupPrebidIfAllowed,
 };

--- a/bundle/src/lib/header-bidding/prebid/analytics.ts
+++ b/bundle/src/lib/header-bidding/prebid/analytics.ts
@@ -26,6 +26,7 @@ const shouldEnableAnalytics = (): boolean => {
 	const hasQueryParam = window.location.search.includes(
 		'pbjs-analytics=true',
 	);
+
 	return (
 		isInServerSideTest ||
 		isInClientSideTest ||

--- a/bundle/src/lib/header-bidding/prebid/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.ts
@@ -1,6 +1,9 @@
 import type { AdSize } from '@guardian/commercial-core/ad-sizes';
 import { createAdSize } from '@guardian/commercial-core/ad-sizes';
-import { PREBID_TIMEOUT } from '@guardian/commercial-core/constants/prebid-timeouts';
+import {
+	PREBID_AUCTION_TIMEOUT,
+	PREBID_FAILSAFE_TIMEOUT,
+} from '@guardian/commercial-core/constants/prebid-timeouts';
 import { EventTimer } from '@guardian/commercial-core/event-timer';
 import type { ConsentState } from '@guardian/consent-manager';
 import { onConsent } from '@guardian/consent-manager';
@@ -62,7 +65,7 @@ const initialise = async (
 		/**
 		 * The amount of time reserved for the auction
 		 */
-		bidderTimeout: PREBID_TIMEOUT,
+		bidderTimeout: PREBID_AUCTION_TIMEOUT,
 		/**
 		 * Applying one global floor price of £0.10 for all bids.
 		 */
@@ -175,8 +178,14 @@ const initialise = async (
 const bidsBackHandler = (
 	adUnits: AdUnitDefinition[],
 	eventTimer: EventTimer,
-): Promise<void> =>
-	new Promise((resolve) => {
+	hasBeenCalled: { value: boolean },
+): Promise<void> => {
+	if (hasBeenCalled.value) {
+		return Promise.resolve();
+	}
+	hasBeenCalled.value = true;
+
+	return new Promise((resolve) => {
 		window.pbjs.setTargetingForGPTAsync(
 			adUnits.map((u) => u.code).filter(isString),
 		);
@@ -189,6 +198,7 @@ const bidsBackHandler = (
 			}
 		});
 	});
+};
 
 let requestQueue: Promise<void> = Promise.resolve();
 
@@ -234,6 +244,25 @@ const requestBids = async (
 
 	const eventTimer = EventTimer.get();
 
+	const isInFailsafeTestGroup = isUserInTestGroup(
+		'commercial-prebid-failsafe-timeout',
+		'variant',
+	);
+
+	// A reference value so that scoping works correctly.
+	const hasBidsBackHandlerBeenCalled = { value: false };
+
+	if (isInFailsafeTestGroup) {
+		// This failsafe timeout is a safety net that invokes bidsBackHandler in case something goes wrong.
+		setTimeout(function () {
+			void bidsBackHandler(
+				adUnits,
+				eventTimer,
+				hasBidsBackHandlerBeenCalled,
+			);
+		}, PREBID_FAILSAFE_TIMEOUT);
+	}
+
 	requestQueue = requestQueue.then(
 		() =>
 			new Promise<void>((resolve) => {
@@ -250,9 +279,11 @@ const requestBids = async (
 					void window.pbjs.requestBids({
 						adUnits,
 						bidsBackHandler: () =>
-							void bidsBackHandler(adUnits, eventTimer).then(
-								resolve,
-							),
+							void bidsBackHandler(
+								adUnits,
+								eventTimer,
+								hasBidsBackHandlerBeenCalled,
+							).then(resolve),
 					});
 				});
 			}),

--- a/bundle/src/lib/header-bidding/prebid/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.ts
@@ -1,6 +1,6 @@
 import type { AdSize } from '@guardian/commercial-core/ad-sizes';
 import { createAdSize } from '@guardian/commercial-core/ad-sizes';
-import { PREBID_TIMEOUT } from '@guardian/commercial-core/constants/prebid-timeout';
+import { PREBID_TIMEOUT } from '@guardian/commercial-core/constants/prebid-timeouts';
 import { EventTimer } from '@guardian/commercial-core/event-timer';
 import type { ConsentState } from '@guardian/consent-manager';
 import { onConsent } from '@guardian/consent-manager';
@@ -106,10 +106,12 @@ const initialise = async (
 		});
 	}
 
-	/** Helper function to decide if a bidder should be included.
+	/**
+	 * Helper function to decide if a bidder should be included.
 	 * It is a curried function prepared with the consent state
 	 * at the time of initialisation to avoid unnecessary repetition
-	 * of consent state throughout */
+	 * of consent state throughout
+	 */
 	const isBidderEnabled = shouldIncludeBidder(consentState);
 
 	// initialise enabled bidders
@@ -158,7 +160,7 @@ const initialise = async (
 		/**
 		 * when hasPrebidSize is true we use size
 		 * set here when adjusting the slot size.
-		 * */
+		 */
 		advert.hasPrebidSize = true;
 		advert.size = size;
 
@@ -209,6 +211,7 @@ const requestBids = async (
 			// calculate this once before mapping over
 			const isSignedIn = await isUserLoggedIn();
 			const pageTargeting = getPageTargeting(consentState, isSignedIn);
+
 			return flatten(
 				adverts.map((advert) =>
 					getHeaderBiddingAdSlots(advert, slotFlatMap).map(

--- a/bundle/src/lib/header-bidding/prebid/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.ts
@@ -181,6 +181,7 @@ const bidsBackHandler = (
 	hasBeenCalled: { value: boolean },
 ): Promise<void> => {
 	if (hasBeenCalled.value) {
+		// This handler has already been called, either by all bids being returned or by the failsafe timeout.
 		return Promise.resolve();
 	}
 	hasBeenCalled.value = true;
@@ -249,11 +250,11 @@ const requestBids = async (
 		'variant',
 	);
 
-	// A reference value so that scoping works correctly.
+	// This is a reference rather than a value type so that scoping works correctly.
 	const hasBidsBackHandlerBeenCalled = { value: false };
 
 	if (isInFailsafeTestGroup) {
-		// This failsafe timeout is a safety net that invokes bidsBackHandler in case something goes wrong.
+		// This failsafe timeout is a safety net that invokes bidsBackHandler in case something goes wrong with Prebid.
 		setTimeout(function () {
 			void bidsBackHandler(
 				adUnits,

--- a/core/src/constants/index.spec.ts
+++ b/core/src/constants/index.spec.ts
@@ -1,4 +1,9 @@
-import { AD_LABEL_HEIGHT, PREBID_TIMEOUT, TOP_ABOVE_NAV_HEIGHT } from '.';
+import {
+	AD_LABEL_HEIGHT,
+	PREBID_AUCTION_TIMEOUT,
+	PREBID_FAILSAFE_TIMEOUT,
+	TOP_ABOVE_NAV_HEIGHT,
+} from '.';
 
 // These tests ensure that we look twice when changing a constant
 describe('Constant values are constant', () => {
@@ -6,8 +11,12 @@ describe('Constant values are constant', () => {
 		expect(TOP_ABOVE_NAV_HEIGHT).toBe(250);
 	});
 
-	test('PREBID_TIMEOUT', () => {
-		expect(PREBID_TIMEOUT).toBe(1500);
+	test('PREBID_AUCTION_TIMEOUT', () => {
+		expect(PREBID_AUCTION_TIMEOUT).toBe(1500);
+	});
+
+	test('PREBID_FAILSAFE_TIMEOUT', () => {
+		expect(PREBID_FAILSAFE_TIMEOUT).toBe(3000);
 	});
 
 	test('AD_LABEL_HEIGHT', () => {

--- a/core/src/constants/index.ts
+++ b/core/src/constants/index.ts
@@ -1,3 +1,6 @@
 export { AD_LABEL_HEIGHT } from './ad-label-height';
-export { FAILSAFE_TIMEOUT, PREBID_TIMEOUT } from './prebid-timeouts';
+export {
+	PREBID_AUCTION_TIMEOUT,
+	PREBID_FAILSAFE_TIMEOUT,
+} from './prebid-timeouts';
 export { TOP_ABOVE_NAV_HEIGHT } from './top-above-nav-height';

--- a/core/src/constants/index.ts
+++ b/core/src/constants/index.ts
@@ -1,3 +1,3 @@
 export { AD_LABEL_HEIGHT } from './ad-label-height';
-export { PREBID_TIMEOUT } from './prebid-timeout';
+export { FAILSAFE_TIMEOUT, PREBID_TIMEOUT } from './prebid-timeouts';
 export { TOP_ABOVE_NAV_HEIGHT } from './top-above-nav-height';

--- a/core/src/constants/prebid-timeout.ts
+++ b/core/src/constants/prebid-timeout.ts
@@ -1,4 +1,0 @@
-/**
- * Unit: milliseconds
- */
-export const PREBID_TIMEOUT = 1500;

--- a/core/src/constants/prebid-timeouts.ts
+++ b/core/src/constants/prebid-timeouts.ts
@@ -1,0 +1,9 @@
+/**
+ * Unit: milliseconds
+ */
+export const PREBID_TIMEOUT = 1_500;
+
+/**
+ * Unit: milliseconds
+ */
+export const FAILSAFE_TIMEOUT = 3_000;

--- a/core/src/constants/prebid-timeouts.ts
+++ b/core/src/constants/prebid-timeouts.ts
@@ -1,9 +1,9 @@
 /**
  * Unit: milliseconds
  */
-export const PREBID_TIMEOUT = 1_500;
+export const PREBID_AUCTION_TIMEOUT = 1_500;
 
 /**
  * Unit: milliseconds
  */
-export const FAILSAFE_TIMEOUT = 3_000;
+export const PREBID_FAILSAFE_TIMEOUT = 3_000;


### PR DESCRIPTION
## What does this change?

Add a failsafe timeout to Prebid behind an AB test. If for some reason the `bidsBackHandler` is not called within three seconds, invoke this handler with the bids that have been returned.

## Why?

Prebid recommends having a failsafe timeout in case something goes wrong[^1]. This will ensure that Prebid doesn't wait indefinitely for bids and could lead to higher ad-ratio.

[^1]: https://docs.prebid.org/features/timeouts.html
