### PR TITLE
Adds an extra test for Prebid timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ There are 2 packages in this repo:
 ### Running locally
 
 Please use the [.devcontainer](.devcontainer) configuration to open your IDE in an isolated development environment ie. a [dev container](https://containers.dev).
-You will need to have Docker installed (or at least have a Docker daemon running). 
+You will need to have Docker installed (or at least have a Docker daemon running).
 See documentation available at https://github.com/guardian/devenv for extra information and help with development containers.
 
 When updating the `devenv.yaml` file, ensure that you regenerate the resulting devcontainer.json files by running `devenv generate`.
@@ -31,6 +31,7 @@ All usual commands should be available from within the dev container.
 To install dependencies, run `pnpm i`.
 
 ### A Note on Deployments
+
 [`@guardian/commercial-bundle`](./bundle/) and [`@guardian/commercial-core`](./core/) are deployed separately.
 
 `@guardian/commercial-bundle` is deployed to PROD automatically when merged to main. It does not use changesets.

--- a/core/src/constants/index.spec.ts
+++ b/core/src/constants/index.spec.ts
@@ -23,3 +23,16 @@ describe('Constant values are constant', () => {
 		expect(AD_LABEL_HEIGHT).toBe(24);
 	});
 });
+
+describe('Prebid timeout combination', () => {
+	/**
+	 * The failsafe timeout should always be much larger than the auction timeout. The failsafe timeout is a safety
+	 * net that invokes the callback in case something goes wrong with Prebid. If these two timeouts are too close
+	 * together, the failsafe timeout might often be invoked before the auction timeout has a chance to complete.
+	 */
+	test('Ensure there is enough buffer between the auction and failsafe timeout', () => {
+		expect(PREBID_AUCTION_TIMEOUT + 1000 <= PREBID_FAILSAFE_TIMEOUT).toBe(
+			true,
+		);
+	});
+});

--- a/docs/header-bidding/readme.md
+++ b/docs/header-bidding/readme.md
@@ -221,6 +221,10 @@ Our Prebid.js set up is defined in [src/lib/header-bidding/prebid/load-modules.t
 
 The Guardian-specific Prebid modules are in [src/lib/header-bidding/prebid/modules](https://github.com/guardian/commercial/tree/1e920009b61342687611056daed7714fe1cfead3/src/lib/header-bidding/prebid/modules).
 
-#### Debugging prebid.js
+### Debugging prebid.js
 
 Adding `?pbjs_debug=true` to the URL will output prebid.js debug information to the developer console.
+
+### Timeouts
+
+We use an auction timeout for both Prebid and APS. If this timeout is reached, the auction is terminated and only bids that have been received within this timeframe are considered for the ad slot. Currently, this is set at 1,500 ms for both Prebid and APS. We have a failsafe timeout around the Prebid auction, whose purpose is to invoke the ad server callback in case something goes wrong with Prebid. In all regular scenarios, Prebid.js will have already invoked the callback before this timeout is reached. This is to ensure the Prebid auction doesn't hang indefinitely in case something goes wrong.


### PR DESCRIPTION
no-op

## What does this change?

Adds a test to explain the relationship between the Prebid timeouts: auction and failsafe.

Updates the header bidding docs with timeout info.
