### PR TITLE
Disable spacefinder for the US elections page

### DIFF
--- a/bundle/src/lib/article-body-adverts.ts
+++ b/bundle/src/lib/article-body-adverts.ts
@@ -36,11 +36,13 @@ const allowArticleBodyAdverts = (): boolean => {
 	const isHosted = window.guardian.config.page.isHosted;
 	const newRecipeDesign =
 		window.guardian.config.page.showNewRecipeDesign ?? false;
+	// Disable Spacefinder for US elections page
+	const isNonSupportedInteractive = isInteractive && window.guardian.config.page.pageId.endsWith('us-senate-house-and-governor-elections-2026-results-from-all-50-states')
 
 	const enableArticleBodyAdverts = isArticle || isInteractive;
 
 	const disableArticleBodyAdverts =
-		isMinuteArticle || isLiveBlog || isHosted || newRecipeDesign;
+		isMinuteArticle || isLiveBlog || isHosted || newRecipeDesign || isNonSupportedInteractive;
 
 	const articleBodyAdverts = () =>
 		shouldLoadAds() &&

--- a/bundle/src/lib/article-body-adverts.ts
+++ b/bundle/src/lib/article-body-adverts.ts
@@ -36,13 +36,21 @@ const allowArticleBodyAdverts = (): boolean => {
 	const isHosted = window.guardian.config.page.isHosted;
 	const newRecipeDesign =
 		window.guardian.config.page.showNewRecipeDesign ?? false;
-	// Disable Spacefinder for US elections page
-	const isNonSupportedInteractive = isInteractive && window.guardian.config.page.pageId.endsWith('us-senate-house-and-governor-elections-2026-results-from-all-50-states')
+	const isNonSupportedInteractive =
+		isInteractive &&
+		window.guardian.config.page.atoms?.includes(
+			// Disable Spacefinder for US midterm election results page
+			'interactives/2026/11/midterms/default',
+		);
 
 	const enableArticleBodyAdverts = isArticle || isInteractive;
 
 	const disableArticleBodyAdverts =
-		isMinuteArticle || isLiveBlog || isHosted || newRecipeDesign || isNonSupportedInteractive;
+		isMinuteArticle ||
+		isLiveBlog ||
+		isHosted ||
+		newRecipeDesign ||
+		isNonSupportedInteractive;
 
 	const articleBodyAdverts = () =>
 		shouldLoadAds() &&

--- a/bundle/src/types/global.ts
+++ b/bundle/src/types/global.ts
@@ -91,6 +91,7 @@ type Stage = 'DEV' | 'CODE' | 'PROD';
 interface PageConfig extends CommercialPageConfig {
 	ajaxUrl?: string; // https://github.com/guardian/frontend/blob/33db7bbd/common/app/views/support/JavaScriptPage.scala#L72
 	assetsPath: string;
+	atoms?: string[];
 	author: string;
 	authorIds: string;
 	blogIds: string;


### PR DESCRIPTION
## What does this change?

Disables Spacefinder on the US midterm elections page when detecting presence of the interactive atom used to display the results

## Why?

We want to manually insert ads on these pages to have a more predictable outcome instead of allowing Spacefinder to run

We can't use a data attribute like `data-spacefinder-disabled` because we would need the interactive code to add this to the DOM after it loads which would be too late for Spacefinder to pick it up


If we decided to use the commercial queue via the `window.guardian` object, we also can't guarantee this information will be available by the time Spacefinder runs if it's being added by the interactive code. We would need to emit an Event (similar to in mobile-sticky handling) which would signal to stop running Spacefinder. This would likely happen after Spacefinder has already initialised which would result in removal or collapsing of slots which would result in non ideal layout shift.

The safest way of doing this to avoid race conditions is to ensure the information is available on the page itself and not relying on interactive code to send signals to the commercial bundle code to pick up
