### PR TITLE
upgrade permissions for changeset workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           client-id: ${{ secrets.GU_CHANGESETS_APP_ID }}
           private-key: ${{ secrets.GU_CHANGESETS_PRIVATE_KEY }}
-          permission-contents: read
+          permission-contents: write
           permission-pull-requests: write
 
       - name: Set git user to Gu Changesets app


### PR DESCRIPTION

<!--

If this PR should trigger a release, make sure you include a changeset.

This can be generated by running `pnpm changeset`.

-->

## What does this change?

We were getting the changeset action failing taking us to this https://docs.github.com/en/rest/git/refs?apiVersion=2026-03-10#create-a-reference which needs contents permission `write`.

## Why?

Workflow for changeset creating a release was failing. 
