### PR TITLE
Rename `mobile-sticky` ad size to `mobileLeaderboard`

### DIFF
--- a/.changeset/orange-hotels-retire.md
+++ b/.changeset/orange-hotels-retire.md
@@ -1,0 +1,6 @@
+---
+"@guardian/commercial-core": patch
+---
+
+Update name of mobile-sticky ad size to mobileLeaderboard
+  

--- a/bundle/src/lib/header-bidding/prebid/bidders/appnexus.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/appnexus.spec.ts
@@ -10,7 +10,7 @@ import {
 	containsDmpu as containsDmpu_,
 	containsLeaderboard as containsLeaderboard_,
 	containsLeaderboardOrBillboard as containsLeaderboardOrBillboard_,
-	containsMobileSticky as containsMobileSticky_,
+	containsMobileLeaderboard as containsMobileLeaderboard_,
 	containsMpu as containsMpu_,
 	containsMpuOrDmpu as containsMpuOrDmpu_,
 	getBreakpointKey as getBreakpointKey_,
@@ -25,7 +25,7 @@ const containsDmpu = containsDmpu_ as jest.Mock;
 const containsLeaderboard = containsLeaderboard_ as jest.Mock;
 const containsLeaderboardOrBillboard =
 	containsLeaderboardOrBillboard_ as jest.Mock;
-const containsMobileSticky = containsMobileSticky_ as jest.Mock;
+const containsMobileLeaderboard = containsMobileLeaderboard_ as jest.Mock;
 const containsMpu = containsMpu_ as jest.Mock;
 const containsMpuOrDmpu = containsMpuOrDmpu_ as jest.Mock;
 const getBreakpointKey = getBreakpointKey_ as jest.Mock;
@@ -76,7 +76,7 @@ describe('getAppNexusDirectPlacementId', () => {
 	test('should return correct placementID for mobile-sticky and in ROW', () => {
 		isInRow.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
-		containsMobileSticky.mockReturnValue(true);
+		containsMobileLeaderboard.mockReturnValue(true);
 		expect(getAppNexusDirectPlacementId([[320, 50]])).toBe('31512573');
 	});
 
@@ -153,7 +153,7 @@ describe('getAppNexusDirectPlacementId', () => {
 	test('should return correct placementID for mobile-sticky in US', () => {
 		isInUsa.mockReturnValue('true');
 		getBreakpointKey.mockReturnValue('M');
-		containsMobileSticky.mockReturnValue(true);
+		containsMobileLeaderboard.mockReturnValue(true);
 		expect(getAppNexusDirectPlacementId([[320, 50]])).toBe('9251752');
 	});
 });

--- a/bundle/src/lib/header-bidding/prebid/bidders/appnexus.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/appnexus.ts
@@ -6,7 +6,7 @@ import {
 	containsBillboardNotLeaderboard,
 	containsLeaderboard,
 	containsLeaderboardOrBillboard,
-	containsMobileSticky,
+	containsMobileLeaderboard,
 	containsMpu,
 	containsMpuOrDmpu,
 	getBreakpointKey,
@@ -41,7 +41,7 @@ export const getAppNexusDirectPlacementId = (sizes: Size[]): string => {
 		return '11016434';
 	}
 
-	if (isInRow() && containsMobileSticky(sizes)) {
+	if (isInRow() && containsMobileLeaderboard(sizes)) {
 		return '31512573';
 	}
 

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.spec.ts
@@ -15,7 +15,7 @@ import {
 	containsDmpu as containsDmpu_,
 	containsLeaderboard as containsLeaderboard_,
 	containsLeaderboardOrBillboard as containsLeaderboardOrBillboard_,
-	containsMobileSticky as containsMobileSticky_,
+	containsMobileLeaderboard as containsMobileLeaderboard_,
 	containsMpu as containsMpu_,
 	containsMpuOrDmpu as containsMpuOrDmpu_,
 	containsPortraitInterstitial as containsPortraitInterstitial_,
@@ -73,7 +73,7 @@ jest.mock('../../utils', () => ({
 	containsDmpu: jest.fn(),
 	containsLeaderboard: jest.fn(),
 	containsLeaderboardOrBillboard: jest.fn(),
-	containsMobileSticky: jest.fn(),
+	containsMobileLeaderboard: jest.fn(),
 	containsMpu: jest.fn(),
 	containsMpuOrDmpu: jest.fn(),
 	containsPortraitInterstitial: jest.fn(),
@@ -91,7 +91,7 @@ const containsDmpu = containsDmpu_ as jest.Mock;
 const containsLeaderboard = containsLeaderboard_ as jest.Mock;
 const containsLeaderboardOrBillboard =
 	containsLeaderboardOrBillboard_ as jest.Mock;
-const containsMobileSticky = containsMobileSticky_ as jest.Mock;
+const containsMobileLeaderboard = containsMobileLeaderboard_ as jest.Mock;
 const containsMpu = containsMpu_ as jest.Mock;
 const containsMpuOrDmpu = containsMpuOrDmpu_ as jest.Mock;
 const containsPortraitInterstitial = containsPortraitInterstitial_ as jest.Mock;
@@ -488,7 +488,7 @@ describe('bids', () => {
 		const mockShouldInclude = jest.fn().mockReturnValue(true);
 		jest.mocked(shouldIncludeBidder).mockReturnValue(mockShouldInclude);
 		isInRow.mockReturnValue(true);
-		containsMobileSticky.mockReturnValue(true);
+		containsMobileLeaderboard.mockReturnValue(true);
 
 		const openXBid = bids(
 			'dfp-ad--mobile-sticky',
@@ -574,7 +574,7 @@ describe('triplelift adapter', () => {
 		containsBillboard.mockReturnValueOnce(false);
 		containsMpu.mockReturnValueOnce(false);
 		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValueOnce(false);
+		containsMobileLeaderboard.mockReturnValueOnce(false);
 		isInUsOrCa.mockReturnValue(true);
 
 		const tripleLiftBids = bids(
@@ -595,7 +595,7 @@ describe('triplelift adapter', () => {
 		containsBillboard.mockReturnValueOnce(false);
 		containsMpu.mockReturnValueOnce(false);
 		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValueOnce(false);
+		containsMobileLeaderboard.mockReturnValueOnce(false);
 		isInAuOrNz.mockReturnValue(true);
 
 		const tripleLiftBids = bids(
@@ -616,7 +616,7 @@ describe('triplelift adapter', () => {
 		containsBillboard.mockReturnValueOnce(false);
 		containsMpu.mockReturnValue(true);
 		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValueOnce(false);
+		containsMobileLeaderboard.mockReturnValueOnce(false);
 		isInUsOrCa.mockReturnValue(true);
 
 		const tripleLiftBids = bids(
@@ -637,7 +637,7 @@ describe('triplelift adapter', () => {
 		containsBillboard.mockReturnValueOnce(false);
 		containsMpu.mockReturnValue(true);
 		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValueOnce(false);
+		containsMobileLeaderboard.mockReturnValueOnce(false);
 		isInAuOrNz.mockReturnValue(true);
 
 		const tripleLiftBids = bids(
@@ -658,7 +658,7 @@ describe('triplelift adapter', () => {
 		containsBillboard.mockReturnValueOnce(false);
 		containsMpu.mockReturnValueOnce(false);
 		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValue(true);
+		containsMobileLeaderboard.mockReturnValue(true);
 		isInUsOrCa.mockReturnValue(true);
 
 		const tripleLiftBids = bids(
@@ -679,7 +679,7 @@ describe('triplelift adapter', () => {
 		containsBillboard.mockReturnValueOnce(false);
 		containsMpu.mockReturnValueOnce(false);
 		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValue(true);
+		containsMobileLeaderboard.mockReturnValue(true);
 		isInAuOrNz.mockReturnValue(true);
 
 		const tripleLiftBids = bids(
@@ -700,7 +700,7 @@ describe('triplelift adapter', () => {
 		containsBillboard.mockReturnValue(true);
 		containsMpu.mockReturnValueOnce(false);
 		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValueOnce(false);
+		containsMobileLeaderboard.mockReturnValueOnce(false);
 		isInUsOrCa.mockReturnValue(true);
 
 		const tripleLiftBids = bids(
@@ -721,7 +721,7 @@ describe('triplelift adapter', () => {
 		containsBillboard.mockReturnValue(true);
 		containsMpu.mockReturnValueOnce(false);
 		containsDmpu.mockReturnValueOnce(false);
-		containsMobileSticky.mockReturnValueOnce(false);
+		containsMobileLeaderboard.mockReturnValueOnce(false);
 		isInAuOrNz.mockReturnValue(true);
 
 		const tripleLiftBids = bids(
@@ -875,7 +875,9 @@ describe('getTeadsParams', () => {
 				});
 			},
 		);
-		test.each([[[320, 50], 'MOBILE STICKY', containsMobileSticky]])(
+		test.each([
+			[[320, 50], 'MOBILE LEADERBOARD', containsMobileLeaderboard],
+		])(
 			'should return correct placement and page ID for %s in RoW when mobile sticky on mobile',
 			(size, label, mockFucntion) => {
 				isInRow.mockReturnValue(true);
@@ -933,7 +935,9 @@ describe('getTeadsParams', () => {
 				});
 			},
 		);
-		test.each([[[320, 50], 'MOBILE STICKY', containsMobileSticky]])(
+		test.each([
+			[[320, 50], 'MOBILE LEADERBOARD', containsMobileLeaderboard],
+		])(
 			'should return correct placement and page ID for %s in US when mobile sticky on mobile',
 			(size, label, mockFunction) => {
 				isInUsa.mockReturnValue(true);
@@ -991,7 +995,9 @@ describe('getTeadsParams', () => {
 				});
 			},
 		);
-		test.each([[[320, 50], 'MOBILE STICKY', containsMobileSticky]])(
+		test.each([
+			[[320, 50], 'MOBILE LEADERBOARD', containsMobileLeaderboard],
+		])(
 			'should return correct placement and page ID for %s in AU/NZ when mobile sticky on mobile',
 			(size, label, mockFunction) => {
 				isInAuOrNz.mockReturnValue(true);
@@ -1025,7 +1031,7 @@ describe('getOzonePlacementId', () => {
 	test('should return inline1 placementID for inline1 slot', () => {
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
-		containsMobileSticky.mockReturnValue(false);
+		containsMobileLeaderboard.mockReturnValue(false);
 		jest.mocked(isUserInTestGroup).mockReturnValueOnce(true);
 		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline1')).toBe(
 			'1500001169',
@@ -1056,14 +1062,14 @@ describe('getOzonePlacementId', () => {
 	test('should return correct placementID for mobile-sticky in US', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
-		containsMobileSticky.mockReturnValue(true);
+		containsMobileLeaderboard.mockReturnValue(true);
 		expect(getOzonePlacementId([[320, 50]])).toBe('3500014217');
 	});
 
 	test('should return correct placementID for mobile-sticky in ROW', () => {
 		isInRow.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
-		containsMobileSticky.mockReturnValue(true);
+		containsMobileLeaderboard.mockReturnValue(true);
 		expect(getOzonePlacementId([[320, 50]])).toBe('1500000260');
 	});
 
@@ -1108,7 +1114,7 @@ describe('getOzonePlacementId', () => {
 		isInUsa.mockReturnValue(true);
 		getBreakpointKey.mockReturnValue('M');
 		containsMpu.mockReturnValue(true);
-		containsMobileSticky.mockReturnValue(false);
+		containsMobileLeaderboard.mockReturnValue(false);
 		expect(getOzonePlacementId([[300, 250]], 'dfp-ad--inline3')).toBe(
 			'1500001036',
 		);

--- a/bundle/src/lib/header-bidding/prebid/bidders/config.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/config.ts
@@ -36,7 +36,7 @@ import {
 	containsDmpu,
 	containsLeaderboard,
 	containsLeaderboardOrBillboard,
-	containsMobileSticky,
+	containsMobileLeaderboard,
 	containsMpu,
 	containsMpuOrDmpu,
 	containsPortraitInterstitial,
@@ -130,7 +130,7 @@ const getIndexSiteId = (slotSizes: Size[]) => {
 	}
 
 	// Return a specific site id for the mobile sticky slot
-	if (containsMobileSticky(slotSizes)) {
+	if (containsMobileLeaderboard(slotSizes)) {
 		return '1047869';
 	}
 
@@ -195,7 +195,7 @@ const getTripleLiftInventoryCode = (slotId: string, sizes: Size[]): string => {
 		}
 	}
 
-	if (containsMobileSticky(sizes)) {
+	if (containsMobileLeaderboard(sizes)) {
 		if (isInUsOrCa()) {
 			return 'theguardian_320x50_HDX';
 		} else if (isInAuOrNz()) {
@@ -247,7 +247,7 @@ const openxBidder: (pageTargeting: PageTargeting) => PrebidBidder = (
 			};
 		}
 		// ROW has a unique unit ID for mobile-sticky
-		if (isInRow() && containsMobileSticky(sizes)) {
+		if (isInRow() && containsMobileLeaderboard(sizes)) {
 			return {
 				delDomain: 'guardian-d.openx.net',
 				unit: '560429384',
@@ -313,7 +313,7 @@ const getTeadsParams = (
 			if (containsMpu(sizes) || containsPortraitInterstitial(sizes)) {
 				return { pageId: 244726, placementId: 261616 };
 			}
-			if (containsMobileSticky(sizes)) {
+			if (containsMobileLeaderboard(sizes)) {
 				return { pageId: 244723, placementId: 261613 };
 			}
 		}
@@ -337,7 +337,7 @@ const getTeadsParams = (
 			if (containsMpu(sizes) || containsPortraitInterstitial(sizes)) {
 				return { pageId: 244729, placementId: 261619 };
 			}
-			if (containsMobileSticky(sizes)) {
+			if (containsMobileLeaderboard(sizes)) {
 				return { pageId: 244730, placementId: 261620 };
 			}
 		}
@@ -361,7 +361,7 @@ const getTeadsParams = (
 			if (containsMpu(sizes) || containsPortraitInterstitial(sizes)) {
 				return { pageId: 247435, placementId: 264331 };
 			}
-			if (containsMobileSticky(sizes)) {
+			if (containsMobileLeaderboard(sizes)) {
 				return { pageId: 247436, placementId: 264332 };
 			}
 		}
@@ -390,7 +390,7 @@ const getOzonePlacementId = (
 			}
 		}
 		if (getBreakpointKey() === 'M') {
-			if (containsMobileSticky(sizes)) {
+			if (containsMobileLeaderboard(sizes)) {
 				if (isCrosswordPage(pageTargeting)) {
 					return '1500001035';
 				}
@@ -415,7 +415,7 @@ const getOzonePlacementId = (
 	}
 
 	if (isInRow()) {
-		if (containsMobileSticky(sizes)) {
+		if (containsMobileLeaderboard(sizes)) {
 			return '1500000260';
 		}
 	}
@@ -495,7 +495,7 @@ const getKargoPlacementId = (sizes: Size[]): string => {
 		return '_qDBbBXYtzA';
 	}
 	// mobile-sticky on mobile
-	if (containsMobileSticky(sizes)) {
+	if (containsMobileLeaderboard(sizes)) {
 		return '_odszPLn2hK';
 	}
 

--- a/bundle/src/lib/header-bidding/prebid/bidders/magnite.ts
+++ b/bundle/src/lib/header-bidding/prebid/bidders/magnite.ts
@@ -8,7 +8,7 @@ import type { Size } from 'prebid.js/dist/src/types/common';
 import {
 	containsBillboard,
 	containsLeaderboardOrBillboard,
-	containsMobileSticky,
+	containsMobileLeaderboard,
 	containsMpu,
 	containsMpuOrDmpu,
 	containsPortraitInterstitial,
@@ -70,7 +70,7 @@ export const getMagniteZoneId = (slotId: string, sizes: Size[]): number => {
 					return 3471464;
 				}
 			}
-			if (containsMobileSticky(sizes)) {
+			if (containsMobileLeaderboard(sizes)) {
 				if (isInRow()) {
 					return 3477560;
 				} else if (isInUsOrCa()) {

--- a/bundle/src/lib/header-bidding/slot-config.ts
+++ b/bundle/src/lib/header-bidding/slot-config.ts
@@ -228,11 +228,11 @@ const getSlotSizeMapping = (): HeaderBiddingSizeMapping => {
 		},
 		'mobile-sticky': {
 			mobile: shouldIncludeMobileSticky()
-				? [getAdSize('mobilesticky'), [300, 50]]
+				? [getAdSize('mobileLeaderboard'), [300, 50]]
 				: [],
 		},
 		'crossword-banner-mobile': {
-			mobile: [getAdSize('mobilesticky')],
+			mobile: [getAdSize('mobileLeaderboard')],
 		},
 		'football-right': {
 			desktop: [

--- a/bundle/src/lib/header-bidding/utils.ts
+++ b/bundle/src/lib/header-bidding/utils.ts
@@ -101,7 +101,7 @@ export const containsBillboardNotLeaderboard = (sizes: Size[]): boolean =>
 export const containsMpuOrDmpu = (sizes: Size[]): boolean =>
 	containsMpu(sizes) || containsDmpu(sizes);
 
-export const containsMobileSticky = (sizes: Size[]): boolean =>
+export const containsMobileLeaderboard = (sizes: Size[]): boolean =>
 	contains(sizes, [320, 50]);
 
 export const containsLeaderboardOrBillboard = (sizes: Size[]): boolean =>

--- a/bundle/src/lib/messenger/passback.ts
+++ b/bundle/src/lib/messenger/passback.ts
@@ -56,15 +56,15 @@ const oustreamSizeMappings = [
 	],
 ] satisfies googletag.SizeMappingArray;
 
-const mobileSticky: [number, number] = [
-	adSizes.mobilesticky.width,
-	adSizes.mobilesticky.height,
+const mobileLeaderboard: [number, number] = [
+	adSizes.mobileLeaderboard.width,
+	adSizes.mobileLeaderboard.height,
 ];
 
-const mobileStickySizes = [mobileSticky];
+const mobileStickySizes = [mobileLeaderboard];
 
 const mobileStickySizeMappings = [
-	[[breakpoints.mobile, 0], [mobileSticky]],
+	[[breakpoints.mobile, 0], [mobileLeaderboard]],
 ] satisfies googletag.SizeMappingArray;
 
 const defaultSizeMappings = [

--- a/core/src/ad-sizes.ts
+++ b/core/src/ad-sizes.ts
@@ -394,7 +394,11 @@ const slotSizeMappings = {
 		desktop: [adSizes.outOfPage],
 	},
 	'mobile-sticky': {
-		mobile: [adSizes.mobileLeaderboard, adSizes.empty, createAdSize(300, 50)],
+		mobile: [
+			adSizes.mobileLeaderboard,
+			adSizes.empty,
+			createAdSize(300, 50),
+		],
 	},
 	'crossword-banner-mobile': {
 		mobile: [adSizes.mobileLeaderboard],

--- a/core/src/ad-sizes.ts
+++ b/core/src/ad-sizes.ts
@@ -89,7 +89,7 @@ type SizeKeys =
 	| 'merchandising'
 	| 'merchandisingHigh'
 	| 'merchandisingHighAdFeature'
-	| 'mobilesticky'
+	| 'mobileLeaderboard'
 	| 'mpu'
 	| 'outOfPage'
 	| 'outstreamDesktop'
@@ -135,7 +135,7 @@ const namedStandardAdSizes = {
 	billboard: createAdSize(970, 250),
 	halfPage: createAdSize(300, 600),
 	leaderboard: createAdSize(728, 90),
-	mobilesticky: createAdSize(320, 50),
+	mobileLeaderboard: createAdSize(320, 50),
 	mpu: createAdSize(300, 250),
 	portrait: createAdSize(300, 1050),
 	skyscraper: createAdSize(160, 600),
@@ -394,10 +394,10 @@ const slotSizeMappings = {
 		desktop: [adSizes.outOfPage],
 	},
 	'mobile-sticky': {
-		mobile: [adSizes.mobilesticky, adSizes.empty, createAdSize(300, 50)],
+		mobile: [adSizes.mobileLeaderboard, adSizes.empty, createAdSize(300, 50)],
 	},
 	'crossword-banner-mobile': {
-		mobile: [adSizes.mobilesticky],
+		mobile: [adSizes.mobileLeaderboard],
 	},
 	'football-right': {
 		desktop: [


### PR DESCRIPTION
## What does this change?

Renames "mobile-sticky" ad size to "mobileLeaderboard"

This is a refactoring change only and should not affect slot targeting sent to GAM or elsewhere

## Why?

The term "mobile sticky" refers to the slot not the ad size. We aleady use the "mobile sticky" ad size in a slot that is not "mobile sticky": in the mobile crosswords banner slot

The fact that it is called "mobile sticky" is confusing as this describes the behaviour and not the slot size.
[According to Google](https://support.google.com/admanager/answer/1100453?hl=en), the name commonly used for the size 320x50 is "mobile leaderboard"

<img width="710" height="165" alt="Image" src="https://github.com/user-attachments/assets/6efad1b6-7e3b-4fcc-ae94-91c0de48fa0e" />
