### PR TITLE
Refactor header bidding initialisation checks. Add APS constant

### DIFF
--- a/.changeset/upset-pumas-wash.md
+++ b/.changeset/upset-pumas-wash.md
@@ -1,0 +1,5 @@
+---
+"@guardian/commercial-core": patch
+---
+
+Added constant for APS timeout

--- a/bundle/src/init/consented/prepare-a9.ts
+++ b/bundle/src/init/consented/prepare-a9.ts
@@ -1,25 +1,12 @@
-import { isInCanada } from '@guardian/commercial-core/geo/geo-utils';
 import { getConsentFor, onConsent } from '@guardian/consent-manager';
 import { log } from '@guardian/libs';
 import { once } from 'lodash-es';
 import { a9Apstag } from '../../lib/__vendor/a9-apstag';
-import { isAdFree } from '../../lib/ad-free';
-import { isGoogleProxy } from '../../lib/detect/detect-google-proxy';
 import { a9 } from '../../lib/header-bidding/a9/a9';
-import { shouldIncludeOnlyA9 } from '../../lib/header-bidding/utils';
-import { isSecureContactPage } from '../../lib/is-secure-contact';
-import { shouldLoadAds } from '../../lib/should-load-ads';
-
-const shouldLoadA9 = () =>
-	// All of the following conditions must be met to load A9
-	(!isSecureContactPage() &&
-		!isGoogleProxy() &&
-		window.guardian.config.switches.a9HeaderBidding &&
-		shouldLoadAds() &&
-		!isAdFree() &&
-		!window.guardian.config.page.hasPageSkin &&
-		!isInCanada()) ??
-	false;
+import {
+	shouldIncludeOnlyA9,
+	shouldLoadA9,
+} from '../../lib/header-bidding/utils';
 
 const setupA9 = (): Promise<void | boolean> => {
 	if (shouldLoadA9() || shouldIncludeOnlyA9) {

--- a/bundle/src/init/consented/prepare-prebid.spec.ts
+++ b/bundle/src/init/consented/prepare-prebid.spec.ts
@@ -1,4 +1,3 @@
-import { isInCanada } from '@guardian/commercial-core/geo/geo-utils';
 import type {
 	ConsentState,
 	TCFv2ConsentState,
@@ -6,24 +5,10 @@ import type {
 } from '@guardian/consent-manager';
 import { getConsentFor, onConsent } from '@guardian/consent-manager';
 import { log } from '@guardian/libs';
-import { isAdFree } from '../../lib/ad-free';
 import { prebid } from '../../lib/header-bidding/prebid';
-import { shouldLoadAds } from '../../lib/should-load-ads';
 import { _ } from './prepare-prebid';
 
 const { setupPrebid } = _;
-
-jest.mock('@guardian/commercial-core/geo/geo-utils', () => ({
-	isInCanada: jest.fn(() => false),
-}));
-
-jest.mock('lib/ad-free', () => ({
-	isAdFree: jest.fn(),
-}));
-
-jest.mock('lib/should-load-ads', () => ({
-	shouldLoadAds: jest.fn(),
-}));
 
 jest.mock('lib/header-bidding/prebid', () => ({
 	prebid: {
@@ -45,6 +30,7 @@ jest.mock('lib/header-bidding/prebid/bidders/config', () => ({
 
 jest.mock('lib/header-bidding/utils', () => ({
 	shouldIncludeOnlyA9: false,
+	shouldLoadPrebid: () => true,
 }));
 
 jest.mock('@guardian/libs', () => ({
@@ -120,149 +106,14 @@ const invalidWithoutConsent = {
 	framework: null,
 } as ConsentState;
 
-const originalUA = navigator.userAgent;
-const fakeUserAgent = (userAgent?: string) => {
-	Object.defineProperty(navigator, 'userAgent', {
-		get: () => userAgent ?? originalUA,
-		configurable: true,
-	});
-};
-
 describe('init', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
-		jest.mocked(isAdFree).mockReturnValue(false);
-		jest.mocked(shouldLoadAds).mockReturnValue(true);
-		fakeUserAgent();
-		window.guardian.config.switches = {};
-	});
-
-	it('should initialise Prebid when Prebid switch is ON and advertising is on and ad-free is off', async () => {
-		expect.hasAssertions();
-		window.guardian.config.switches = {
-			prebidHeaderBidding: true,
-		};
-		mockOnConsent(tcfv2WithConsent);
-		mockGetConsentFor(true);
-
-		await setupPrebid();
-		expect(prebid.initialise).toHaveBeenCalled();
-	});
-
-	it('should not initialise Prebid when useragent is Google Web Preview', async () => {
-		expect.hasAssertions();
-		window.guardian.config.switches = {
-			prebidHeaderBidding: true,
-		};
-		fakeUserAgent('Google Web Preview');
-		mockOnConsent(tcfv2WithConsent);
-		mockGetConsentFor(true);
-
-		await setupPrebid();
-		expect(prebid.initialise).not.toHaveBeenCalled();
-	});
-
-	it('should not initialise Prebid when no header bidding switches are on', async () => {
-		expect.hasAssertions();
-
-		window.guardian.config.switches = {
-			prebidHeaderBidding: false,
-		};
-		mockOnConsent(tcfv2WithConsent);
-		mockGetConsentFor(true);
-
-		await setupPrebid();
-		expect(prebid.initialise).not.toHaveBeenCalled();
-	});
-
-	it('should initialise Prebid when NOT in Canada', async () => {
-		expect.hasAssertions();
-
-		window.guardian.config.switches = {
-			prebidHeaderBidding: true,
-		};
-		mockOnConsent(tcfv2WithConsent);
-		mockGetConsentFor(true);
-
-		await setupPrebid();
-		expect(prebid.initialise).toHaveBeenCalled();
-	});
-
-	it('should NOT initialise Prebid when in Canada', async () => {
-		expect.hasAssertions();
-
-		window.guardian.config.switches = {
-			prebidHeaderBidding: true,
-		};
-		mockOnConsent(tcfv2WithConsent);
-		mockGetConsentFor(true);
-		(isInCanada as jest.Mock).mockReturnValueOnce(true);
-
-		await setupPrebid();
-		expect(prebid.initialise).not.toHaveBeenCalled();
-	});
-
-	it('should not initialise Prebid when advertising is switched off', async () => {
-		expect.hasAssertions();
-
-		window.guardian.config.switches = {
-			prebidHeaderBidding: true,
-		};
-		// (shouldLoadAds as jest.Mock).mockReturnValue(false);
-		jest.mocked(shouldLoadAds).mockReturnValue(false);
-		mockOnConsent(tcfv2WithConsent);
-		mockGetConsentFor(true);
-
-		await setupPrebid();
-		expect(prebid.initialise).not.toHaveBeenCalled();
-	});
-
-	it('should not initialise Prebid when ad-free is on', async () => {
-		expect.hasAssertions();
-
-		window.guardian.config.switches = {
-			prebidHeaderBidding: true,
-		};
-		jest.mocked(isAdFree).mockReturnValue(true);
-		mockOnConsent(tcfv2WithConsent);
-		mockGetConsentFor(true);
-
-		await setupPrebid();
-		expect(prebid.initialise).not.toHaveBeenCalled();
-	});
-
-	it('should not initialise Prebid when the page has a pageskin', async () => {
-		expect.hasAssertions();
-
-		window.guardian.config.switches = {
-			prebidHeaderBidding: true,
-		};
-		window.guardian.config.page.hasPageSkin = true;
-		mockOnConsent(tcfv2WithConsent);
-		mockGetConsentFor(true);
-
-		await setupPrebid();
-		expect(prebid.initialise).not.toHaveBeenCalled();
-	});
-
-	it('should initialise Prebid when the page has no pageskin', async () => {
-		window.guardian.config.switches = {
-			prebidHeaderBidding: true,
-		};
-		window.guardian.config.page.hasPageSkin = false;
-		mockOnConsent(tcfv2WithConsent);
-		mockGetConsentFor(true);
-
-		await setupPrebid();
-		expect(prebid.initialise).toHaveBeenCalled();
 	});
 
 	it('should initialise Prebid if the framework is TCFv2 ', async () => {
 		expect.hasAssertions();
 
-		window.guardian.config.switches = {
-			prebidHeaderBidding: true,
-		};
 		mockOnConsent(tcfv2WithConsent);
 		mockGetConsentFor(true);
 
@@ -273,9 +124,6 @@ describe('init', () => {
 	it('should initialise Prebid in USNAT if doNotSell is false', async () => {
 		expect.hasAssertions();
 
-		window.guardian.config.switches = {
-			prebidHeaderBidding: true,
-		};
 		mockOnConsent(usnatWithConsent);
 		mockGetConsentFor(true);
 
@@ -286,9 +134,6 @@ describe('init', () => {
 	it('should not initialise Prebid in USNAT if doNotSell is true', async () => {
 		expect.assertions(2);
 
-		window.guardian.config.switches = {
-			prebidHeaderBidding: true,
-		};
 		mockOnConsent(usnatWithoutConsent);
 		mockGetConsentFor(false);
 
@@ -305,9 +150,6 @@ describe('init', () => {
 	it('should initialise Prebid in AUS if Advertising is not rejected', async () => {
 		expect.hasAssertions();
 
-		window.guardian.config.switches = {
-			prebidHeaderBidding: true,
-		};
 		mockOnConsent(ausWithConsent);
 		mockGetConsentFor(true);
 
@@ -318,9 +160,6 @@ describe('init', () => {
 	it('should not initialise Prebid in AUS if Advertising is rejected', async () => {
 		expect.assertions(2);
 
-		window.guardian.config.switches = {
-			prebidHeaderBidding: true,
-		};
 		mockOnConsent(ausWithoutConsent);
 		mockGetConsentFor(false);
 
@@ -337,9 +176,6 @@ describe('init', () => {
 	it('should not initialise Prebid if the framework is invalid', async () => {
 		expect.assertions(2);
 
-		window.guardian.config.switches = {
-			prebidHeaderBidding: true,
-		};
 		mockOnConsent(invalidWithoutConsent);
 		mockGetConsentFor(true);
 

--- a/bundle/src/init/consented/prepare-prebid.ts
+++ b/bundle/src/init/consented/prepare-prebid.ts
@@ -1,22 +1,9 @@
-import { isInCanada } from '@guardian/commercial-core/geo/geo-utils';
 import type { ConsentState } from '@guardian/consent-manager';
 import { onConsent } from '@guardian/consent-manager';
 import { log } from '@guardian/libs';
 import { once } from 'lodash-es';
-import { isAdFree } from '../../lib/ad-free';
-import { isGoogleProxy } from '../../lib/detect/detect-google-proxy';
 import { prebid } from '../../lib/header-bidding/prebid';
-import { shouldIncludeOnlyA9 } from '../../lib/header-bidding/utils';
-import { shouldLoadAds } from '../../lib/should-load-ads';
-
-const shouldLoadPrebid = () =>
-	!isGoogleProxy() &&
-	window.guardian.config.switches.prebidHeaderBidding &&
-	shouldLoadAds() &&
-	!isAdFree() &&
-	!window.guardian.config.page.hasPageSkin &&
-	!shouldIncludeOnlyA9 &&
-	!isInCanada();
+import { shouldLoadPrebid } from '../../lib/header-bidding/utils';
 
 const loadPrebid = async (consentState: ConsentState): Promise<void> => {
 	await import(

--- a/bundle/src/lib/header-bidding/a9/a9.ts
+++ b/bundle/src/lib/header-bidding/a9/a9.ts
@@ -1,3 +1,4 @@
+import { APS_AUCTION_TIMEOUT } from '@guardian/commercial-core/constants/header-bidding-timeouts';
 import { flatten } from 'lodash-es';
 import type { Advert } from '../../../define/Advert';
 import type {
@@ -7,12 +8,12 @@ import type {
 import { reportError } from '../../error/report-error';
 import type { HeaderBiddingSlot, SlotFlatMap } from '../prebid-types';
 import { getHeaderBiddingAdSlots } from '../slot-config';
+import { shouldLoadA9 } from '../utils';
 
 /*
  * Amazon's header bidding javascript library
  * https://ams.amazon.com/webpublisher/uam/docs/web-integration-documentation/integration-guide/javascript-guide/display.html
  */
-
 class A9AdUnit implements A9AdUnitInterface {
 	slotID: string;
 	slotName?: string;
@@ -28,8 +29,6 @@ class A9AdUnit implements A9AdUnitInterface {
 let initialised = false;
 let requestQueue = Promise.resolve();
 
-const bidderTimeout = 1500;
-
 const initialise = (): void => {
 	if (!initialised && window.apstag) {
 		initialised = true;
@@ -42,7 +41,7 @@ const initialise = (): void => {
 		window.apstag.init({
 			pubID: window.guardian.config.page.a9PublisherId,
 			adServer: 'googletag',
-			bidTimeout: bidderTimeout,
+			bidTimeout: APS_AUCTION_TIMEOUT,
 			blockedBidders,
 		});
 	}
@@ -60,11 +59,7 @@ const requestBids = async (
 	adverts: Advert[],
 	slotFlatMap?: SlotFlatMap,
 ): Promise<void> => {
-	if (!initialised) {
-		return requestQueue;
-	}
-
-	if (!window.guardian.config.switches.a9HeaderBidding) {
+	if (!shouldLoadA9() || !initialised) {
 		return requestQueue;
 	}
 

--- a/bundle/src/lib/header-bidding/prebid/index.ts
+++ b/bundle/src/lib/header-bidding/prebid/index.ts
@@ -3,7 +3,7 @@ import { createAdSize } from '@guardian/commercial-core/ad-sizes';
 import {
 	PREBID_AUCTION_TIMEOUT,
 	PREBID_FAILSAFE_TIMEOUT,
-} from '@guardian/commercial-core/constants/prebid-timeouts';
+} from '@guardian/commercial-core/constants/header-bidding-timeouts';
 import { EventTimer } from '@guardian/commercial-core/event-timer';
 import type { ConsentState } from '@guardian/consent-manager';
 import { onConsent } from '@guardian/consent-manager';
@@ -23,6 +23,7 @@ import {
 	isSwitchedOn,
 	shouldIncludeBidder,
 	shouldIncludePermutive,
+	shouldLoadPrebid,
 	stripDfpAdPrefixFrom,
 } from '../utils';
 import { getGUAnalyticsConfig } from './analytics';
@@ -204,11 +205,7 @@ const requestBids = async (
 	adverts: Advert[],
 	slotFlatMap?: SlotFlatMap,
 ): Promise<void> => {
-	if (!initialised) {
-		return requestQueue;
-	}
-
-	if (!window.guardian.config.switches.prebidHeaderBidding) {
+	if (!shouldLoadPrebid() || !initialised) {
 		return requestQueue;
 	}
 

--- a/bundle/src/lib/header-bidding/utils.spec.ts
+++ b/bundle/src/lib/header-bidding/utils.spec.ts
@@ -5,17 +5,20 @@ import {
 	getConsentFor as getConsentFor_,
 } from '@guardian/consent-manager';
 import type { CountryCode } from '@guardian/libs';
+import { isAdFree } from '../../lib/ad-free';
 import type { SourceBreakpoint } from '../detect/detect-breakpoint';
 import {
 	getCurrentTweakpoint as getCurrentTweakpoint_,
 	matchesBreakpoints as matchesBreakpoints_,
 } from '../detect/detect-breakpoint';
+import { shouldLoadAds } from '../should-load-ads';
 import {
 	getBreakpointKey,
 	getLargestSize,
 	removeFalsyValues,
 	shouldIncludeBidder,
 	shouldIncludeMobileSticky,
+	shouldLoadPrebid,
 	stripDfpAdPrefixFrom,
 	stripMobileSuffix,
 	stripTrailingNumbersAbove1,
@@ -65,6 +68,13 @@ jest.mock('@guardian/commercial-core/geo/get-locale', () => ({
 jest.mock('lib/detect/detect-breakpoint', () => ({
 	getCurrentTweakpoint: jest.fn(() => 'mobile'),
 	matchesBreakpoints: jest.fn(),
+}));
+
+jest.mock('lib/ad-free', () => ({
+	isAdFree: jest.fn(),
+}));
+jest.mock('lib/should-load-ads', () => ({
+	shouldLoadAds: jest.fn(),
 }));
 
 const resetConfig = () => {
@@ -470,6 +480,119 @@ describe('Utils', () => {
 			getLocale.mockReturnValue('US');
 			window.location.hash = '#mobile-sticky';
 			expect(shouldIncludeMobileSticky()).toBe(true);
+		});
+	});
+
+	describe('Header bidding', () => {
+		const originalUA = navigator.userAgent;
+		const fakeUserAgent = (userAgent?: string) => {
+			Object.defineProperty(navigator, 'userAgent', {
+				get: () => userAgent ?? originalUA,
+				configurable: true,
+			});
+		};
+
+		describe('shouldLoadPrebid', () => {
+			beforeEach(() => {
+				jest.resetAllMocks();
+				jest.mocked(isAdFree).mockReturnValue(false);
+				jest.mocked(shouldLoadAds).mockReturnValue(true);
+				fakeUserAgent();
+				window.guardian.config.switches = {};
+			});
+
+			it('should return true when Prebid switch is ON and advertising is on and ad-free is off', () => {
+				expect.hasAssertions();
+				window.guardian.config.switches = {
+					prebidHeaderBidding: true,
+				};
+				expect(shouldLoadPrebid()).toBe(true);
+			});
+
+			it('should return false when useragent is Google Web Preview', () => {
+				expect.hasAssertions();
+				window.guardian.config.switches = {
+					prebidHeaderBidding: true,
+				};
+				fakeUserAgent('Google Web Preview');
+
+				expect(shouldLoadPrebid()).toBe(false);
+			});
+
+			it('should return false when no header bidding switches are on', () => {
+				expect.hasAssertions();
+
+				window.guardian.config.switches = {
+					prebidHeaderBidding: false,
+				};
+
+				expect(shouldLoadPrebid()).toBe(false);
+			});
+
+			it('should return true when NOT in Canada', () => {
+				expect.hasAssertions();
+
+				window.guardian.config.switches = {
+					prebidHeaderBidding: true,
+				};
+
+				expect(shouldLoadPrebid()).toBe(true);
+			});
+
+			it('should return false when in Canada', () => {
+				expect.hasAssertions();
+
+				window.guardian.config.switches = {
+					prebidHeaderBidding: true,
+				};
+
+				(getLocale as jest.Mock).mockReturnValueOnce('CA');
+
+				expect(shouldLoadPrebid()).toBe(false);
+			});
+
+			it('should return false when advertising is switched off', () => {
+				expect.hasAssertions();
+
+				window.guardian.config.switches = {
+					prebidHeaderBidding: true,
+				};
+
+				jest.mocked(shouldLoadAds).mockReturnValue(false);
+
+				expect(shouldLoadPrebid()).toBe(false);
+			});
+
+			it('should return false when ad-free is on', () => {
+				expect.hasAssertions();
+
+				window.guardian.config.switches = {
+					prebidHeaderBidding: true,
+				};
+				jest.mocked(isAdFree).mockReturnValue(true);
+
+				expect(shouldLoadPrebid()).toBe(false);
+			});
+
+			it('should return false when the page has a pageskin', () => {
+				expect.hasAssertions();
+
+				window.guardian.config.switches = {
+					prebidHeaderBidding: true,
+				};
+				window.guardian.config.page.hasPageSkin = true;
+
+				expect(shouldLoadPrebid()).toBe(false);
+			});
+
+			it('should return true when the page has no pageskin', () => {
+				window.guardian.config.switches = {
+					prebidHeaderBidding: true,
+				};
+				window.guardian.config.page.hasPageSkin = false;
+
+				expect(shouldLoadPrebid()).toBe(true);
+			});
 		});
 	});
 });

--- a/bundle/src/lib/header-bidding/utils.ts
+++ b/bundle/src/lib/header-bidding/utils.ts
@@ -11,6 +11,10 @@ import { type ConsentState, getConsentFor } from '@guardian/consent-manager';
 import { isString } from '@guardian/libs';
 import { once } from 'lodash-es';
 import type { Size } from 'prebid.js/dist/src/types/common';
+import { isAdFree } from '../../lib/ad-free';
+import { isGoogleProxy } from '../../lib/detect/detect-google-proxy';
+import { isSecureContactPage } from '../../lib/is-secure-contact';
+import { shouldLoadAds } from '../../lib/should-load-ads';
 import {
 	getCurrentTweakpoint,
 	matchesBreakpoints,
@@ -49,6 +53,13 @@ const isValidPageForMobileSticky = (): boolean => {
 		pageId.startsWith('football/')
 	);
 };
+
+const canLoadHeaderBidders = (): boolean =>
+	!isGoogleProxy() &&
+	shouldLoadAds() &&
+	!isAdFree() &&
+	!window.guardian.config.page.hasPageSkin &&
+	!isInCanada();
 
 /**
  * Cleans an object for targetting. Removes empty strings and other falsy values.
@@ -260,3 +271,13 @@ export const containsWS = (sizes: Size[]): boolean =>
 	contains(sizes, [160, 600]);
 
 export const shouldIncludeOnlyA9 = window.location.hash.includes('#only-a9');
+
+export const shouldLoadPrebid = () =>
+	canLoadHeaderBidders() &&
+	window.guardian.config.switches.prebidHeaderBidding === true &&
+	!shouldIncludeOnlyA9;
+
+export const shouldLoadA9 = () =>
+	canLoadHeaderBidders() &&
+	window.guardian.config.switches.a9HeaderBidding === true &&
+	!isSecureContactPage();

--- a/core/src/constants/header-bidding-timeouts.ts
+++ b/core/src/constants/header-bidding-timeouts.ts
@@ -1,6 +1,11 @@
 /**
  * Unit: milliseconds
  */
+export const APS_AUCTION_TIMEOUT = 1_500;
+
+/**
+ * Unit: milliseconds
+ */
 export const PREBID_AUCTION_TIMEOUT = 1_500;
 
 /**

--- a/core/src/constants/index.spec.ts
+++ b/core/src/constants/index.spec.ts
@@ -1,5 +1,6 @@
 import {
 	AD_LABEL_HEIGHT,
+	APS_AUCTION_TIMEOUT,
 	PREBID_AUCTION_TIMEOUT,
 	PREBID_FAILSAFE_TIMEOUT,
 	TOP_ABOVE_NAV_HEIGHT,
@@ -9,6 +10,10 @@ import {
 describe('Constant values are constant', () => {
 	test('TOP_ABOVE_NAV_HEIGHT', () => {
 		expect(TOP_ABOVE_NAV_HEIGHT).toBe(250);
+	});
+
+	test('APS_AUCTION_TIMEOUT', () => {
+		expect(APS_AUCTION_TIMEOUT).toBe(1500);
 	});
 
 	test('PREBID_AUCTION_TIMEOUT', () => {

--- a/core/src/constants/index.ts
+++ b/core/src/constants/index.ts
@@ -1,6 +1,7 @@
 export { AD_LABEL_HEIGHT } from './ad-label-height';
 export {
+	APS_AUCTION_TIMEOUT,
 	PREBID_AUCTION_TIMEOUT,
 	PREBID_FAILSAFE_TIMEOUT,
-} from './prebid-timeouts';
+} from './header-bidding-timeouts';
 export { TOP_ABOVE_NAV_HEIGHT } from './top-above-nav-height';


### PR DESCRIPTION
## What does this change?

Creates a constant for the APS header bidding auction timeout. This is 1500ms, the same as Prebid.

When `requestBids` is called for Prebid/APS, run the same synchronous checks we do when we initialise Prebid and move the helper functions into the header bidding utils file.

## Why?

There's an upcoming AB test which will change both the Prebid and APS auction timeout values. This will be easier to achieve if there are constants for both. Also, a constant for APS will help to ensure APS is not forgotten when updating header bidding code. We sometimes overlook APS as we rarely make changes in this area.

When we initialise Prebid/APS, we run some checks to ensure that we are allowed to run it, including whether the feature switch is ON. Later, when we request bids, we check that Prebid/APS is initialised and we also check the feature switch again. With this change, instead of only checking the feature switch, we include the other synchronous checks too. This is not necessary, but is defensive and I think easier to follow. If we were to introduce a Prebid/APS check in the future that may change in the page lifecycle, then this change will protect against us running Prebid/APS when we shouldn't.