### PR TITLE
Disable spacefinder when data attribute detected in article body

### DIFF
--- a/bundle/src/lib/article-body-adverts.ts
+++ b/bundle/src/lib/article-body-adverts.ts
@@ -36,11 +36,12 @@ const allowArticleBodyAdverts = (): boolean => {
 	const isHosted = window.guardian.config.page.isHosted;
 	const newRecipeDesign =
 		window.guardian.config.page.showNewRecipeDesign ?? false;
+	const isSpacefinderDisabled = document.querySelector('.article-body-commercial-selector[data-spacefinder-disabled=true]')
 
 	const enableArticleBodyAdverts = isArticle || isInteractive;
 
 	const disableArticleBodyAdverts =
-		isMinuteArticle || isLiveBlog || isHosted || newRecipeDesign;
+		isMinuteArticle || isLiveBlog || isHosted || newRecipeDesign || isSpacefinderDisabled;
 
 	const articleBodyAdverts = () =>
 		shouldLoadAds() &&


### PR DESCRIPTION
## What does this change?

Prevents Spacefinder runnning if the `data-spacefinder-disabled` attribute is found on the tag with the class `article-body-commercial-selector`

## Why?

We need to be able to turn off Spacefinder for select articles ahead of them being published.
This is a proposed way to do this, as the interactive code can manipulate the DOM to add this data attribute 