### PR TITLE
Add hashed email support for Ozone

### DIFF
--- a/.changeset/shaggy-paths-shave.md
+++ b/.changeset/shaggy-paths-shave.md
@@ -1,0 +1,5 @@
+---
+'@guardian/commercial-core': minor
+---
+
+Add `ozone` client to `hashEmailForClient` to support hashing emails for the Ozone Prebid `pubProvidedId` integration

--- a/bundle/src/lib/header-bidding/prebid/id-handlers/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/index.ts
@@ -5,6 +5,7 @@ import { isSwitchedOn } from '../../utils';
 import { getUserIdForId5 } from './id5';
 import { getUserIdForIntentIQ } from './intent-iq';
 import { getUserIdForLiveRamp } from './liveramp';
+import { getUserIdForOzone } from './ozone';
 import { sharedId } from './shared';
 import { getUserIdForTradeDesk } from './tradedesk';
 
@@ -22,6 +23,8 @@ export const getUserSyncSettings = async (
 		getUserIdForTradeDesk(userEmail, consentState);
 	const fetchIntentIQUserId =
 		getConsentFor('intentIQ', consentState) && getUserIdForIntentIQ();
+	const fetchOzoneUserId =
+		getConsentFor('ozone', consentState) && getUserIdForOzone(userEmail);
 
 	// run all ID providers asynchronously
 
@@ -35,7 +38,9 @@ export const getUserSyncSettings = async (
 		fetchLiveRampUserId,
 		fetchTradeDeskUserId,
 		fetchIntentIQUserId,
+		fetchOzoneUserId,
 	]);
+
 
 	const userIds = [...userIdModules]
 		// typescript doesn't like flatMap here

--- a/bundle/src/lib/header-bidding/prebid/id-handlers/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/index.ts
@@ -41,7 +41,6 @@ export const getUserSyncSettings = async (
 		fetchOzoneUserId,
 	]);
 
-
 	const userIds = [...userIdModules]
 		// typescript doesn't like flatMap here
 		.map((idModule) => {

--- a/bundle/src/lib/header-bidding/prebid/id-handlers/ozone.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/ozone.spec.ts
@@ -1,0 +1,64 @@
+import * as core from '@guardian/commercial-core';
+import { isUserInTestGroup } from '../../../../ab-testing';
+import { getUserIdForOzone } from './ozone';
+
+jest.mock('../../../../ab-testing');
+
+const mockIsUserInTestGroup = isUserInTestGroup as jest.MockedFunction<
+	typeof isUserInTestGroup
+>;
+
+describe('getUserIdForOzone', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it('returns undefined when the user is not in the test variant group', async () => {
+		mockIsUserInTestGroup.mockReturnValue(false);
+
+		const result = await getUserIdForOzone('test@example.com');
+
+		expect(result).toBeUndefined();
+	});
+
+	it('returns undefined when there is no email', async () => {
+		mockIsUserInTestGroup.mockReturnValue(true);
+
+		const result = await getUserIdForOzone(null);
+
+		expect(result).toBeUndefined();
+	});
+
+	it('returns a pubProvidedId config with the hashed email eid when in the variant group', async () => {
+		mockIsUserInTestGroup.mockReturnValue(true);
+		jest.spyOn(core, 'hashEmailForClient').mockResolvedValueOnce(
+			'hashed-email-value',
+		);
+
+		const result = await getUserIdForOzone('test@example.com');
+
+		expect(core.hashEmailForClient).toHaveBeenCalledWith(
+			'test@example.com',
+			'ozone',
+		);
+		expect(result).toEqual({
+			name: 'pubProvidedId',
+			params: {
+				eids: [
+					{
+						source: 'ozoneproject.com',
+						uids: [
+							{
+								id: 'hashed-email-value',
+								atype: 3,
+								ext: {
+									stype: 'ppuid',
+								},
+							},
+						],
+					},
+				],
+			},
+		});
+	});
+});

--- a/bundle/src/lib/header-bidding/prebid/id-handlers/ozone.ts
+++ b/bundle/src/lib/header-bidding/prebid/id-handlers/ozone.ts
@@ -1,0 +1,35 @@
+import { hashEmailForClient } from '@guardian/commercial-core';
+import type { UserIdConfig } from 'prebid.js/dist/modules/userId/spec';
+import { isUserInTestGroup } from '../../../../ab-testing';
+
+const OZONE_HEM_TEST_ID = 'commercial-ozone-hashed-email';
+
+export const getUserIdForOzone = async (
+	email: string | null,
+): Promise<UserIdConfig<'pubProvidedId'> | undefined> => {
+	const isInTest = isUserInTestGroup(OZONE_HEM_TEST_ID, 'variant');
+
+	if (email && isInTest) {
+		const hashedEmail = await hashEmailForClient(email, 'ozone');
+		return {
+			name: 'pubProvidedId',
+			params: {
+				eids: [
+					{
+						source: 'ozoneproject.com',
+						uids: [
+							{
+								id: hashedEmail,
+								atype: 3,
+								ext: {
+									stype: 'ppuid',
+								},
+							},
+						],
+					},
+				],
+			},
+		};
+	}
+	return undefined;
+};

--- a/bundle/src/lib/header-bidding/prebid/modules/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/modules/index.ts
@@ -22,6 +22,7 @@ import 'prebid.js/modules/euidIdSystem';
 import 'prebid.js/modules/id5IdSystem';
 import 'prebid.js/modules/identityLinkIdSystem';
 import 'prebid.js/modules/pairIdSystem';
+import 'prebid.js/modules/pubProvidedIdSystem';
 import 'prebid.js/modules/sharedIdSystem';
 import 'prebid.js/modules/uid2IdSystem';
 import 'prebid.js/modules/userId';

--- a/core/src/email-hash.spec.ts
+++ b/core/src/email-hash.spec.ts
@@ -23,6 +23,17 @@ describe('hashEmail', () => {
 		);
 	});
 
+	it('returns a hex encoded email for ozone', async () => {
+		const hashedEmail = await hashEmailForClient(
+			'testGuardianUser@gmail.com',
+			'ozone',
+		);
+
+		expect(hashedEmail).toBe(
+			'528f4e83dbdd916e811358e43518555f68229b1dc279b6b2cd3c480f68371e7d',
+		);
+	});
+
 	it('returns a base64 encoded email for uid2', async () => {
 		const hashedEmail = await hashEmailForClient(
 			'user@example.com',

--- a/core/src/email-hash.ts
+++ b/core/src/email-hash.ts
@@ -1,4 +1,4 @@
-type HashClient = 'euid' | 'id5' | 'liveramp' | 'uid2' | 'permutive';
+type HashClient = 'euid' | 'id5' | 'liveramp' | 'uid2' | 'permutive' | 'ozone';
 type Email = `${string}@${string}`;
 
 function toBase64(content: ArrayBuffer): string {
@@ -39,6 +39,7 @@ async function hashEmailForClient(
 		case 'id5':
 		case 'liveramp':
 		case 'permutive':
+		case 'ozone':
 			return toHex(hashBuffer);
 	}
 }


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?
Adds hashed email support for Ozone via Prebid pubProvidedId, gated behind a zero percent AB test and consent. Adds ozone as a HashClient in `email-hash.ts` reusing existing normalisation rules. 
Added unit tests and a changeset for the core package.

[See companion DCR pr ](https://github.com/guardian/dotcom-rendering/pull/16582)


