### PR TITLE
Use port 3032 for DCR in playwright

### DIFF
--- a/.devcontainer/devenv.yaml
+++ b/.devcontainer/devenv.yaml
@@ -21,7 +21,7 @@ modules:
 # Optional: Ports to forward
 forwardPorts:
     - 3031 # commercial
-    - 3030 # dcr in docker container for playwright
+    - 3032 # dcr in docker container for playwright
     - 4321 # port for running `pnpm playwright:open` locally
 
 # Optional: Mount directories from host to container

--- a/.devcontainer/shared/devcontainer.json
+++ b/.devcontainer/shared/devcontainer.json
@@ -17,7 +17,7 @@
   },
   "forwardPorts" : [
     3031,
-    3030,
+    3032,
     4321
   ],
   "image" : "mcr.microsoft.com/devcontainers/base:ubuntu26.04",

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,7 +22,7 @@ Unit tests use Jest with jsdom. Coverage thresholds are enforced, especially
 for `bundle/src/lib` and `bundle/src/init/consented`; avoid lowering them.
 Playwright tests require the bundle dev server and a DCR instance configured to
 load it, as described in `bundle/README.md`. The CI setup runs DCR in a
-container on port 3030 and starts the bundle server on port 3031.
+container on port 3032 and starts the bundle server on port 3031.
 
 ## Architecture
 

--- a/scripts/start_dcr_container.sh
+++ b/scripts/start_dcr_container.sh
@@ -16,7 +16,7 @@ echo "Pulling image $IMAGE"
 # The container images are created via this workflow: https://github.com/guardian/dotcom-rendering/blob/18f4f9f6b861b04e2ad8deed82f442938e9f9197/.github/workflows/container.yml
 /usr/bin/docker run -d \
     --network host \
-    -p 3030:3030 \
+    -p 3030:3032 \
     -e "PORT=3030" \
     -e "COMMERCIAL_BUNDLE_URL=http://localhost:3031/graun.standalone.commercial.js" \
     $IMAGE


### PR DESCRIPTION
## What does this change?

When running DCR in a docker container for use in Playwright, this now uses port 3032 in the dev container and forwards this port outside of the dev container too

## Why?

This ensures we avoid clashing with local running DCR on port 3030 when running DCR + commercial locally

