### PR TITLE
mobile above nav (Test for crosswords)

### DIFF
--- a/.changeset/sharp-lands-pull.md
+++ b/.changeset/sharp-lands-pull.md
@@ -2,5 +2,5 @@
 "@guardian/commercial-core": minor
 ---
 
-Adding a new slot mobile-above-nav and a new size mobilestickyXl 100x320
+Adding a new slot mobile-above-nav and a new size mobilestickyXl 320x100
 

--- a/.changeset/sharp-lands-pull.md
+++ b/.changeset/sharp-lands-pull.md
@@ -2,5 +2,5 @@
 "@guardian/commercial-core": minor
 ---
 
-Adding a new slot mobile-above-nav and a new size mobilestickyXl 320x100
+Adding a new slot mobile-above-nav and a new size mobileLeaderboardXl 320x100
 

--- a/.changeset/sharp-lands-pull.md
+++ b/.changeset/sharp-lands-pull.md
@@ -1,0 +1,6 @@
+---
+"@guardian/commercial-core": minor
+---
+
+Adding a new slot mobile-above-nav and a new size mobilestickyXl 100x320
+

--- a/bundle/src/events/render-advert-label.ts
+++ b/bundle/src/events/render-advert-label.ts
@@ -133,6 +133,17 @@ const renderAdvertLabel = (
 						'true',
 					);
 				}
+				if (
+					adSlotNode.parentElement?.classList.contains(
+						'ad-slot-container',
+					) &&
+					adSlotNode.id === 'dfp-ad--mobile-above-nav'
+				) {
+					adSlotNode.parentElement.setAttribute(
+						'mobile-above-nav-ad-rendered',
+						'true',
+					);
+				}
 				// \Remove this
 
 				if (shouldRenderCloseButton(adSlotNode)) {

--- a/bundle/src/events/render-advert-label.ts
+++ b/bundle/src/events/render-advert-label.ts
@@ -134,10 +134,7 @@ const renderAdvertLabel = (
 					) &&
 					renderedAttr
 				) {
-					adSlotNode.parentElement.setAttribute(
-						renderedAttr,
-						'true',
-					);
+					adSlotNode.parentElement.setAttribute(renderedAttr, 'true');
 				}
 				// \Remove this
 

--- a/bundle/src/events/render-advert-label.ts
+++ b/bundle/src/events/render-advert-label.ts
@@ -80,6 +80,11 @@ const createAdTestLabel = (
 	return adTestLabel;
 };
 
+const renderedAttrSlots: Record<string, string> = {
+	'dfp-ad--top-above-nav': 'top-above-nav-ad-rendered',
+	'dfp-ad--mobile-above-nav': 'mobile-above-nav-ad-rendered',
+};
+
 const createAdTestCookieRemovalLink = (): HTMLElement => {
 	const adTestCookieRemovalLink = document.createElement('div');
 	adTestCookieRemovalLink.style.cssText =
@@ -121,26 +126,16 @@ const renderAdvertLabel = (
 			return fastdom.mutate(() => {
 				adSlotNode.setAttribute('data-label-show', 'true');
 				adSlotNode.setAttribute('ad-label-text', adLabelContent);
-				// Remove this once new `ad-slot-container--centre-slot` class is in place
+
+				const renderedAttr = renderedAttrSlots[adSlotNode.id];
 				if (
 					adSlotNode.parentElement?.classList.contains(
 						'ad-slot-container',
 					) &&
-					adSlotNode.id === 'dfp-ad--top-above-nav'
+					renderedAttr
 				) {
 					adSlotNode.parentElement.setAttribute(
-						'top-above-nav-ad-rendered',
-						'true',
-					);
-				}
-				if (
-					adSlotNode.parentElement?.classList.contains(
-						'ad-slot-container',
-					) &&
-					adSlotNode.id === 'dfp-ad--mobile-above-nav'
-				) {
-					adSlotNode.parentElement.setAttribute(
-						'mobile-above-nav-ad-rendered',
+						renderedAttr,
 						'true',
 					);
 				}

--- a/bundle/src/events/render-advert-label.ts
+++ b/bundle/src/events/render-advert-label.ts
@@ -136,7 +136,6 @@ const renderAdvertLabel = (
 				) {
 					adSlotNode.parentElement.setAttribute(renderedAttr, 'true');
 				}
-				// \Remove this
 
 				if (shouldRenderCloseButton(adSlotNode)) {
 					adSlotNode.insertBefore(

--- a/core/src/ad-sizes.test.ts
+++ b/core/src/ad-sizes.test.ts
@@ -33,7 +33,7 @@ const sizes = [
 	['googleCard', 300, 274, '300,274'],
 	['outstreamGoogleDesktop', 550, 310, '550,310'],
 	['300x600', 300, 600, '300,600'],
-	['mobilestickyXl', 320, 100, '320,100'],
+	['mobileLeaderboardXl', 320, 100, '320,100'],
 ] as const;
 
 describe('getAdSize', () => {

--- a/core/src/ad-sizes.test.ts
+++ b/core/src/ad-sizes.test.ts
@@ -33,6 +33,7 @@ const sizes = [
 	['googleCard', 300, 274, '300,274'],
 	['outstreamGoogleDesktop', 550, 310, '550,310'],
 	['300x600', 300, 600, '300,600'],
+	['mobilestickyXl', 320, 100, '320,100'],
 ] as const;
 
 describe('getAdSize', () => {

--- a/core/src/ad-sizes.ts
+++ b/core/src/ad-sizes.ts
@@ -90,6 +90,7 @@ type SizeKeys =
 	| 'merchandisingHigh'
 	| 'merchandisingHighAdFeature'
 	| 'mobilesticky'
+	| 'mobilestickyXl'
 	| 'mpu'
 	| 'outOfPage'
 	| 'outstreamDesktop'
@@ -117,6 +118,7 @@ type SlotName =
 	| 'mobile-sticky'
 	| 'football-right'
 	| 'mostpop'
+	| 'mobile-above-nav'
 	| 'right'
 	| 'sponsor-logo'
 	| 'survey'
@@ -136,6 +138,7 @@ const namedStandardAdSizes = {
 	halfPage: createAdSize(300, 600),
 	leaderboard: createAdSize(728, 90),
 	mobilesticky: createAdSize(320, 50),
+	mobilestickyXl: createAdSize(320, 100),
 	mpu: createAdSize(300, 250),
 	portrait: createAdSize(300, 1050),
 	skyscraper: createAdSize(160, 600),
@@ -398,6 +401,20 @@ const slotSizeMappings = {
 	},
 	'crossword-banner-mobile': {
 		mobile: [adSizes.mobilesticky],
+	},
+	'mobile-above-nav': {
+		mobile: [
+			adSizes.empty,
+			adSizes.mobilesticky,
+			adSizes.mobilestickyXl,
+			adSizes.fluid,
+		],
+		tablet: [
+			adSizes.empty,
+			adSizes.mobilesticky,
+			adSizes.mobilestickyXl,
+			adSizes.fluid,
+		],
 	},
 	'football-right': {
 		desktop: [

--- a/core/src/ad-sizes.ts
+++ b/core/src/ad-sizes.ts
@@ -405,15 +405,11 @@ const slotSizeMappings = {
 	'mobile-above-nav': {
 		mobile: [
 			adSizes.empty,
-			adSizes.mobilesticky,
 			adSizes.mobilestickyXl,
-			adSizes.fluid,
 		],
 		tablet: [
 			adSizes.empty,
-			adSizes.mobilesticky,
 			adSizes.mobilestickyXl,
-			adSizes.fluid,
 		],
 	},
 	'football-right': {

--- a/core/src/ad-sizes.ts
+++ b/core/src/ad-sizes.ts
@@ -90,7 +90,7 @@ type SizeKeys =
 	| 'merchandisingHigh'
 	| 'merchandisingHighAdFeature'
 	| 'mobilesticky'
-	| 'mobilestickyXl'
+	| 'mobileLeaderboardXl'
 	| 'mpu'
 	| 'outOfPage'
 	| 'outstreamDesktop'
@@ -138,7 +138,7 @@ const namedStandardAdSizes = {
 	halfPage: createAdSize(300, 600),
 	leaderboard: createAdSize(728, 90),
 	mobilesticky: createAdSize(320, 50),
-	mobilestickyXl: createAdSize(320, 100),
+	mobileLeaderboardXl: createAdSize(320, 100),
 	mpu: createAdSize(300, 250),
 	portrait: createAdSize(300, 1050),
 	skyscraper: createAdSize(160, 600),
@@ -403,8 +403,8 @@ const slotSizeMappings = {
 		mobile: [adSizes.mobilesticky],
 	},
 	'mobile-above-nav': {
-		mobile: [adSizes.empty, adSizes.mobilestickyXl],
-		tablet: [adSizes.empty, adSizes.mobilestickyXl],
+		mobile: [adSizes.empty, adSizes.mobileLeaderboardXl],
+		tablet: [adSizes.empty, adSizes.mobileLeaderboardXl],
 	},
 	'football-right': {
 		desktop: [

--- a/core/src/ad-sizes.ts
+++ b/core/src/ad-sizes.ts
@@ -403,14 +403,8 @@ const slotSizeMappings = {
 		mobile: [adSizes.mobilesticky],
 	},
 	'mobile-above-nav': {
-		mobile: [
-			adSizes.empty,
-			adSizes.mobilestickyXl,
-		],
-		tablet: [
-			adSizes.empty,
-			adSizes.mobilestickyXl,
-		],
+		mobile: [adSizes.empty, adSizes.mobilestickyXl],
+		tablet: [adSizes.empty, adSizes.mobilestickyXl],
 	},
 	'football-right': {
 		desktop: [


### PR DESCRIPTION
<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

Adds a new mobile above nav slot with a new size `mobileLeaderboardXl: 100px 320px` I have kept the naming consistent with mobile sticky for now even though it should be `mobileLeaderboardXl`.

## Why?

We are experimenting with a above nav advert on the crossword pages and the crossword front
