### PR TITLE
Fix changesets action in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,9 +61,7 @@ jobs:
           publish-script: pnpm changeset publish
           pr-title: 🦋 Release package updates
           commit-message: Bump package versions
-          setupGitUser: false
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token }}
 
   publish-beta:
     name: '@guardian/commercial-core'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,8 @@ jobs:
         with:
           app-id: ${{ secrets.GU_CHANGESETS_APP_ID }}
           private-key: ${{ secrets.GU_CHANGESETS_PRIVATE_KEY }}
+          permission-contents: read
+          permission-pull-requests: write
 
       - name: Set git user to Gu Changesets app
         run: |


### PR DESCRIPTION
## What does this change?

- Sets `github-token` variable instead of providing this via an environment variable
  - Additionally limits the scope of this app token to `contents: read` and `pull-requests: write` (see https://github.com/actions/create-github-app-token#permission-permission-name)
- Removes `setupGitUser` variable as this is no longer valid

## Why?

Fixing the changesets release action in the publish workflow

Follow-on from first attempt in #2698 where the error was:
```
Error: Error: The GITHUB_TOKEN environment variable is set and does not match the "github-token" input. Please pass the custom GitHub token to the "github-token" input and remove the GITHUB_TOKEN environment variable to avoid conflicts.
```