### PR TITLE
Ozone outstream tweaks

### DIFF
--- a/.changeset/young-terms-sleep.md
+++ b/.changeset/young-terms-sleep.md
@@ -1,0 +1,5 @@
+---
+"@guardian/commercial-core": patch
+---
+
+Adds ozone outstream to list of proxy ad sizes

--- a/bundle/src/lib/header-bidding/prebid/index.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.spec.ts
@@ -618,7 +618,10 @@ describe('isInPrebidFloorPriceTest', () => {
 					enabled: true,
 					data: expect.objectContaining({
 						schema: { fields: ['mediaType'] },
-						values: { '*': 0.1 },
+						values: expect.objectContaining({
+							banner: 0.1,
+							video: 0.1,
+						}),
 						default: 0.1,
 					}),
 				}),

--- a/bundle/src/lib/header-bidding/prebid/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.ts
@@ -56,8 +56,6 @@ const initialise = async (
 		'holdback',
 	);
 
-	console.log('canUsePriceFloors:', canUsePriceFloors);
-
 	const shouldEnableTransactionIds = isUserInTestGroup(
 		'commercial-prebid-transaction-ids',
 		'variant',
@@ -77,7 +75,7 @@ const initialise = async (
 						enabled: true,
 						data: {
 							schema: { fields: ['mediaType'] },
-							values: { banner: 0.1, video: 0.1 }, // The wildcard token doesn't seem to work correctly.
+							values: { banner: 0.1, video: 0.1 },
 							default: 0.1,
 						},
 					},

--- a/bundle/src/lib/header-bidding/prebid/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.ts
@@ -56,6 +56,8 @@ const initialise = async (
 		'holdback',
 	);
 
+	console.log('canUsePriceFloors:', canUsePriceFloors);
+
 	const shouldEnableTransactionIds = isUserInTestGroup(
 		'commercial-prebid-transaction-ids',
 		'variant',
@@ -75,7 +77,7 @@ const initialise = async (
 						enabled: true,
 						data: {
 							schema: { fields: ['mediaType'] },
-							values: { '*': 0.1 },
+							values: { banner: 0.1, video: 0.1 }, // The wildcard token doesn't seem to work correctly.
 							default: 0.1,
 						},
 					},

--- a/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.spec.ts
@@ -99,7 +99,8 @@ describe('PrebidAdUnit', () => {
 				sizes: [[300, 250]],
 			},
 			video: {
-				playerSize: [[640, 360]],
+				playerSize: [640, 360],
+				mimes: ['video/mp4'],
 				context: 'outstream',
 				placement: 3,
 				plcmt: 4,
@@ -177,7 +178,8 @@ describe('PrebidAdUnit', () => {
 				sizes: [[300, 250]],
 			},
 			video: {
-				playerSize: [[640, 360]],
+				playerSize: [640, 360],
+				mimes: ['video/mp4'],
 				context: 'outstream',
 				placement: 3,
 				plcmt: 4,

--- a/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
@@ -1,3 +1,4 @@
+import { outstreamSizes } from '@guardian/commercial-core/ad-sizes';
 import type { PageTargeting } from '@guardian/commercial-core/targeting/build-page-targeting';
 import type { ConsentState } from '@guardian/consent-manager';
 import { log } from '@guardian/libs';
@@ -9,7 +10,7 @@ import type { MediaTypes } from 'prebid.js/dist/src/mediaTypes';
 import type { VideoMediaType } from 'prebid.js/dist/src/video';
 import type { Advert } from '../../../define/Advert';
 import type { HeaderBiddingSlot } from '../prebid-types';
-import { isOutstream } from '../utils';
+import { isOutstreamOzone } from '../utils';
 import { bids } from './bidders/config';
 
 export class PrebidAdUnit implements AdUnitDefinition {
@@ -33,10 +34,12 @@ export class PrebidAdUnit implements AdUnitDefinition {
 		consentState: ConsentState,
 	) {
 		/**
-		 * Outstream ad sizes are only compatible with the mediaTypes.video property of PrebidAdUnit
+		 * Only the Outstream Ozone ad size is compatible with the mediaTypes.video property of PrebidAdUnit
 		 */
-		const bannerSizes = slot.sizes.filter((size) => !isOutstream(size));
-		const videoSizes = slot.sizes.filter((size) => isOutstream(size));
+		const bannerSizes = slot.sizes.filter(
+			(size) => !isOutstreamOzone(size),
+		);
+		const videoSizes = slot.sizes.filter((size) => isOutstreamOzone(size));
 		const useOutstreamVideo =
 			slot.key === 'inline1' && videoSizes.length > 0;
 
@@ -48,8 +51,9 @@ export class PrebidAdUnit implements AdUnitDefinition {
 			...(useOutstreamVideo
 				? {
 						video: {
+							playerSize: outstreamSizes.outstreamOzone.toArray(),
+							mimes: ['video/mp4'],
 							context: 'outstream',
-							playerSize: videoSizes,
 							placement: 3, // in-article
 							plcmt: 4, // outstream
 						} as VideoMediaType,

--- a/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
+++ b/bundle/src/lib/header-bidding/prebid/prebid-ad-unit.ts
@@ -33,22 +33,20 @@ export class PrebidAdUnit implements AdUnitDefinition {
 		pageTargeting: PageTargeting,
 		consentState: ConsentState,
 	) {
-		/**
-		 * Only the Outstream Ozone ad size is compatible with the mediaTypes.video property of PrebidAdUnit
-		 */
 		const bannerSizes = slot.sizes.filter(
 			(size) => !isOutstreamOzone(size),
 		);
-		const videoSizes = slot.sizes.filter((size) => isOutstreamOzone(size));
-		const useOutstreamVideo =
-			slot.key === 'inline1' && videoSizes.length > 0;
+
+		const useVideoMediaType =
+			slot.key === 'inline1' &&
+			slot.sizes.some((size) => isOutstreamOzone(size));
 
 		this.code = advert.id;
 		this.mediaTypes = {
 			banner: {
 				sizes: bannerSizes,
 			},
-			...(useOutstreamVideo
+			...(useVideoMediaType
 				? {
 						video: {
 							playerSize: outstreamSizes.outstreamOzone.toArray(),

--- a/bundle/src/lib/header-bidding/utils.ts
+++ b/bundle/src/lib/header-bidding/utils.ts
@@ -1,7 +1,4 @@
-import {
-	type AdSizeString,
-	outstreamSizes,
-} from '@guardian/commercial-core/ad-sizes';
+import { outstreamSizes } from '@guardian/commercial-core/ad-sizes';
 import {
 	isInAuOrNz,
 	isInCanada,
@@ -113,10 +110,9 @@ export const containsLeaderboardOrBillboard = (sizes: Size[]): boolean =>
 export const containsPortraitInterstitial = (sizes: Size[]): boolean =>
 	contains(sizes, [320, 480]);
 
-export const isOutstream = (size: Size) =>
-	Object.values(outstreamSizes)
-		.map((outstreamSize) => outstreamSize.toString())
-		.includes(size.toString() as AdSizeString);
+export const isOutstreamOzone = (size: [number, number]): boolean =>
+	size[0] === outstreamSizes.outstreamOzone[0] &&
+	size[1] === outstreamSizes.outstreamOzone[1];
 
 export const getLargestSize = (sizes: Size[]): Size | null => {
 	const reducer = (previous: Size, current: Size) => {

--- a/core/src/ad-sizes.ts
+++ b/core/src/ad-sizes.ts
@@ -21,7 +21,6 @@ type BreakpointIndices = Indices<typeof breakpoints>;
  *
  * size[0] = 200; // throws error
  * size.width = 200; // throws error
- *
  */
 class AdSize extends Array<number> {
 	readonly [0]: number;
@@ -51,8 +50,16 @@ class AdSize extends Array<number> {
 		const isFluid = this.toString() === 'fluid';
 		const isMerch = this.width === 88;
 		const isSponsorLogo = this.width === 3 && this.height === 3;
+		const isOzoneOutstream = this.width === 640 && this.height === 360;
 
-		return isOutOfPage || isEmpty || isFluid || isMerch || isSponsorLogo;
+		return (
+			isOutOfPage ||
+			isEmpty ||
+			isFluid ||
+			isMerch ||
+			isSponsorLogo ||
+			isOzoneOutstream
+		);
 	}
 
 	get width(): number {
@@ -149,7 +156,11 @@ const outstreamSizes = {
 	outstreamDesktop: createAdSize(620, 350),
 	outstreamGoogleDesktop: createAdSize(550, 310),
 	outstreamMobile: createAdSize(300, 197),
-	outstreamOzone: createAdSize(640, 360), // Uses the same size for both desktop and mobile
+	/**
+	 * 640x360 is the industry-standard 16:9 ratio for outstream video. Ozone's renderer
+	 * is responsive and will scale the player to fit the width of the user's screen.
+	 */
+	outstreamOzone: createAdSize(640, 360),
 };
 
 /**


### PR DESCRIPTION
## What does this change?

Limits the Prebid `video` media type to the Ozone Outstream size only. The `playerSize` value should of type: Array[Integer,Integer][^1].

Adds `mimes: ['video/mp4']` to the video media type. Some bidders explicitly look for this.

Updates the price floors to explicitly set the floor to 10c for both banner and video. When testing locally, the wildcard `'*'` was only being used for banner. I'm unsure to why this is, but being explicit fixes the issue.

Adds the size `outstreamOzone` to the list of proxy ad sizes. The height 360px is only fulfilled if there is room for it on the page, otherwise it will shrink down to maintain aspect ratio. We don't want to set a minimum height by default for this ad size.

## Why?

We are not seeing meaningful spending with the new Ozone outstream ad size and we hope these changes might fix that. 

## Screenshots

<img width="1300" height="485" alt="image" src="https://github.com/user-attachments/assets/c1d8d6f0-f630-417a-a263-a82e8de0c450" />


[^1]: https://docs.prebid.org/dev-docs/adunit-reference.html
