### PR TITLE
Update Spacefinder rich links rules

### DIFF
--- a/bundle/playwright/fixtures/pages/articles.ts
+++ b/bundle/playwright/fixtures/pages/articles.ts
@@ -5,7 +5,7 @@ import type { GuPage } from './Page';
  * Array.from(document.querySelectorAll('.article-body-commercial-selector > *')).map((el, index) => el.classList.contains('ad-slot-container') ? index : undefined).filter((index) => index !== undefined)
  *
  * Make sure that you are on the same viewport size as the test you are trying to update.
- **/
+ */
 const articles = [
 	{
 		path: '/Article/https://www.theguardian.com/politics/2022/feb/10/keir-starmer-says-stop-the-war-coalition-gives-help-to-authoritarians-like-putin',

--- a/bundle/playwright/tests/rich-links.spec.ts
+++ b/bundle/playwright/tests/rich-links.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test';
+import { breakpoints } from '../lib/breakpoints';
+import { cmpAcceptAll } from '../lib/cmp';
+import { loadPage } from '../lib/load-page';
+import { waitForIsland } from '../lib/util';
+
+const url =
+	'/Article/https://www.theguardian.com/football/2026/sep/06/exceptional-arteta-arsenal-fightback-win-chelsea';
+
+/**
+ * Within Spacefinder, we make an assumption on the height of the rich link images in
+ * order to place adverts appropriately. If the display of rich link images changes,
+ * we may need to revisit this assumption.
+ */
+test.describe('Rich links', () => {
+	const expectedImageHeightsByBreakpoint = {
+		mobile: 0,
+		tablet: 112,
+		desktop: 112,
+		wide: 176,
+	};
+
+	breakpoints.forEach(({ breakpoint, width, height }) => {
+		test(`Rich link has expected dimensions ${breakpoint}`, async ({
+			page,
+		}) => {
+			await page.setViewportSize({
+				width,
+				height,
+			});
+
+			await loadPage({ page, path: url });
+			await cmpAcceptAll(page);
+
+			await waitForIsland(page, 'RichLinkComponent');
+
+			// const richLinkImage = page.getByTestId('rich-link-image');
+			const richLinkImage = page.getByAltText(
+				'Martin Ødegaard (right) with Declan Rice',
+			);
+
+			const expectedImageHeight =
+				expectedImageHeightsByBreakpoint[breakpoint];
+
+			if (expectedImageHeight === 0) {
+				await expect(richLinkImage).not.toBeVisible();
+				return;
+			}
+
+			const boundingBox = await richLinkImage.boundingBox();
+
+			expect(boundingBox?.height).toBe(expectedImageHeight);
+		});
+	});
+});

--- a/bundle/playwright/tests/rich-links.spec.ts
+++ b/bundle/playwright/tests/rich-links.spec.ts
@@ -34,7 +34,6 @@ test.describe('Rich links', () => {
 
 			await waitForIsland(page, 'RichLinkComponent');
 
-			// const richLinkImage = page.getByTestId('rich-link-image');
 			const richLinkImage = page.getByAltText(
 				'Martin Ødegaard (right) with Declan Rice',
 			);

--- a/bundle/src/insert/spacefinder/article.ts
+++ b/bundle/src/insert/spacefinder/article.ts
@@ -7,7 +7,10 @@ import {
 	createAdSlot,
 	wrapSlotInContainer,
 } from '../../lib/create-ad-slot';
-import { getCurrentBreakpoint } from '../../lib/detect/detect-breakpoint';
+import {
+	getCurrentBreakpoint,
+	getCurrentTweakpoint,
+} from '../../lib/detect/detect-breakpoint';
 import fastdom from '../../lib/fastdom-promise';
 import { computeStickyHeights, insertHeightStyles } from '../sticky-inlines';
 import { calculateInteractiveGridType } from './interactive';
@@ -102,6 +105,11 @@ const decideAdditionalSizes = async (
 };
 
 const addDesktopInline1 = (fillSlot: FillAdSlot): Promise<boolean> => {
+	const rulesForTweakpoint =
+		getCurrentTweakpoint() === 'desktop'
+			? rules.desktopInline1
+			: rules.leftColInline1;
+
 	// these are added here and not in size mappings because the inline[i] name
 	// is also used on fronts, where we don't want outstream or tall ads
 	const additionalSizes = {
@@ -127,7 +135,7 @@ const addDesktopInline1 = (fillSlot: FillAdSlot): Promise<boolean> => {
 		await Promise.all(slots);
 	};
 
-	return spaceFiller.fillSpace(rules.desktopInline1, insertAd, {
+	return spaceFiller.fillSpace(rulesForTweakpoint, insertAd, {
 		waitForImages: true,
 		waitForInteractives: true,
 		pass: 'inline1',

--- a/bundle/src/insert/spacefinder/liveblog-adverts.ts
+++ b/bundle/src/insert/spacefinder/liveblog-adverts.ts
@@ -150,8 +150,7 @@ const getSpaceFillerRules = (
 };
 
 /**
- * Recursively looks at the next highest element
- * in the page until we find a content block.
+ * Recursively looks at the next highest element in the page until we find a content block.
  *
  * We cannot be sure that the element above the ad slot is a content
  * block, as there may be other types of elements inserted into the page.

--- a/bundle/src/insert/spacefinder/richLinks.ts
+++ b/bundle/src/insert/spacefinder/richLinks.ts
@@ -1,0 +1,35 @@
+import { getCurrentTweakpoint } from '../../lib/detect/detect-breakpoint';
+
+const IMAGE_HEIGHT_DEFAULT = 112;
+// No image is displayed at the mobile breakpoint. An image is displayed from the mobileMedium breakpoint onwards.
+const IMAGE_HEIGHT_MOBILE = 0;
+const IMAGE_HEIGHT_WIDE = 176;
+
+/**
+ * Spacefinder requires opponents on the page to have consistent dimensions so that it can reliably place adverts
+ * at appropriate places within the article content. Rich links don't fit this requirement, as the image is obtained
+ * via a client-side request which is made after the initial page load, making its dimensions unpredictable.
+ *
+ * We do not wait for the rich link image to load before running Spacefinder, as this may cause a delay. Any delays
+ * to inserting ad slots can be costly.
+ *
+ * Fortunately, the rich link text content is rendered server-side, which means that the dimensions of this part of
+ * the rich link component is consistent. The dimensions of the image can be calculated, given the user's breakpoint.
+ *
+ * However, despite the vast majority of rich links having images, not all do. Therefore we err on the side of
+ * caution: we assume that a rich link _will_ have an image and risk placing an ad further down the page than
+ * we need to, rather than assuming it doesn't and risk colliding with the rich link component.
+ */
+const calculateRichLinkImageHeight = (): number => {
+	const tweakpoint = getCurrentTweakpoint();
+	switch (tweakpoint) {
+		case 'mobile':
+			return IMAGE_HEIGHT_MOBILE;
+		case 'wide':
+			return IMAGE_HEIGHT_WIDE;
+		default:
+			return IMAGE_HEIGHT_DEFAULT;
+	}
+};
+
+export default calculateRichLinkImageHeight;

--- a/bundle/src/insert/spacefinder/richLinks.ts
+++ b/bundle/src/insert/spacefinder/richLinks.ts
@@ -8,17 +8,19 @@ const IMAGE_HEIGHT_WIDE = 176;
 /**
  * Spacefinder requires opponents on the page to have consistent dimensions so that it can reliably place adverts
  * at appropriate places within the article content. Rich links don't fit this requirement, as the image is obtained
- * via a client-side request which is made after the initial page load, making its dimensions unpredictable.
+ * via a client-side request which is made after the initial page load, making its dimensions unpredictable at the
+ * time Spacefinder runs.
  *
- * We do not wait for the rich link image to load before running Spacefinder, as this may cause a delay. Any delays
- * to inserting ad slots can be costly.
+ * We do not wait for the rich link image to load before running Spacefinder, as this may cause a delay
+ * to Spacefinder. Any delays to inserting ad slots can be costly.
  *
- * Fortunately, the rich link text content is rendered server-side, which means that the dimensions of this part of
- * the rich link component is consistent. The dimensions of the image can be calculated, given the user's breakpoint.
+ * The rich link text content is rendered server-side, which means that the dimensions of this part of
+ * the rich link component is consistent. Further, the dimensions of the image can be calculated given
+ * the user's breakpoint, so we are able to work out a rich link's eventual height even before it has loaded.
  *
- * However, despite the vast majority of rich links having images, not all do. Therefore we err on the side of
- * caution: we assume that a rich link _will_ have an image and risk placing an ad further down the page than
- * we need to, rather than assuming it doesn't and risk colliding with the rich link component.
+ * There is one caveat, which is that despite the vast majority of rich links having images, not all do. Therefore
+ * we err on the side of caution: we assume that a rich link _will_ have an image and risk placing an ad further
+ * down the page than we need to, rather than assuming it doesn't and risk colliding with the rich link component.
  */
 const calculateRichLinkImageHeight = (): number => {
 	const tweakpoint = getCurrentTweakpoint();

--- a/bundle/src/insert/spacefinder/rules.ts
+++ b/bundle/src/insert/spacefinder/rules.ts
@@ -241,7 +241,7 @@ const mobileOpponentSelectorRules: OpponentSelectorRules = {
 		marginBottom: minDistanceBetweenInlineAds,
 		marginTop: minDistanceBetweenInlineAds,
 	},
-	[`${inlineOpponentSelector},${leftColumnOpponentSelector}`]: {
+	[inlineOpponentSelector]: {
 		marginBottom: 35,
 		marginTop: 200,
 		/**
@@ -250,6 +250,13 @@ const mobileOpponentSelectorRules: OpponentSelectorRules = {
 		 * to the current content, so we can place an ad there.
 		 */
 		bypassMinTop: 'h2,[data-spacefinder-type$="NumberedTitleBlockElement"]',
+	},
+	/**
+	 * Left column content isn't full width, so has less visual weight than other inline content
+	 */
+	[leftColumnOpponentSelector]: {
+		marginBottom: 35,
+		marginTop: 100,
 	},
 	[inlineFullWidthOpponentSelector]: {
 		marginBottom: 200,

--- a/bundle/src/insert/spacefinder/rules.ts
+++ b/bundle/src/insert/spacefinder/rules.ts
@@ -34,6 +34,7 @@ const highValueSections = [
 const isInHighValueSection = highValueSections.includes(
 	window.guardian.config.page.section,
 );
+
 // desktop only — excludes test sections so variant doesn't affect heading margins
 const isInOriginalHighValueSection = originalHighValueSections.includes(
 	window.guardian.config.page.section,
@@ -76,7 +77,6 @@ const inlineOpponentSelector = ['inline', 'supporting', 'showcase', 'halfWidth']
 			`:scope > [data-spacefinder-role="${role}"], [data-spacefinder-role="nested"] > [data-spacefinder-role="${role}"]`,
 	)
 	.join(',');
-
 const inlineFullWidthOpponentSelector = `:scope > [data-spacefinder-role="fullWidth"], [data-spacefinder-role="nested"] > [data-spacefinder-role="fullWidth"]`;
 
 const horizontalRuleSelector =
@@ -90,9 +90,8 @@ const desktopInline1: SpacefinderRules = {
 	minDistanceFromTop: isImmersive ? 700 : 300,
 	minDistanceFromBottom: 300,
 	opponentSelectorRules: {
-		// don't place ads right after a heading
 		[headingSelector]: {
-			marginBottom: 150,
+			marginBottom: 150, // don't place ads right after a heading
 			marginTop: isInOriginalHighValueSection ? 0 : 190,
 		},
 		[adSlotContainerSelector]: {
@@ -124,6 +123,7 @@ const desktopInline1: SpacefinderRules = {
 
 const desktopRightRailMinAbove = (isConsentless: boolean) => {
 	const base = 1000;
+
 	/**
 	 * In special cases, inline2 can overlap the "Most viewed" island, so
 	 * we need to make an adjustment to move the inline2 further down the page
@@ -135,41 +135,42 @@ const desktopRightRailMinAbove = (isConsentless: boolean) => {
 	if (hasShowcaseMainElement || (!hasImages && hasVideo)) {
 		return base + 250;
 	}
+
 	return base;
 };
 
-const desktopRightRail = (isConsentless: boolean): SpacefinderRules => {
-	return {
-		bodySelector,
-		candidateSelector,
-		minDistanceFromTop: desktopRightRailMinAbove(isConsentless),
-		minDistanceFromBottom: 300,
-		opponentSelectorRules: {
-			[adSlotContainerSelector]: {
-				marginBottom: 500,
-				marginTop: 500,
-			},
-			[rightColumnOpponentSelector]: {
-				marginBottom: 0,
-				marginTop: 600,
-			},
+const desktopRightRail = (isConsentless: boolean): SpacefinderRules => ({
+	bodySelector,
+	candidateSelector,
+	minDistanceFromTop: desktopRightRailMinAbove(isConsentless),
+	minDistanceFromBottom: 300,
+	opponentSelectorRules: {
+		[adSlotContainerSelector]: {
+			marginBottom: 500,
+			marginTop: 500,
 		},
-		/**
-		 * Filter out any candidates that are too close to the last winner
-		 * see https://github.com/guardian/commercial/tree/main/docs/spacefinder#avoiding-other-winning-candidates
-		 * for more information
-		 **/
-		filter: (candidate, lastWinner) => {
-			if (!lastWinner) {
-				return true;
-			}
-			const largestSizeForSlot = adSizes.halfPage.height;
-			const distanceBetweenAds =
-				candidate.top - lastWinner.top - largestSizeForSlot;
-			return distanceBetweenAds >= minDistanceBetweenRightRailAds;
+		[rightColumnOpponentSelector]: {
+			marginBottom: 0,
+			marginTop: 600,
 		},
-	};
-};
+	},
+	/**
+	 * Filter out any candidates that are too close to the last winner
+	 * see https://github.com/guardian/commercial/tree/main/docs/spacefinder#avoiding-other-winning-candidates
+	 * for more information
+	 **/
+	filter: (candidate, lastWinner) => {
+		if (!lastWinner) {
+			return true;
+		}
+
+		const largestSizeForSlot = adSizes.halfPage.height;
+		const distanceBetweenAds =
+			candidate.top - lastWinner.top - largestSizeForSlot;
+
+		return distanceBetweenAds >= minDistanceBetweenRightRailAds;
+	},
+});
 
 const interactiveRightRail: SpacefinderRules = {
 	bodySelector,
@@ -211,9 +212,8 @@ const mobileCandidateSelector =
 const mobileHeadingSelector = `${headingSelector}, :scope > [data-spacefinder-type$="NumberedTitleBlockElement"]`;
 
 const mobileOpponentSelectorRules: OpponentSelectorRules = {
-	// don't place ads right after a heading
 	[mobileHeadingSelector]: {
-		marginBottom: 100,
+		marginBottom: 100, // don't place ads right after a heading
 		marginTop: 0,
 	},
 	[adSlotContainerSelector]: {
@@ -223,7 +223,11 @@ const mobileOpponentSelectorRules: OpponentSelectorRules = {
 	[`${inlineOpponentSelector},${leftColumnOpponentSelector}`]: {
 		marginBottom: 35,
 		marginTop: 200,
-		// Usually we don't want an ad right before videos, embeds and atoms etc. so that we don't break up related content too much. But if we have a heading above, anything above the heading won't be related to the current content, so we can place an ad there.
+		/**
+		 * Usually we don't want an ad right before videos, embeds and atoms etc. so that we don't break up
+		 * related content too much. But if we have a heading above, anything above the heading won't be related
+		 * to the current content, so we can place an ad there.
+		 */
 		bypassMinTop: 'h2,[data-spacefinder-type$="NumberedTitleBlockElement"]',
 	},
 	[inlineFullWidthOpponentSelector]: {
@@ -233,7 +237,11 @@ const mobileOpponentSelectorRules: OpponentSelectorRules = {
 	[rightColumnOpponentSelector]: {
 		marginBottom: 35,
 		marginTop: 200,
-		// Usually we don't want an ad right before videos, embeds and atoms etc. so that we don't break up related content too much. But if we have a heading above, anything above the heading won't be related to the current content, so we can place an ad there.
+		/**
+		 * Usually we don't want an ad right before videos, embeds and atoms etc. so that we don't break up
+		 * related content too much. But if we have a heading above, anything above the heading won't be related
+		 * to the current content, so we can place an ad there.
+		 */
 		bypassMinTop: 'h2,[data-spacefinder-type$="NumberedTitleBlockElement"]',
 	},
 };
@@ -264,7 +272,9 @@ const mobileAndTabletInlines: SpacefinderRules = {
 		if (!lastWinner) {
 			return true;
 		}
+
 		const distanceBetweenAds = candidate.top - lastWinner.top;
+
 		return distanceBetweenAds >= minDistanceBetweenInlineAds;
 	},
 };

--- a/bundle/src/insert/spacefinder/rules.ts
+++ b/bundle/src/insert/spacefinder/rules.ts
@@ -11,6 +11,8 @@ const inHighValueSectionVariant = isUserInTestGroup(
 	'variant',
 );
 
+const isInRichLinkTest = isUserInTestGroup('commercial-rich-links', 'variant');
+
 const originalHighValueSections = [
 	'business',
 	'environment',
@@ -135,10 +137,14 @@ const leftColInline1: SpacefinderRules = {
 	...desktopInline1,
 	opponentSelectorRules: {
 		...desktopInline1OpponentSelectorRules,
-		[leftColumnOpponentSelector]: {
-			isLeftColumnOpponent: true,
-			distanceBetweenTops: 100,
-		},
+		...(isInRichLinkTest
+			? {
+					[leftColumnOpponentSelector]: {
+						isLeftColumnOpponent: true,
+						distanceBetweenTops: 100,
+					},
+				}
+			: {}),
 	},
 };
 
@@ -252,11 +258,11 @@ const mobileOpponentSelectorRules: OpponentSelectorRules = {
 		bypassMinTop: 'h2,[data-spacefinder-type$="NumberedTitleBlockElement"]',
 	},
 	/**
-	 * Left column content isn't full width, so has less visual weight than other inline content
+	 * Left column content isn't full width, so has less visual weight than other inline content.
 	 */
 	[leftColumnOpponentSelector]: {
 		marginBottom: 35,
-		marginTop: 100,
+		marginTop: isInRichLinkTest ? 100 : 200,
 	},
 	[inlineFullWidthOpponentSelector]: {
 		marginBottom: 200,

--- a/bundle/src/insert/spacefinder/rules.ts
+++ b/bundle/src/insert/spacefinder/rules.ts
@@ -84,39 +84,60 @@ const horizontalRuleSelector =
 
 const headingSelector = `:scope > h2, [data-spacefinder-role="nested"] > h2, :scope > h3, [data-spacefinder-role="nested"] > h3`;
 
+const desktopInline1OpponentSelectorRules: OpponentSelectorRules = {
+	[headingSelector]: {
+		marginBottom: 150, // don't place ads right after a heading
+		marginTop: isInOriginalHighValueSection ? 0 : 190,
+	},
+	[adSlotContainerSelector]: {
+		marginBottom: 500,
+		marginTop: 500,
+	},
+	[inlineOpponentSelector]: {
+		marginBottom: 35,
+		marginTop: 200,
+	},
+	[inlineFullWidthOpponentSelector]: {
+		marginBottom: 200,
+		marginTop: 200,
+	},
+	// At the desktop breakpoint, this content is rendered inline, but
+	// does not take up the full width. It is floated to the left.
+	[leftColumnOpponentSelector]: {
+		marginBottom: 50,
+		marginTop: 100,
+	},
+	[rightColumnOpponentSelector]: {
+		marginBottom: 0,
+		marginTop: 150,
+	},
+	['[data-spacefinder-role="supporting"]']: {
+		marginBottom: 0,
+		marginTop: 100,
+	},
+};
+
+/**
+ * Spacefinder rules for the inline1 advert between the desktop and the leftCol breakpoint.
+ */
 const desktopInline1: SpacefinderRules = {
 	bodySelector,
 	candidateSelector,
 	minDistanceFromTop: isImmersive ? 700 : 300,
 	minDistanceFromBottom: 300,
+	opponentSelectorRules: desktopInline1OpponentSelectorRules,
+};
+
+/**
+ * Spacefinder rules for the inline1 advert from the leftCol breakpoint
+ */
+const leftColInline1: SpacefinderRules = {
+	...desktopInline1,
 	opponentSelectorRules: {
-		[headingSelector]: {
-			marginBottom: 150, // don't place ads right after a heading
-			marginTop: isInOriginalHighValueSection ? 0 : 190,
-		},
-		[adSlotContainerSelector]: {
-			marginBottom: 500,
-			marginTop: 500,
-		},
-		[inlineOpponentSelector]: {
-			marginBottom: 35,
-			marginTop: 200,
-		},
-		[inlineFullWidthOpponentSelector]: {
-			marginBottom: 200,
-			marginTop: 200,
-		},
+		...desktopInline1OpponentSelectorRules,
 		[leftColumnOpponentSelector]: {
-			marginBottom: 50,
-			marginTop: 100,
-		},
-		[rightColumnOpponentSelector]: {
-			marginBottom: 0,
-			marginTop: 150,
-		},
-		['[data-spacefinder-role="supporting"]']: {
-			marginBottom: 0,
-			marginTop: 100,
+			isLeftColumnOpponent: true,
+			distanceBetweenTops: 100,
 		},
 	},
 };
@@ -281,6 +302,7 @@ const mobileAndTabletInlines: SpacefinderRules = {
 
 export const rules = {
 	desktopInline1,
+	leftColInline1,
 	desktopRightRail,
 	interactiveRightRail,
 	mobileAndTabletInlines,

--- a/bundle/src/insert/spacefinder/spacefinder.ts
+++ b/bundle/src/insert/spacefinder/spacefinder.ts
@@ -354,12 +354,14 @@ const testCandidate = (
 		: (isOpponentAbove && isOpponentBelow) ||
 			(!isOpponentAbove && !isOpponentBelow);
 
-	const pass = isTopOfCandidateFarEnoughFromOpponent(
-		candidate,
-		opponent,
-		rule,
-		isOpponentBelow,
-	);
+	const pass =
+		!opponentOverlaps &&
+		isTopOfCandidateFarEnoughFromOpponent(
+			candidate,
+			opponent,
+			rule,
+			isOpponentBelow,
+		);
 
 	if (!pass) {
 		if (opponentOverlaps) {

--- a/bundle/src/insert/spacefinder/spacefinder.ts
+++ b/bundle/src/insert/spacefinder/spacefinder.ts
@@ -7,11 +7,11 @@ import { getUrlVars } from '../../lib/url';
 
 type RuleSpacing = {
 	/**
-	 * Don't place an ad closer than this to the bottom of the opponent
+	 * The minimum spacing in px between the bottom of the opponent and the top of an ad
 	 */
 	marginBottom: number;
 	/**
-	 * Don't place an ad closer than this to the top of the opponent
+	 * The minimum spacing in px between the top of the opponent and the bottom of an ad
 	 */
 	marginTop: number;
 	bypassMinTop?: string;
@@ -147,6 +147,7 @@ const onImagesLoaded = memoize((rules: SpacefinderRules) => {
 				img.addEventListener('load', resolve);
 			}),
 	);
+
 	return Promise.all(imgPromises).then(() => Promise.resolve());
 }, getFuncId);
 
@@ -314,7 +315,7 @@ const testCandidate = (
 	const isOpponentAbove =
 		opponent.top < candidate.top && opponent.bottom <= candidate.top;
 
-	// this can happen when the an opponent like an image or interactive is floated right
+	// This can happen when the an opponent like an image or interactive is floated left or right
 	const opponentOverlaps =
 		(isOpponentAbove && isOpponentBelow) ||
 		(!isOpponentAbove && !isOpponentBelow);
@@ -447,6 +448,7 @@ class SpaceError extends Error {
 		this.message = `There is no space left matching rules from ${rules.bodySelector}`;
 	}
 }
+
 /**
  * Wait for the page to be ready (images loaded, interactives loaded)
  * or for LOADING_TIMEOUT to elapse, whichever comes first.
@@ -624,13 +626,13 @@ const findSpace = async (
 export { findSpace, SpaceError };
 
 export type {
-	RuleSpacing,
 	OpponentSelectorRules,
+	RuleSpacing,
+	SpacefinderExclusions,
+	SpacefinderItem,
+	SpacefinderMetaItem,
+	SpacefinderOptions,
+	SpacefinderPass,
 	SpacefinderRules,
 	SpacefinderWriter,
-	SpacefinderOptions,
-	SpacefinderItem,
-	SpacefinderExclusions,
-	SpacefinderPass,
-	SpacefinderMetaItem,
 };

--- a/bundle/src/insert/spacefinder/spacefinder.ts
+++ b/bundle/src/insert/spacefinder/spacefinder.ts
@@ -4,8 +4,9 @@ import { log } from '@guardian/libs';
 import { memoize } from 'lodash-es';
 import fastdom from '../../lib/fastdom-promise';
 import { getUrlVars } from '../../lib/url';
+import calculateRichLinkImageHeight from './richLinks';
 
-type RuleSpacing = {
+type InlineRuleSpacing = {
 	/**
 	 * The minimum spacing in px between the bottom of the opponent and the top of an ad
 	 */
@@ -15,7 +16,28 @@ type RuleSpacing = {
 	 */
 	marginTop: number;
 	bypassMinTop?: string;
+	isLeftColumnOpponent?: never;
 };
+
+/**
+ * Rule spacing for when the opponent is in the left or right column.
+ */
+type AdjacentRuleSpacing = {
+	/**
+	 * If the opponent is in the left column, then we want to use slightly different rule
+	 * spacing. We want to allow some vertical overlap between the advert and the opponent,
+	 * as the opponent is not inline.
+	 *
+	 * TODO: Use this for right-column opponents as well.
+	 */
+	isLeftColumnOpponent: true;
+	/**
+	 * The minimum spacing in px between the top of the opponent and the top of an ad.
+	 */
+	distanceBetweenTops: number;
+};
+
+type RuleSpacing = InlineRuleSpacing | AdjacentRuleSpacing;
 
 type SpacefinderMetaItem = {
 	required?: number;
@@ -232,13 +254,17 @@ const partitionCandidates = <T>(
 };
 
 /**
- * Check if the top of the candidate is far enough from the opponent
+ * Check if the top of the candidate is far enough from the opponent.
  *
- * The candidate is the element where we would like to insert an ad above. Candidates satisfy the `selector` rule.
+ * The candidate is the element where we would like to insert an ad above.
+ * Candidates satisfy the `selector` rule.
  *
  * Opponents are other elements in the article that are in the spacefinder ruleset
  * for the current pass. This includes slots inserted by a previous pass but not
- * those in the current pass as they're all inserted at the end.
+ * those in the current pass, as they're all inserted at the end.
+ *
+ * If the opponent is in the left column, we check the distance between the top
+ * of the candidate and the top of the opponent. Otherwise, see the graph below:
  *
  *                                                        │
  *                     Opponent Below                     │             Opponent Above
@@ -271,6 +297,13 @@ const isTopOfCandidateFarEnoughFromOpponent = (
 	isOpponentBelow: boolean,
 ): boolean => {
 	const potentialInsertPosition = candidate.top;
+
+	if (rule.isLeftColumnOpponent) {
+		return (
+			isOpponentBelow ||
+			potentialInsertPosition - opponent.top >= rule.distanceBetweenTops
+		);
+	}
 
 	if (isOpponentBelow && rule.marginTop) {
 		if (rule.bypassMinTop && candidate.element.matches(rule.bypassMinTop)) {
@@ -315,19 +348,18 @@ const testCandidate = (
 	const isOpponentAbove =
 		opponent.top < candidate.top && opponent.bottom <= candidate.top;
 
-	// This can happen when the an opponent like an image or interactive is floated left or right
-	const opponentOverlaps =
-		(isOpponentAbove && isOpponentBelow) ||
-		(!isOpponentAbove && !isOpponentBelow);
+	// this can happen when the an opponent like an image or interactive is floated left or right
+	const opponentOverlaps = rule.isLeftColumnOpponent
+		? candidate.top === opponent.top
+		: (isOpponentAbove && isOpponentBelow) ||
+			(!isOpponentAbove && !isOpponentBelow);
 
-	const pass =
-		!opponentOverlaps &&
-		isTopOfCandidateFarEnoughFromOpponent(
-			candidate,
-			opponent,
-			rule,
-			isOpponentBelow,
-		);
+	const pass = isTopOfCandidateFarEnoughFromOpponent(
+		candidate,
+		opponent,
+		rule,
+		isOpponentBelow,
+	);
 
 	if (!pass) {
 		if (opponentOverlaps) {
@@ -336,9 +368,11 @@ const testCandidate = (
 			});
 		} else {
 			// if the test fails, add debug information to the candidate metadata
-			const required = isOpponentBelow
-				? rule.marginTop
-				: rule.marginBottom;
+			const required = rule.isLeftColumnOpponent
+				? 0
+				: isOpponentBelow
+					? rule.marginTop
+					: rule.marginBottom;
 			const actual = isOpponentBelow
 				? opponent.top - candidate.top
 				: candidate.top - opponent.bottom;
@@ -512,16 +546,33 @@ const getCandidates = (
 	return candidates;
 };
 
-const getDimensions = (element: HTMLElement): Readonly<SpacefinderItem> =>
-	Object.freeze({
+const getDimensions = (element: HTMLElement): Readonly<SpacefinderItem> => {
+	let bottom = element.offsetTop + element.offsetHeight;
+
+	/*
+	 * Special handling for rich links: we don't wait for rich link images to load before running Spacefinder.
+	 * If the image hasn't loaded yet, we add the expected image height. This assumes there will be an image
+	 * with the rich link; sometimes there is not and we'll insert an ad lower than needed.
+	 */
+	if (element.dataset.spacefinderRole === 'richLink') {
+		const imageHeight = calculateRichLinkImageHeight();
+		const image = element.querySelector('[data-name="rich-link-image"]');
+
+		if (image === null) {
+			bottom += imageHeight;
+		}
+	}
+
+	return Object.freeze({
 		top: element.offsetTop,
-		bottom: element.offsetTop + element.offsetHeight,
+		bottom,
 		element,
 		meta: {
 			tooClose: [],
 			overlaps: [],
 		},
 	});
+};
 
 const getMeasurements = (
 	rules: SpacefinderRules,

--- a/bundle/src/insert/spacefinder/spacefinder.ts
+++ b/bundle/src/insert/spacefinder/spacefinder.ts
@@ -2,6 +2,7 @@
 
 import { log } from '@guardian/libs';
 import { memoize } from 'lodash-es';
+import { isUserInTestGroup } from '../../ab-testing';
 import fastdom from '../../lib/fastdom-promise';
 import { getUrlVars } from '../../lib/url';
 import calculateRichLinkImageHeight from './richLinks';
@@ -556,7 +557,11 @@ const getDimensions = (element: HTMLElement): Readonly<SpacefinderItem> => {
 	 * If the image hasn't loaded yet, we add the expected image height. This assumes there will be an image
 	 * with the rich link; sometimes there is not and we'll insert an ad lower than needed.
 	 */
-	if (element.dataset.spacefinderRole === 'richLink') {
+	const isInRichLinkTest = isUserInTestGroup(
+		'commercial-rich-links',
+		'variant',
+	);
+	if (isInRichLinkTest && element.dataset.spacefinderRole === 'richLink') {
 		const imageHeight = calculateRichLinkImageHeight();
 		const image = element.querySelector('[data-name="rich-link-image"]');
 

--- a/bundle/src/insert/spacefinder/spacefinder.ts
+++ b/bundle/src/insert/spacefinder/spacefinder.ts
@@ -371,20 +371,32 @@ const testCandidate = (
 			});
 		} else {
 			// if the test fails, add debug information to the candidate metadata
-			const required = rule.isLeftColumnOpponent
-				? 0
-				: isOpponentBelow
+			if (rule.isLeftColumnOpponent) {
+				const required = rule.distanceBetweenTops;
+				const actual =
+					opponent.top > candidate.top
+						? opponent.top - candidate.top
+						: candidate.top - opponent.top;
+
+				candidate.meta.tooClose.push({
+					required,
+					actual,
+					element: opponent.element,
+				});
+			} else {
+				const required = isOpponentBelow
 					? rule.marginTop
 					: rule.marginBottom;
-			const actual = isOpponentBelow
-				? opponent.top - candidate.top
-				: candidate.top - opponent.bottom;
+				const actual = isOpponentBelow
+					? opponent.top - candidate.top
+					: candidate.top - opponent.bottom;
 
-			candidate.meta.tooClose.push({
-				required,
-				actual,
-				element: opponent.element,
-			});
+				candidate.meta.tooClose.push({
+					required,
+					actual,
+					element: opponent.element,
+				});
+			}
 		}
 	}
 

--- a/bundle/src/insert/spacefinder/spacefinder.ts
+++ b/bundle/src/insert/spacefinder/spacefinder.ts
@@ -28,8 +28,6 @@ type AdjacentRuleSpacing = {
 	 * If the opponent is in the left column, then we want to use slightly different rule
 	 * spacing. We want to allow some vertical overlap between the advert and the opponent,
 	 * as the opponent is not inline.
-	 *
-	 * TODO: Use this for right-column opponents as well.
 	 */
 	isLeftColumnOpponent: true;
 	/**

--- a/bundle/src/lib/detect/detect-breakpoint.ts
+++ b/bundle/src/lib/detect/detect-breakpoint.ts
@@ -1,5 +1,5 @@
-import { breakpoints as sourceBreakpoints } from '@guardian/source/foundations';
 import type { Breakpoint as SourceBreakpoint } from '@guardian/source/foundations';
+import { breakpoints as sourceBreakpoints } from '@guardian/source/foundations';
 import { getViewport } from './detect-viewport';
 
 const breakpoints = {
@@ -168,11 +168,11 @@ initMediaQueryListeners();
 
 export {
 	getBreakpoint,
-	getTweakpoint,
 	getCurrentBreakpoint,
 	getCurrentTweakpoint,
-	matchesBreakpoints,
+	getTweakpoint,
 	hasCrossedBreakpoint,
+	matchesBreakpoints,
 };
 
 export type { SourceBreakpoint };

--- a/core/src/geo/get-locale.ts
+++ b/core/src/geo/get-locale.ts
@@ -26,7 +26,7 @@ export const __resetCachedValue = (): void => (locale = undefined);
 
 /**
  * Fetches the user's current location as an ISO 3166-1 alpha-2 string e.g. 'GB', 'AU' etc
- * Note: This has been copied from guardian-libs and made syncronous by ommiting the call to
+ * Note: This has been copied from guardian-libs and made syncronous by omitting the call to
  * the geolocation API
  */
 export const getLocale = (): CountryCode => {

--- a/core/src/geo/get-locale.ts
+++ b/core/src/geo/get-locale.ts
@@ -26,7 +26,7 @@ export const __resetCachedValue = (): void => (locale = undefined);
 
 /**
  * Fetches the user's current location as an ISO 3166-1 alpha-2 string e.g. 'GB', 'AU' etc
- * Note: This has been copied from guardian-libs and made syncronous by omitting the call to
+ * Note: This has been copied from guardian-libs and made synchronous by omitting the call to
  * the geolocation API
  */
 export const getLocale = (): CountryCode => {


### PR DESCRIPTION
## What does this change?

When in the variant of the `commercial-rich-links` AB test:
- If the rich link component has not hydrated and the rich link image has not loaded by the time Spacefinder runs, calculate the eventual height of the image, combining this with the height of the rest of the rich link element to get its eventual height once it loads.
- From the `leftCol` breakpoint, when the left column content is above the potential advert placement, the top of the advert cannot be within 100px of the top of the content. Adverts can also be placed closer when the content is below the advert placement.
- At mobile/tablet breakpoints, reduces the amount of space required between the bottom of an advert and the top of a rich link from 200px to 100px. Currently, a paragraph needs 200px of space between its top and the top of a rich link, and 35px between its top and the bottom of an advert.

## Why?

- We do not wait for the rich link image to load before inserting inline ads. There is a race condition between the rich link image loading and Spacefinder running. Sometimes the rich link image loads before Spacefinder runs and sometimes after. The ad can appear adjacent to the rich link if the ad slots are inserted before the rich link image loads. At some breakpoints, this can create whitespace between a rich link, a paragraph and an ad.
- There is one caveat that sometimes rich links do not have an image and we will be assuming that it does. Given the images without images are seldom used, hopefully this does not have a large effect.

Given that the first change, despite being a fix, will have a negative impact on ad-ratio, we also tweak the Spacefinder rules at the leftCol breakpoint and mobile/tablet:

- Before this change, from the `leftCol` breakpoint when the left column content is above the potential advert placement, the top of the advert could not be within 50px from the _bottom_ of the content. From the left-col breakpoint, rich links appear entirely in the left-column. Content in the left column has less visual weight than inline content, so we don't need to avoid these elements as much when inserting adverts.
- At mobile/tablet breakpoints, rich links are only 140px wide so the visual weight of ads and rich links is not too strong. This change should have a milder effect on ad-ratio.

## Screenshots

When Spacefinder wins the race against the rich link image, we get the image on the right: Spacefinder does not take into account the height of the image and so thinks it can place an ad higher up than it should. The intention was to leave at least 50px between the bottom of the rich link and the top of the content, which it has clearly failed. When the rich link wins the race, we get the image on the left. This is the intended functionality, but does leave the advert quite far down the page.

<img width="2613" height="1784" alt="image" src="https://github.com/user-attachments/assets/c40acaa8-81c4-4891-a210-71ff19d28ba3" />



Restrictions have been loosened on adverts appearing close to left-column content from the leftCol breakpoint.

Here is an example where the advert appears below the content.

<img width="2684" height="1734" alt="ad-below" src="https://github.com/user-attachments/assets/c5f0f565-3e3b-4d9d-805b-95a1cbdd96a5" />




And one where the advert appears above the content. You can see the reason why the winner on the left was not a winner on the right in the Spacefinder Debug Mode message.

<img width="2685" height="1690" alt="ad-above" src="https://github.com/user-attachments/assets/7dc8392a-d879-4484-b41a-0ac9d7d814a8" />




An example of the change at mobile/tablet breakpoints. Look at the middle page and the second winning paragraph on this page. The one that begins: "My parents said they had tried...". Adverts are now able to be placed closer above rich links and thumbnails. Before this change, the bottom of the advert had to be at least 200px from the top of the content, as shown by Spacefinder Debug mode in the screenshot. This seems too high and has been reduced to 100px.

<img width="1631" height="1726" alt="Screenshot 2026-09-07 at 18 38 38" src="https://github.com/user-attachments/assets/d9edbf64-8543-4ca6-adc4-f4b0e547d1ff" />
