### PR TITLE
Update changesets release action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,6 +65,9 @@ jobs:
           commit-message: Bump package versions
           # Changesets app token
           github-token: ${{ steps.app-token.outputs.token }}
+        # If there are no unreleased changes, this action fails
+        # We have no dependent steps so don't need to recognise this as a failure
+        continue-on-error: true
 
   publish-beta:
     name: '@guardian/commercial-core'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.GU_CHANGESETS_APP_ID }}
+          client-id: ${{ secrets.GU_CHANGESETS_APP_ID }}
           private-key: ${{ secrets.GU_CHANGESETS_PRIVATE_KEY }}
           permission-contents: read
           permission-pull-requests: write
@@ -63,6 +63,7 @@ jobs:
           publish-script: pnpm changeset publish
           pr-title: 🦋 Release package updates
           commit-message: Bump package versions
+          # Changesets app token
           github-token: ${{ steps.app-token.outputs.token }}
 
   publish-beta:
@@ -98,8 +99,8 @@ jobs:
         id: changeset
         with:
           publish-script: pnpm changeset publish --tag beta
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Github actions token
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment on PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
## What does this change?

- Adds `continue-on-error` for changesets release action
  - This now fails when there is nothing to release (see https://github.com/changesets/changesets/commit/92b1c1b6b1733b1f1799a73828d378646b068798) 
  - We don't have any dependent steps after this so we don't need to rely on a fact that a new version was published or not
 

Additionally:
- removes GITHUB_TOKEN env variable from the other changesets/action usage, preferring to provide this via the `github-token` input instead (see https://github.com/changesets/action/commit/cb3f0110d7423cd340b1c5d63584c0ea6ee63959)
- Renames `app-id` to `client-id` in input for `actions/create-github-app-token` after warning in console about input deprecation
- Adds comments to explain why the two Github tokens are different for the beta changesets release and the full changesets release

## Why?

Fixing the NPM release workflow after upgrading to `changesets/action@v2` and `@changesets/cli@v3`