### PR TITLE
Update changesets action inputs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,8 +59,8 @@ jobs:
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
           publish-script: pnpm changeset publish
-          title: 🦋 Release package updates
-          commit: Bump package versions
+          pr-title: 🦋 Release package updates
+          commit-message: Bump package versions
           setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## What does this change?

Updates the names of the action inputs for the changesets action

## Why?

These changed in v2 of changesets but we didn't spot it until the action started erroring on the main branch

It's hard to test this properly ahead of merging as it only works on the "NPM Publish" job within the workflow and not on the "beta release" part
